### PR TITLE
Introduce runtime adapter stop lifecycle contract

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.89.0"

--- a/src/control_plane/controller.rs
+++ b/src/control_plane/controller.rs
@@ -211,7 +211,7 @@ impl ControlPlaneController {
                 }
                 PipelineDesiredState::Stopped | PipelineDesiredState::Paused | PipelineDesiredState::Draining => {
                     if let Some(handle) = running_guard.remove(&pipeline_id) {
-                        handle.abort();
+                        self.adapter.stop_attempt(&handle).await?;
                     }
                     if let Some(h) = pollers_guard.remove(&pipeline_id) {
                         h.abort();

--- a/src/executor/local_runtime_adapter.rs
+++ b/src/executor/local_runtime_adapter.rs
@@ -3,7 +3,9 @@ use async_trait::async_trait;
 
 use crate::cluster::node_assignment::node_to_vertex_ids;
 use crate::common::test_utils::gen_unique_grpc_port;
-use crate::executor::runtime_adapter::{AttemptHandle, RuntimeAdapter, StartAttemptRequest};
+use crate::executor::runtime_adapter::{
+    AttemptHandle, RuntimeAdapter, StartAttemptRequest, TaskPlacementStrategyName,
+};
 use crate::runtime::master::Master;
 use crate::runtime::master_server::{MasterServer, TaskKey};
 use crate::runtime::worker::WorkerConfig;
@@ -132,6 +134,19 @@ impl RuntimeAdapter for LocalRuntimeAdapter {
             worker_addrs,
             join,
         })
+    }
+
+    async fn stop_attempt(&self, handle: &AttemptHandle) -> Result<()> {
+        handle.abort();
+        Ok(())
+    }
+
+    fn supported_task_placement_strategies(&self) -> &'static [TaskPlacementStrategyName] {
+        &[
+            TaskPlacementStrategyName::SingleNode,
+            TaskPlacementStrategyName::SingleWorker,
+            TaskPlacementStrategyName::OperatorPerNode,
+        ]
     }
 }
 

--- a/src/executor/runtime_adapter.rs
+++ b/src/executor/runtime_adapter.rs
@@ -43,8 +43,17 @@ impl AttemptHandle {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskPlacementStrategyName {
+    SingleNode,
+    SingleWorker,
+    OperatorPerNode,
+}
+
 #[async_trait]
 pub trait RuntimeAdapter: Send + Sync {
     async fn start_attempt(&self, req: StartAttemptRequest) -> Result<AttemptHandle>;
+    async fn stop_attempt(&self, handle: &AttemptHandle) -> Result<()>;
+    fn supported_task_placement_strategies(&self) -> &'static [TaskPlacementStrategyName];
 }
 


### PR DESCRIPTION
## Summary
- add `stop_attempt` to the runtime adapter trait so lifecycle shutdown is adapter-owned
- add `supported_task_placement_strategies` capability surface on the adapter contract
- route control-plane stop path through adapter lifecycle API instead of direct handle abort

## Test plan
- [ ] `cargo check` (blocked in this environment by rustc 1.86 vs deps requiring >=1.88)
- [ ] smoke validate local orchestrated stop path

Made with [Cursor](https://cursor.com)