### PR TITLE
k8s integration 3/5: worker runtime spec propagation

### DIFF
--- a/src/api/pipeline_context.rs
+++ b/src/api/pipeline_context.rs
@@ -55,7 +55,7 @@ impl PipelineContext {
         let execution_ids = ExecutionIds::fresh(AttemptId(1));
 
         match self.spec.execution_profile.clone() {
-            ExecutionProfile::InProcess { num_threads_per_task } => {
+            ExecutionProfile::InProcess => {
                 execution_graph.update_channels_with_node_mapping_and_transport(
                     None,
                     &self.spec.worker_runtime.transport,
@@ -69,7 +69,7 @@ impl PipelineContext {
                     execution_ids,
                     execution_graph,
                     vertex_ids,
-                    num_threads_per_task,
+                    self.spec.worker_runtime.num_threads_per_task,
                     TransportBackendType::InMemory,
                 );
                 worker_config.storage_budgets = self.spec.worker_runtime.storage.budgets.clone();

--- a/src/api/spec/pipeline.rs
+++ b/src/api/spec/pipeline.rs
@@ -26,7 +26,7 @@ pub enum ExecutionMode {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ExecutionProfile {
-    InProcess { num_threads_per_task: usize },
+    InProcess,
     Local {
         task_placement_strategy: TaskPlacementStrategyName,
         resource_strategy: ResourceStrategy,
@@ -54,7 +54,7 @@ impl ExecutionProfile {
 
     pub fn runtime_adapter_spec(&self) -> Option<RuntimeAdapterSpec> {
         match self {
-            ExecutionProfile::InProcess { .. } => None,
+            ExecutionProfile::InProcess => None,
             ExecutionProfile::Local { .. } => Some(RuntimeAdapterSpec::Local),
             ExecutionProfile::K8s { .. } => Some(RuntimeAdapterSpec::K8s),
         }
@@ -62,7 +62,7 @@ impl ExecutionProfile {
 
     pub fn task_placement_strategy(&self) -> Option<&TaskPlacementStrategyName> {
         match self {
-            ExecutionProfile::InProcess { .. } => None,
+            ExecutionProfile::InProcess => None,
             ExecutionProfile::Local { task_placement_strategy, .. } => Some(task_placement_strategy),
             ExecutionProfile::K8s { task_placement_strategy, .. } => Some(task_placement_strategy),
         }
@@ -70,7 +70,7 @@ impl ExecutionProfile {
 
     pub fn resource_strategy(&self) -> Option<&ResourceStrategy> {
         match self {
-            ExecutionProfile::InProcess { .. } => None,
+            ExecutionProfile::InProcess => None,
             ExecutionProfile::Local { resource_strategy, .. } => Some(resource_strategy),
             ExecutionProfile::K8s { resource_strategy, .. } => Some(resource_strategy),
         }
@@ -113,9 +113,7 @@ impl PipelineSpecBuilder {
     pub fn new() -> Self {
         Self {
             spec: PipelineSpec {
-                execution_profile: ExecutionProfile::InProcess {
-                    num_threads_per_task: 4,
-                },
+                execution_profile: ExecutionProfile::InProcess,
                 execution_mode: ExecutionMode::Streaming,
                 parallelism: 1,
                 resource_profiles: ResourceProfiles::default(),
@@ -150,8 +148,13 @@ impl PipelineSpecBuilder {
         self
     }
 
-    pub fn with_in_process_threads(mut self, num_threads_per_task: usize) -> Self {
-        self.spec.execution_profile = ExecutionProfile::InProcess { num_threads_per_task };
+    pub fn with_in_process_profile(mut self) -> Self {
+        self.spec.execution_profile = ExecutionProfile::InProcess;
+        self
+    }
+
+    pub fn with_worker_runtime_spec(mut self, worker_runtime: WorkerRuntimeSpec) -> Self {
+        self.spec.worker_runtime = worker_runtime;
         self
     }
 

--- a/src/api/spec/resources.rs
+++ b/src/api/spec/resources.rs
@@ -21,5 +21,6 @@ impl Default for ResourceStrategy {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ResourceProfiles {
+    pub master_default: ResourceProfile,
     pub worker_default: ResourceProfile,
 }

--- a/src/api/spec/worker_runtime.rs
+++ b/src/api/spec/worker_runtime.rs
@@ -9,6 +9,7 @@ use crate::transport::transport_spec::TransportSpec;
 pub struct WorkerRuntimeSpec {
     pub transport: TransportSpec,
     pub storage: StorageSpec,
+    pub num_threads_per_task: usize,
     /// Snapshot history retention window, in milliseconds.
     /// When omitted, defaults to 10 minutes.
     pub history_retention_window_ms: Option<u64>,
@@ -19,6 +20,7 @@ impl Default for WorkerRuntimeSpec {
         Self {
             transport: TransportSpec::default(),
             storage: StorageSpec::default(),
+            num_threads_per_task: 4,
             history_retention_window_ms: None,
         }
     }

--- a/src/executor/k8s_runtime_adapter.rs
+++ b/src/executor/k8s_runtime_adapter.rs
@@ -254,6 +254,8 @@ impl RuntimeAdapter for K8sRuntimeAdapter {
             .get(0)
             .cloned()
             .unwrap_or_default();
+        let master_resource = resource_plan.master_resource.clone();
+        let master_resources_json = Self::resource_requirements(&master_resource);
         let worker_resources_json = Self::resource_requirements(&worker_resource);
 
         let bootstrap_payload = WorkerBootstrapPayload {
@@ -303,6 +305,9 @@ impl RuntimeAdapter for K8sRuntimeAdapter {
                 }]
             }]
         });
+        if let Some(resources) = master_resources_json {
+            master_pod_spec["containers"][0]["resources"] = resources;
+        }
         if !self.config.master_node_selector.is_empty() {
             master_pod_spec["nodeSelector"] = json!(self.config.master_node_selector);
         }

--- a/src/executor/local_runtime_adapter.rs
+++ b/src/executor/local_runtime_adapter.rs
@@ -126,7 +126,7 @@ impl RuntimeAdapter for LocalRuntimeAdapter {
                     .into_iter()
                     .map(|v| std::sync::Arc::<str>::from(v))
                     .collect(),
-                1,
+                req.worker_runtime.num_threads_per_task,
                 transport_backend_type,
             )
             .with_master_addr(master_addr.clone());

--- a/src/executor/resource_planner.rs
+++ b/src/executor/resource_planner.rs
@@ -2,6 +2,7 @@ use crate::api::spec::resources::{ResourceProfile, ResourceProfiles, ResourceStr
 use crate::executor::placement::WorkerTaskPlacement;
 #[derive(Clone, Debug)]
 pub struct ResourcePlan {
+    pub master_resource: ResourceProfile,
     pub worker_resources: Vec<ResourceProfile>,
 }
 
@@ -18,6 +19,7 @@ impl ResourcePlanner {
             ResourceStrategy::PerWorker => profiles.worker_default.clone(),
         };
         ResourcePlan {
+            master_resource: profiles.master_default.clone(),
             worker_resources: vec![profile; workers],
         }
     }

--- a/src/runtime/tests/request_source_e2e_test.rs
+++ b/src/runtime/tests/request_source_e2e_test.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{logical_graph::LogicalGraph, ExecutionProfile, PipelineContext, PipelineSpecBuilder},
+    api::{logical_graph::LogicalGraph, ExecutionProfile, PipelineContext, PipelineSpecBuilder, WorkerRuntimeSpec},
     common::test_utils::{IdentityMapFunction, gen_unique_grpc_port},
     api::{Planner, PlanningContext},
     runtime::{
@@ -310,7 +310,11 @@ async fn test_request_source_sink_e2e() {
         // Build PipelineSpec with the pre-constructed logical graph (keep upstream test structure).
         let spec = PipelineSpecBuilder::new()
             .with_parallelism(parallelism)
-            .with_execution_profile(ExecutionProfile::InProcess { num_threads_per_task: 4 })
+            .with_execution_profile(ExecutionProfile::InProcess)
+            .with_worker_runtime_spec(WorkerRuntimeSpec {
+                num_threads_per_task: 4,
+                ..WorkerRuntimeSpec::default()
+            })
             .with_logical_graph(logical_graph)
             .build();
 

--- a/src/runtime/tests/window_operator_benchmark.rs
+++ b/src/runtime/tests/window_operator_benchmark.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{ExecutionMode, ExecutionProfile, PipelineContext, PipelineSpecBuilder},
+    api::{ExecutionMode, ExecutionProfile, PipelineContext, PipelineSpecBuilder, WorkerRuntimeSpec},
     api::compile_logical_graph,
     common::test_utils::{gen_unique_grpc_port, print_pipeline_state},
     runtime::{
@@ -254,7 +254,11 @@ pub async fn run_window_benchmark(config: WindowBenchmarkConfig) -> Result<Bench
             schema,
         )
         .sql(&sql)
-        .with_execution_profile(ExecutionProfile::InProcess { num_threads_per_task: 4 });
+        .with_execution_profile(ExecutionProfile::InProcess)
+        .with_worker_runtime_spec(WorkerRuntimeSpec {
+            num_threads_per_task: 4,
+            ..WorkerRuntimeSpec::default()
+        });
 
     
     // Set execution mode 

--- a/src/runtime/tests/window_request_operator_benchmark.rs
+++ b/src/runtime/tests/window_request_operator_benchmark.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{ExecutionMode, ExecutionProfile, PipelineContext, PipelineSpecBuilder},
+    api::{ExecutionMode, ExecutionProfile, PipelineContext, PipelineSpecBuilder, WorkerRuntimeSpec},
     common::test_utils::{gen_unique_grpc_port, print_pipeline_state},
     runtime::metrics::PipelineStateHistory,
     runtime::{
@@ -181,7 +181,11 @@ pub async fn run_window_request_benchmark(
             Some(SinkConfig::InMemoryStorageGrpcSinkConfig(format!("http://{}", storage_server_addr)))
         )
         .sql(sql)
-        .with_execution_profile(ExecutionProfile::InProcess { num_threads_per_task: 4 })
+        .with_execution_profile(ExecutionProfile::InProcess)
+        .with_worker_runtime_spec(WorkerRuntimeSpec {
+            num_threads_per_task: 4,
+            ..WorkerRuntimeSpec::default()
+        })
         .with_execution_mode(ExecutionMode::Request)
         .build();
     let context = PipelineContext::new(spec);

--- a/src/runtime/tests/word_count_benchmark.rs
+++ b/src/runtime/tests/word_count_benchmark.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{ExecutionProfile, PipelineContext, PipelineSpecBuilder},
+    api::{ExecutionProfile, PipelineContext, PipelineSpecBuilder, WorkerRuntimeSpec},
     api::compile_logical_graph,
     common::test_utils::{gen_unique_grpc_port, print_pipeline_state},
     runtime::{
@@ -181,7 +181,11 @@ pub async fn run_word_count_benchmark(
         )
         .with_sink_inline(SinkConfig::InMemoryStorageGrpcSinkConfig(format!("http://{}", storage_server_addr)))
         .sql("SELECT word, COUNT(*) as count FROM word_count_source GROUP BY word")
-        .with_execution_profile(ExecutionProfile::InProcess { num_threads_per_task: 4 })
+        .with_execution_profile(ExecutionProfile::InProcess)
+        .with_worker_runtime_spec(WorkerRuntimeSpec {
+            num_threads_per_task: 4,
+            ..WorkerRuntimeSpec::default()
+        })
         .build();
 
     let logical_graph = compile_logical_graph(&spec);

--- a/src/runtime/tests/word_count_test.rs
+++ b/src/runtime/tests/word_count_test.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{ExecutionProfile, PipelineContext, PipelineSpecBuilder},
+    api::{ExecutionProfile, PipelineContext, PipelineSpecBuilder, WorkerRuntimeSpec},
     common::{test_utils::{gen_unique_grpc_port, print_pipeline_state}, message::Message},
     runtime::{
         functions::{
@@ -51,7 +51,11 @@ fn test_word_count() -> Result<()> {
             storage_server_addr
         )))
         .sql("SELECT word, COUNT(*) as count FROM word_count_source GROUP BY word")
-        .with_execution_profile(ExecutionProfile::InProcess { num_threads_per_task: 4 })
+        .with_execution_profile(ExecutionProfile::InProcess)
+        .with_worker_runtime_spec(WorkerRuntimeSpec {
+            num_threads_per_task: 4,
+            ..WorkerRuntimeSpec::default()
+        })
         .build();
     let context = PipelineContext::new(spec);
 

--- a/src/runtime/tests/worker_test.rs
+++ b/src/runtime/tests/worker_test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::{
-    api::{ExecutionProfile, PipelineContext, PipelineSpecBuilder},
+    api::{ExecutionProfile, PipelineContext, PipelineSpecBuilder, WorkerRuntimeSpec},
     common::{message::Message, test_utils::{create_test_string_batch, gen_unique_grpc_port, verify_message_records_match}, WatermarkMessage, MAX_WATERMARK_VALUE},
     runtime::operators::{sink::sink_operator::SinkConfig, source::source_operator::{SourceConfig, VectorSourceConfig}},
     storage::{InMemoryStorageClient, InMemoryStorageServer}
@@ -46,7 +46,11 @@ fn test_worker_execution() -> Result<()> {
         )
         .with_sink_inline(SinkConfig::InMemoryStorageGrpcSinkConfig(format!("http://{}", storage_server_addr)))
         .sql("SELECT value FROM test_table")
-        .with_execution_profile(ExecutionProfile::InProcess { num_threads_per_task: 4 })
+        .with_execution_profile(ExecutionProfile::InProcess)
+        .with_worker_runtime_spec(WorkerRuntimeSpec {
+            num_threads_per_task: 4,
+            ..WorkerRuntimeSpec::default()
+        })
         .build();
     let context = PipelineContext::new(spec);
 

--- a/src/sql_testing/sql_tests.rs
+++ b/src/sql_testing/sql_tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{ExecutionProfile, PipelineContext, PipelineSpecBuilder},
+    api::{ExecutionProfile, PipelineContext, PipelineSpecBuilder, WorkerRuntimeSpec},
     common::{message::Message, test_utils::{gen_unique_grpc_port, verify_message_records_match}, WatermarkMessage, MAX_WATERMARK_VALUE},
     runtime::operators::{sink::sink_operator::SinkConfig, source::source_operator::{SourceConfig, VectorSourceConfig}},
     storage::{InMemoryStorageClient, InMemoryStorageServer}
@@ -503,7 +503,11 @@ async fn run_sql_test_case(test_case: &SqlTestCase) -> Result<()> {
         )
         .with_sink_inline(SinkConfig::InMemoryStorageGrpcSinkConfig(format!("http://{}", storage_server_addr)))
         .sql(test_case.sql)
-        .with_execution_profile(ExecutionProfile::InProcess { num_threads_per_task: 4 })
+        .with_execution_profile(ExecutionProfile::InProcess)
+        .with_worker_runtime_spec(WorkerRuntimeSpec {
+            num_threads_per_task: 4,
+            ..WorkerRuntimeSpec::default()
+        })
         .build();
     let context = PipelineContext::new(spec);
 


### PR DESCRIPTION
## Summary
- propagate worker runtime/resource profile details consistently through pipeline spec and execution paths
- align in-process/local execution call sites and tests with the updated runtime-spec flow
- keep resource planner and adapter entrypoints compatible with the expanded runtime spec

## Test plan
- [ ] `cargo test runtime::tests::worker_test`
- [ ] `cargo test runtime::tests::request_source_e2e_test`
- [ ] `cargo test sql_testing::sql_tests`

Made with [Cursor](https://cursor.com)