### PR TITLE
k8s integration 1/5: adapter base and lifecycle wiring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,11 +78,14 @@ axum = "0.7"
 hyper = "1.0"
 reqwest = { version = "0.11", features = ["json"] }
 base64 = "0.22"
+kube = { version = "0.88", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.21", features = ["v1_26"] }
 
 [dev-dependencies]
 tower = "0.5"
 http-body-util = "0.1"
 testcontainers = "0.15"
+serde_yaml = "0.9"
 
 [build]
 rustflags = ["--cfg", "tokio_unstable"]

--- a/proto/master_service.proto
+++ b/proto/master_service.proto
@@ -7,6 +7,7 @@ service MasterService {
   rpc GetTaskCheckpoint(GetTaskCheckpointRequest) returns (GetTaskCheckpointResponse);
   rpc GetLatestCompleteCheckpoint(GetLatestCompleteCheckpointRequest) returns (GetLatestCompleteCheckpointResponse);
   rpc GetLatestSnapshot(GetLatestSnapshotRequest) returns (GetLatestSnapshotResponse);
+  rpc GetWorkerBootstrap(GetWorkerBootstrapRequest) returns (GetWorkerBootstrapResponse);
 }
 
 message StateBlob {
@@ -56,6 +57,14 @@ message GetLatestSnapshotResponse {
   bytes snapshot_bytes = 2;
   uint64 ts_ms = 3;
   uint64 seq = 4;
+}
+
+message GetWorkerBootstrapRequest {
+  string worker_id = 1;
+}
+
+message GetWorkerBootstrapResponse {
+  bytes bootstrap_bytes = 1;
 }
 
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,5 +16,7 @@ pub use compiler::compile_logical_graph;
 pub use spec::pipeline::{ExecutionMode, ExecutionProfile, PipelineSpec, PipelineSpecBuilder};
 pub use spec::operators::{OperatorOverride, OperatorOverrides};
 pub use spec::connectors::{DatagenSpec, RequestSourceSinkSpec, SinkSpec, SourceSpec, SourceBindingSpec};
+pub use spec::placement::PlacementStrategy;
+pub use spec::resources::{ResourceProfiles, ResourceStrategy};
 pub use spec::storage::StorageSpec;
 pub use spec::worker_runtime::WorkerRuntimeSpec;

--- a/src/api/spec/mod.rs
+++ b/src/api/spec/mod.rs
@@ -1,6 +1,8 @@
 pub mod connectors;
 pub mod operators;
+pub mod placement;
 pub mod pipeline;
+pub mod resources;
 pub mod storage;
 pub mod worker_runtime;
 

--- a/src/api/spec/pipeline.rs
+++ b/src/api/spec/pipeline.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 use crate::api::LogicalGraph;
 use crate::api::spec::connectors::{RequestSourceSinkSpec, SinkSpec, SourceBindingSpec};
 use crate::api::spec::operators::{OperatorOverride, OperatorOverrides};
+use crate::api::spec::placement::PlacementStrategy;
+use crate::api::spec::resources::{ResourceProfiles, ResourceStrategy};
 use crate::api::spec::worker_runtime::WorkerRuntimeSpec;
 use crate::api::spec::storage::StorageSpec;
 use crate::runtime::operators::sink::sink_operator::SinkConfig;
@@ -34,6 +36,9 @@ pub struct PipelineSpec {
     pub execution_profile: ExecutionProfile,
     pub execution_mode: ExecutionMode,
     pub parallelism: usize,
+    pub placement_strategy: PlacementStrategy,
+    pub resource_strategy: ResourceStrategy,
+    pub resource_profiles: ResourceProfiles,
     pub worker_runtime: WorkerRuntimeSpec,
     /// Per-operator-type storage overrides (shared across all instances of that operator type in a worker).
     /// Key is a stable operator-type string (e.g. "window").
@@ -73,6 +78,9 @@ impl PipelineSpecBuilder {
                 },
                 execution_mode: ExecutionMode::Streaming,
                 parallelism: 1,
+                placement_strategy: PlacementStrategy::default(),
+                resource_strategy: ResourceStrategy::default(),
+                resource_profiles: ResourceProfiles::default(),
                 worker_runtime: WorkerRuntimeSpec::default(),
                 operator_type_storage: HashMap::new(),
                 operator_overrides: OperatorOverrides::default(),
@@ -101,6 +109,21 @@ impl PipelineSpecBuilder {
 
     pub fn with_execution_profile(mut self, profile: ExecutionProfile) -> Self {
         self.spec.execution_profile = profile;
+        self
+    }
+
+    pub fn with_placement_strategy(mut self, strategy: PlacementStrategy) -> Self {
+        self.spec.placement_strategy = strategy;
+        self
+    }
+
+    pub fn with_resource_strategy(mut self, strategy: ResourceStrategy) -> Self {
+        self.spec.resource_strategy = strategy;
+        self
+    }
+
+    pub fn with_resource_profiles(mut self, profiles: ResourceProfiles) -> Self {
+        self.spec.resource_profiles = profiles;
         self
     }
 

--- a/src/api/spec/placement.rs
+++ b/src/api/spec/placement.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PlacementStrategy {
+    SingleNode,
+    OperatorPerNode,
+    RoundRobin,
+}
+
+impl Default for PlacementStrategy {
+    fn default() -> Self {
+        Self::SingleNode
+    }
+}

--- a/src/api/spec/resources.rs
+++ b/src/api/spec/resources.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceProfile {
+    pub cpu_request: Option<String>,
+    pub cpu_limit: Option<String>,
+    pub mem_request: Option<String>,
+    pub mem_limit: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ResourceStrategy {
+    PerWorker,
+    PerOperatorType,
+}
+
+impl Default for ResourceStrategy {
+    fn default() -> Self {
+        Self::PerWorker
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ResourceProfiles {
+    pub worker_default: ResourceProfile,
+    pub stateless_default: ResourceProfile,
+    pub stateful_by_type: HashMap<String, ResourceProfile>,
+}

--- a/src/cluster/cluster_provider.rs
+++ b/src/cluster/cluster_provider.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 /// Represents a node in the cluster
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClusterNode {
     pub node_id: String,
     pub node_ip: String,
@@ -24,6 +26,7 @@ pub trait ClusterProvider: Send + Sync {
     fn get_all_nodes(&self) -> &HashMap<String, ClusterNode>;
 }
 
+// TODO this is not used, we can delete
 /// Simple in-memory cluster provider
 #[derive(Debug, Clone)]
 pub struct InMemoryClusterProvider {

--- a/src/executor/k8s_runtime_adapter.rs
+++ b/src/executor/k8s_runtime_adapter.rs
@@ -1,0 +1,446 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use base64::{engine::general_purpose, Engine as _};
+use kube::{Api, Client, ResourceExt};
+use kube::api::{DeleteParams, PostParams};
+use k8s_openapi::api::apps::v1::{Deployment, StatefulSet};
+use k8s_openapi::api::core::v1::Service;
+use serde_json::json;
+use tokio::time::sleep;
+
+use crate::api::spec::placement::PlacementStrategy;
+use crate::api::spec::resources::ResourceProfile;
+use crate::cluster::cluster_provider::ClusterNode;
+use crate::executor::resource_planner::{DefaultResourcePlanner, ResourcePlanner};
+use crate::executor::runtime_adapter::{AttemptHandle, RuntimeAdapter, StartAttemptRequest};
+use crate::runtime::bootstrap::WorkerBootstrapPayload;
+
+pub struct K8sRuntimeConfig {
+    pub namespace: String,
+    pub master_image: String,
+    pub worker_image: String,
+    pub master_port: u16,
+    pub worker_port: u16,
+    pub master_labels: HashMap<String, String>,
+    pub worker_labels: HashMap<String, String>,
+    pub master_annotations: HashMap<String, String>,
+    pub worker_annotations: HashMap<String, String>,
+    pub master_node_selector: HashMap<String, String>,
+    pub worker_node_selector: HashMap<String, String>,
+    pub master_tolerations: Option<serde_json::Value>,
+    pub worker_tolerations: Option<serde_json::Value>,
+    pub master_affinity: Option<serde_json::Value>,
+    pub worker_affinity: Option<serde_json::Value>,
+}
+
+impl Default for K8sRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            namespace: "default".to_string(),
+            master_image: "volga_stream:latest".to_string(),
+            worker_image: "volga_stream:latest".to_string(),
+            master_port: 7000,
+            worker_port: 7001,
+            master_labels: HashMap::new(),
+            worker_labels: HashMap::new(),
+            master_annotations: HashMap::new(),
+            worker_annotations: HashMap::new(),
+            master_node_selector: HashMap::new(),
+            worker_node_selector: HashMap::new(),
+            master_tolerations: None,
+            worker_tolerations: None,
+            master_affinity: None,
+            worker_affinity: None,
+        }
+    }
+}
+
+pub struct K8sRuntimeAdapter {
+    client: Client,
+    config: K8sRuntimeConfig,
+}
+
+impl K8sRuntimeAdapter {
+    pub async fn new(config: K8sRuntimeConfig) -> Result<Self> {
+        let client = Client::try_default().await?;
+        Ok(Self { client, config })
+    }
+
+    fn encode_b64<T: serde::Serialize>(value: &T) -> Result<String> {
+        let bytes = bincode::serialize(value)?;
+        Ok(general_purpose::STANDARD.encode(bytes))
+    }
+
+    fn make_worker_nodes(
+        worker_statefulset: &str,
+        headless_service: &str,
+        namespace: &str,
+        worker_port: u16,
+        replicas: usize,
+    ) -> Vec<ClusterNode> {
+        (0..replicas)
+            .map(|i| {
+                let pod_name = format!("{worker_statefulset}-{i}");
+                let addr = format!(
+                    "{}.{}.{}.svc.cluster.local",
+                    pod_name, headless_service, namespace
+                );
+                ClusterNode::new(pod_name, addr, worker_port)
+            })
+            .collect()
+    }
+
+    fn resource_requirements(profile: &ResourceProfile) -> Option<serde_json::Value> {
+        let mut limits = serde_json::Map::new();
+        let mut requests = serde_json::Map::new();
+
+        if let Some(cpu) = &profile.cpu_limit {
+            limits.insert("cpu".to_string(), json!(cpu));
+        }
+        if let Some(mem) = &profile.mem_limit {
+            limits.insert("memory".to_string(), json!(mem));
+        }
+        if let Some(cpu) = &profile.cpu_request {
+            requests.insert("cpu".to_string(), json!(cpu));
+        }
+        if let Some(mem) = &profile.mem_request {
+            requests.insert("memory".to_string(), json!(mem));
+        }
+
+        if limits.is_empty() && requests.is_empty() {
+            return None;
+        }
+
+        let mut out = serde_json::Map::new();
+        if !limits.is_empty() {
+            out.insert("limits".to_string(), serde_json::Value::Object(limits));
+        }
+        if !requests.is_empty() {
+            out.insert("requests".to_string(), serde_json::Value::Object(requests));
+        }
+        Some(serde_json::Value::Object(out))
+    }
+
+    fn master_service_name(base: &str) -> String {
+        format!("{base}-master")
+    }
+
+    fn worker_service_name(base: &str) -> String {
+        format!("{base}-worker")
+    }
+
+    fn worker_statefulset_name(base: &str) -> String {
+        format!("{base}-workers")
+    }
+
+    async fn wait_for_statefulset_ready(
+        &self,
+        api: &Api<StatefulSet>,
+        name: &str,
+        replicas: usize,
+    ) -> Result<()> {
+        for _ in 0..60 {
+            if let Ok(ss) = api.get(name).await {
+                let ready = ss.status.and_then(|s| s.ready_replicas).unwrap_or(0) as usize;
+                if ready >= replicas {
+                    return Ok(());
+                }
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+        Err(anyhow!("statefulset {name} did not become ready"))
+    }
+
+    async fn wait_for_deployment_ready(&self, api: &Api<Deployment>, name: &str) -> Result<()> {
+        for _ in 0..60 {
+            if let Ok(dep) = api.get(name).await {
+                let ready = dep.status.and_then(|s| s.ready_replicas).unwrap_or(0);
+                if ready > 0 {
+                    return Ok(());
+                }
+            }
+            sleep(Duration::from_secs(1)).await;
+        }
+        Err(anyhow!("deployment {name} did not become ready"))
+    }
+
+    fn base_name(execution_ids: &crate::control_plane::types::ExecutionIds) -> String {
+        format!(
+            "volga-{}-{}",
+            execution_ids.pipeline_id.0.to_string(),
+            execution_ids.attempt_id.0
+        )
+        .to_lowercase()
+    }
+
+    fn merge_labels(
+        base: serde_json::Map<String, serde_json::Value>,
+        extra: &HashMap<String, String>,
+    ) -> serde_json::Map<String, serde_json::Value> {
+        let mut labels = base;
+        for (k, v) in extra {
+            labels.insert(k.clone(), json!(v));
+        }
+        labels
+    }
+}
+
+#[async_trait]
+impl RuntimeAdapter for K8sRuntimeAdapter {
+    async fn start_attempt(&self, mut req: StartAttemptRequest) -> Result<AttemptHandle> {
+        if req.placement_strategy != PlacementStrategy::SingleNode {
+            panic!("K8sRuntimeAdapter currently supports SingleNode placement only");
+        }
+
+        let base = Self::base_name(&req.execution_ids);
+        let master_service_name = Self::master_service_name(&base);
+        let worker_service_name = Self::worker_service_name(&base);
+        let worker_statefulset = Self::worker_statefulset_name(&base);
+
+        let replicas = req.num_workers_per_operator.max(1);
+        let worker_nodes = Self::make_worker_nodes(
+            &worker_statefulset,
+            &worker_service_name,
+            &self.config.namespace,
+            self.config.worker_port,
+            replicas,
+        );
+
+        let planner = DefaultResourcePlanner;
+        let resource_plan = planner.plan(
+            &req.execution_graph,
+            replicas,
+            &req.pipeline_spec.resource_strategy,
+            &req.pipeline_spec.resource_profiles,
+        );
+        let worker_resource = resource_plan
+            .worker_resources
+            .get(0)
+            .cloned()
+            .unwrap_or_default();
+        let worker_resources_json = Self::resource_requirements(&worker_resource);
+
+        let bootstrap_payload = WorkerBootstrapPayload {
+            execution_ids: req.execution_ids.clone(),
+            pipeline_spec: req.pipeline_spec.clone(),
+            placement_strategy: req.placement_strategy.clone(),
+            cluster_nodes: worker_nodes.clone(),
+            transport_overrides_queue_records: req.transport_overrides_queue_records.clone(),
+            worker_runtime: req.worker_runtime.clone(),
+            operator_type_storage_overrides: req.operator_type_storage_overrides.clone(),
+        };
+
+        let bootstrap_b64 = Self::encode_b64(&bootstrap_payload)?;
+        let worker_addrs = worker_nodes
+            .iter()
+            .map(|n| format!("{}:{}", n.node_ip, n.node_port))
+            .collect::<Vec<_>>();
+
+        let master_addr = format!("{}.{}:{}", master_service_name, self.config.namespace, self.config.master_port);
+
+        let master_env = vec![
+            json!({"name": "VOLGA_MASTER_BIND_ADDR", "value": format!("0.0.0.0:{}", self.config.master_port)}),
+            json!({"name": "VOLGA_WORKER_ADDRS", "value": worker_addrs.join(",")}),
+            json!({"name": "VOLGA_BOOTSTRAP_B64", "value": bootstrap_b64}),
+        ];
+
+        let base_labels = json!({
+            "app": "volga",
+            "pipeline_id": req.execution_ids.pipeline_id.0.to_string(),
+            "attempt_id": format!("{}", req.execution_ids.attempt_id.0),
+        })
+        .as_object()
+        .expect("labels map")
+        .clone();
+        let master_labels = Self::merge_labels(base_labels.clone(), &self.config.master_labels);
+        let worker_labels = Self::merge_labels(base_labels, &self.config.worker_labels);
+
+        let mut master_pod_spec = json!({
+            "containers": [{
+                "name": "master",
+                "image": self.config.master_image,
+                "command": ["/volga_master"],
+                "env": master_env,
+                "ports": [{
+                    "containerPort": self.config.master_port,
+                    "name": "grpc"
+                }]
+            }]
+        });
+        if !self.config.master_node_selector.is_empty() {
+            master_pod_spec["nodeSelector"] = json!(self.config.master_node_selector);
+        }
+        if let Some(tolerations) = &self.config.master_tolerations {
+            master_pod_spec["tolerations"] = tolerations.clone();
+        }
+        if let Some(affinity) = &self.config.master_affinity {
+            master_pod_spec["affinity"] = affinity.clone();
+        }
+
+        let master_deployment: Deployment = serde_json::from_value(json!({
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "name": master_service_name,
+                "namespace": self.config.namespace,
+                "labels": master_labels,
+                "annotations": self.config.master_annotations,
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": { "matchLabels": master_labels },
+                "template": {
+                    "metadata": { "labels": master_labels, "annotations": self.config.master_annotations },
+                    "spec": master_pod_spec
+                }
+            }
+        }))?;
+
+        let master_service: Service = serde_json::from_value(json!({
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": master_service_name,
+                "namespace": self.config.namespace,
+                "labels": master_labels,
+                "annotations": self.config.master_annotations,
+            },
+            "spec": {
+                "selector": master_labels,
+                "ports": [{
+                    "port": self.config.master_port,
+                    "targetPort": self.config.master_port,
+                    "name": "grpc"
+                }]
+            }
+        }))?;
+
+        let worker_service: Service = serde_json::from_value(json!({
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "name": worker_service_name,
+                "namespace": self.config.namespace,
+                "labels": worker_labels,
+                "annotations": self.config.worker_annotations,
+            },
+            "spec": {
+                "clusterIP": "None",
+                "selector": worker_labels,
+                "ports": [{
+                    "port": self.config.worker_port,
+                    "targetPort": self.config.worker_port,
+                    "name": "grpc"
+                }]
+            }
+        }))?;
+
+        let mut worker_container = json!({
+            "name": "worker",
+            "image": self.config.worker_image,
+            "command": ["/volga_worker"],
+            "env": [
+                {"name": "VOLGA_MASTER_ADDR", "value": master_addr},
+                {"name": "VOLGA_WORKER_PORT", "value": format!("{}", self.config.worker_port)},
+                {"name": "VOLGA_WORKER_BIND_ADDR", "value": format!("0.0.0.0:{}", self.config.worker_port)},
+                {
+                    "name": "VOLGA_WORKER_ID",
+                    "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}}
+                }
+            ],
+            "ports": [{
+                "containerPort": self.config.worker_port,
+                "name": "grpc"
+            }]
+        });
+        if let Some(resources) = worker_resources_json {
+            worker_container["resources"] = resources;
+        }
+
+        let mut worker_pod_spec = json!({
+            "containers": [worker_container]
+        });
+        if !self.config.worker_node_selector.is_empty() {
+            worker_pod_spec["nodeSelector"] = json!(self.config.worker_node_selector);
+        }
+        if let Some(tolerations) = &self.config.worker_tolerations {
+            worker_pod_spec["tolerations"] = tolerations.clone();
+        }
+        if let Some(affinity) = &self.config.worker_affinity {
+            worker_pod_spec["affinity"] = affinity.clone();
+        }
+
+        let worker_statefulset_obj: StatefulSet = serde_json::from_value(json!({
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "name": worker_statefulset,
+                "namespace": self.config.namespace,
+                "labels": worker_labels,
+                "annotations": self.config.worker_annotations,
+            },
+            "spec": {
+                "serviceName": worker_service_name,
+                "replicas": replicas,
+                "selector": { "matchLabels": worker_labels },
+                "template": {
+                    "metadata": { "labels": worker_labels, "annotations": self.config.worker_annotations },
+                    "spec": worker_pod_spec
+                }
+            }
+        }))?;
+
+        let deployments: Api<Deployment> = Api::namespaced(self.client.clone(), &self.config.namespace);
+        let services: Api<Service> = Api::namespaced(self.client.clone(), &self.config.namespace);
+        let statefulsets: Api<StatefulSet> = Api::namespaced(self.client.clone(), &self.config.namespace);
+
+        services.create(&PostParams::default(), &master_service).await?;
+        deployments.create(&PostParams::default(), &master_deployment).await?;
+        services.create(&PostParams::default(), &worker_service).await?;
+        statefulsets.create(&PostParams::default(), &worker_statefulset_obj).await?;
+
+        self.wait_for_deployment_ready(&deployments, &master_service_name).await?;
+        self.wait_for_statefulset_ready(&statefulsets, &worker_statefulset, replicas).await?;
+
+        let execution_ids = req.execution_ids.clone();
+        let (stop_sender, stop_receiver) = tokio::sync::oneshot::channel();
+        let join = tokio::spawn(async move {
+            let _ = stop_receiver.await;
+            Ok(crate::runtime::observability::PipelineSnapshot::new(HashMap::new()))
+        });
+
+        Ok(AttemptHandle {
+            execution_ids,
+            master_addr,
+            worker_addrs,
+            join,
+            stop_sender: Some(stop_sender),
+        })
+    }
+
+    async fn stop_attempt(&self, handle: AttemptHandle) -> Result<()> {
+        let base = Self::base_name(&handle.execution_ids);
+        let master_service_name = Self::master_service_name(&base);
+        let worker_service_name = Self::worker_service_name(&base);
+        let worker_statefulset = Self::worker_statefulset_name(&base);
+
+        let deployments: Api<Deployment> = Api::namespaced(self.client.clone(), &self.config.namespace);
+        let services: Api<Service> = Api::namespaced(self.client.clone(), &self.config.namespace);
+        let statefulsets: Api<StatefulSet> = Api::namespaced(self.client.clone(), &self.config.namespace);
+
+        let _ = deployments.delete(&master_service_name, &DeleteParams::default()).await;
+        let _ = services.delete(&master_service_name, &DeleteParams::default()).await;
+        let _ = statefulsets.delete(&worker_statefulset, &DeleteParams::default()).await;
+        let _ = services.delete(&worker_service_name, &DeleteParams::default()).await;
+
+        if let Some(stop_sender) = handle.stop_sender {
+            let _ = stop_sender.send(());
+        } else {
+            handle.abort();
+        }
+        Ok(())
+    }
+}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,2 +1,4 @@
 pub mod runtime_adapter;
 pub mod local_runtime_adapter;
+pub mod resource_planner;
+pub mod k8s_runtime_adapter;

--- a/src/executor/resource_planner.rs
+++ b/src/executor/resource_planner.rs
@@ -1,0 +1,41 @@
+use crate::api::spec::resources::{ResourceProfile, ResourceProfiles, ResourceStrategy};
+use crate::runtime::execution_graph::ExecutionGraph;
+
+#[derive(Clone, Debug)]
+pub struct ResourcePlan {
+    pub worker_resources: Vec<ResourceProfile>,
+}
+
+pub trait ResourcePlanner: Send + Sync {
+    fn plan(
+        &self,
+        graph: &ExecutionGraph,
+        num_workers: usize,
+        strategy: &ResourceStrategy,
+        profiles: &ResourceProfiles,
+    ) -> ResourcePlan;
+}
+
+pub struct DefaultResourcePlanner;
+
+impl ResourcePlanner for DefaultResourcePlanner {
+    fn plan(
+        &self,
+        _graph: &ExecutionGraph,
+        num_workers: usize,
+        strategy: &ResourceStrategy,
+        profiles: &ResourceProfiles,
+    ) -> ResourcePlan {
+        let workers = num_workers.max(1);
+        let profile = match strategy {
+            ResourceStrategy::PerWorker => profiles.worker_default.clone(),
+            ResourceStrategy::PerOperatorType => {
+                // TODO: implement operator-type planning with stateless chaining.
+                profiles.worker_default.clone()
+            }
+        };
+        ResourcePlan {
+            worker_resources: vec![profile; workers],
+        }
+    }
+}

--- a/src/runtime/bootstrap.rs
+++ b/src/runtime/bootstrap.rs
@@ -1,0 +1,21 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::api::spec::placement::PlacementStrategy;
+use crate::api::spec::pipeline::PipelineSpec;
+use crate::api::WorkerRuntimeSpec;
+use crate::cluster::cluster_provider::ClusterNode;
+use crate::control_plane::types::ExecutionIds;
+use crate::api::StorageSpec;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WorkerBootstrapPayload {
+    pub execution_ids: ExecutionIds,
+    pub pipeline_spec: PipelineSpec,
+    pub placement_strategy: PlacementStrategy,
+    pub cluster_nodes: Vec<ClusterNode>,
+    pub transport_overrides_queue_records: HashMap<String, u32>,
+    pub worker_runtime: WorkerRuntimeSpec,
+    pub operator_type_storage_overrides: HashMap<String, StorageSpec>,
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -7,6 +7,7 @@ pub mod worker;
 pub mod worker_server;
 pub mod master;
 pub mod master_server;
+pub mod bootstrap;
 pub mod functions;
 pub mod metrics;
 pub mod observability;

--- a/tests/k8s_pipeline_lifecycle.rs
+++ b/tests/k8s_pipeline_lifecycle.rs
@@ -1,0 +1,75 @@
+use std::env;
+use std::fs;
+
+use anyhow::Result;
+use testcontainers::{clients::Cli, images::generic::GenericImage};
+
+use volga_stream::api::spec::pipeline::PipelineSpecBuilder;
+use volga_stream::api::ExecutionProfile;
+use volga_stream::control_plane::types::{AttemptId, ExecutionIds};
+use volga_stream::executor::k8s_runtime_adapter::{K8sRuntimeAdapter, K8sRuntimeConfig};
+use volga_stream::executor::runtime_adapter::StartAttemptRequest;
+use volga_stream::runtime::execution_graph::ExecutionGraph;
+
+#[tokio::test]
+async fn k8s_pipeline_lifecycle() -> Result<()> {
+    let image = match env::var("VOLGA_STREAM_IMAGE") {
+        Ok(value) => value,
+        Err(_) => {
+            eprintln!("VOLGA_STREAM_IMAGE not set; skipping k8s lifecycle test");
+            return Ok(());
+        }
+    };
+
+    let docker = Cli::default();
+    let k3s_image = GenericImage::new("rancher/k3s", "v1.28.2-k3s1")
+        .with_env_var("K3S_KUBECONFIG_MODE", "644")
+        .with_exposed_port(6443);
+    let node = docker.run(k3s_image);
+    let host_port = node.get_host_port_ipv4(6443);
+
+    let kubeconfig_raw = String::from_utf8(
+        node.exec(vec!["/bin/sh", "-c", "cat /etc/rancher/k3s/k3s.yaml"])
+            .stdout,
+    )?;
+    let kubeconfig = kubeconfig_raw.replace(
+        "https://127.0.0.1:6443",
+        &format!("https://127.0.0.1:{host_port}"),
+    );
+    let kubeconfig_path = env::temp_dir().join(format!("kubeconfig-{}.yaml", uuid::Uuid::new_v4()));
+    fs::write(&kubeconfig_path, kubeconfig)?;
+    env::set_var("KUBECONFIG", &kubeconfig_path);
+
+    let adapter = K8sRuntimeAdapter::new(K8sRuntimeConfig {
+        master_image: image.clone(),
+        worker_image: image,
+        ..K8sRuntimeConfig::default()
+    })
+    .await?;
+
+    let mut spec = PipelineSpecBuilder::new()
+        .with_execution_profile(ExecutionProfile::Orchestrated {
+            num_workers_per_operator: 1,
+        })
+        .build();
+    spec.sql = None;
+
+    let execution_ids = ExecutionIds::fresh(AttemptId(1));
+    let handle = adapter
+        .start_attempt(StartAttemptRequest {
+            execution_ids: execution_ids.clone(),
+            pipeline_spec: spec.clone(),
+            execution_graph: ExecutionGraph::new(),
+            num_workers_per_operator: 1,
+            placement_strategy: spec.placement_strategy.clone(),
+            transport_overrides_queue_records: spec.transport_overrides_queue_records(),
+            worker_runtime: spec.worker_runtime.clone(),
+            operator_type_storage_overrides: spec.operator_type_storage_overrides(),
+        })
+        .await?;
+
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    adapter.stop_attempt(handle).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add the runtime-adapter lifecycle foundation for Kubernetes orchestration, including `start_attempt`/`stop_attempt` integration points
- introduce the initial `K8sRuntimeAdapter` resource lifecycle (master Deployment/Service + worker StatefulSet/headless Service)
- add bootstrap/test scaffolding needed for adapter-driven bring-up and teardown

## Test plan
- [ ] `cargo test --test k8s_pipeline_lifecycle`
- [ ] `cargo test --test control_plane_e2e_test`
- [ ] targeted adapter lifecycle sanity run in a k8s-enabled environment

Made with [Cursor](https://cursor.com)