### PR TITLE
Extract minimal placement core

### DIFF
--- a/src/executor/local_runtime_adapter.rs
+++ b/src/executor/local_runtime_adapter.rs
@@ -3,9 +3,8 @@ use async_trait::async_trait;
 
 use crate::cluster::node_assignment::node_to_vertex_ids;
 use crate::common::test_utils::gen_unique_grpc_port;
-use crate::executor::runtime_adapter::{
-    AttemptHandle, RuntimeAdapter, StartAttemptRequest, TaskPlacementStrategyName,
-};
+use crate::executor::placement::TaskPlacementStrategyName;
+use crate::executor::runtime_adapter::{AttemptHandle, RuntimeAdapter, StartAttemptRequest};
 use crate::runtime::master::Master;
 use crate::runtime::master_server::{MasterServer, TaskKey};
 use crate::runtime::worker::WorkerConfig;
@@ -142,11 +141,7 @@ impl RuntimeAdapter for LocalRuntimeAdapter {
     }
 
     fn supported_task_placement_strategies(&self) -> &'static [TaskPlacementStrategyName] {
-        &[
-            TaskPlacementStrategyName::SingleNode,
-            TaskPlacementStrategyName::SingleWorker,
-            TaskPlacementStrategyName::OperatorPerNode,
-        ]
+        &[TaskPlacementStrategyName::SingleWorker]
     }
 }
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,2 +1,3 @@
 pub mod runtime_adapter;
 pub mod local_runtime_adapter;
+pub mod placement;

--- a/src/executor/placement.rs
+++ b/src/executor/placement.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+
+use crate::cluster::cluster_provider::ClusterNode;
+use crate::cluster::node_assignment::{
+    node_to_vertex_ids, ExecutionVertexNodeMapping, NodeAssignStrategy, SingleWorkerStrategy,
+};
+use crate::runtime::execution_graph::ExecutionGraph;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskPlacementStrategyName {
+    SingleWorker,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerEndpoint {
+    pub worker_id: String,
+    pub host: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkerTaskPlacement {
+    pub endpoint: WorkerEndpoint,
+    pub task_ids: Vec<String>,
+}
+
+pub type TaskPlacementMapping = ExecutionVertexNodeMapping;
+
+pub fn strategy_from_name(name: TaskPlacementStrategyName) -> Box<dyn NodeAssignStrategy> {
+    match name {
+        TaskPlacementStrategyName::SingleWorker => Box::new(SingleWorkerStrategy),
+    }
+}
+
+pub fn build_task_placement_mapping(
+    execution_graph: &ExecutionGraph,
+    strategy: &dyn NodeAssignStrategy,
+    cluster_nodes: &[ClusterNode],
+) -> TaskPlacementMapping {
+    strategy.assign_nodes(execution_graph, cluster_nodes)
+}
+
+pub fn worker_to_task_ids(mapping: &TaskPlacementMapping) -> HashMap<String, Vec<String>> {
+    node_to_vertex_ids(mapping)
+}

--- a/src/executor/runtime_adapter.rs
+++ b/src/executor/runtime_adapter.rs
@@ -5,6 +5,7 @@ use tokio::task::JoinHandle;
 use crate::cluster::cluster_provider::ClusterProvider;
 use crate::cluster::node_assignment::NodeAssignStrategy;
 use crate::control_plane::types::ExecutionIds;
+use crate::executor::placement::TaskPlacementStrategyName;
 use crate::runtime::execution_graph::ExecutionGraph;
 use crate::runtime::observability::PipelineSnapshot;
 use crate::api::WorkerRuntimeSpec;
@@ -41,13 +42,6 @@ impl AttemptHandle {
     pub fn is_finished(&self) -> bool {
         self.join.is_finished()
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TaskPlacementStrategyName {
-    SingleNode,
-    SingleWorker,
-    OperatorPerNode,
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- add `executor::placement` module with minimal placement primitives and helpers
- introduce `TaskPlacementStrategyName::SingleWorker` as the only active placement strategy in V2 path
- move adapter placement capability typing into placement module and update local adapter support list

## Test plan
- [ ] `cargo check` (blocked in this environment by rustc 1.86 vs deps requiring >=1.88)
- [ ] validate local adapter path still resolves worker task mapping through node assignment

Made with [Cursor](https://cursor.com)