### PR TITLE
Add minimal per-worker resource model

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,5 +16,6 @@ pub use compiler::compile_logical_graph;
 pub use spec::pipeline::{ExecutionMode, ExecutionProfile, PipelineSpec, PipelineSpecBuilder};
 pub use spec::operators::{OperatorOverride, OperatorOverrides};
 pub use spec::connectors::{DatagenSpec, RequestSourceSinkSpec, SinkSpec, SourceSpec, SourceBindingSpec};
+pub use spec::resources::{ResourceProfile, ResourceProfiles, ResourceStrategy};
 pub use spec::storage::StorageSpec;
 pub use spec::worker_runtime::WorkerRuntimeSpec;

--- a/src/api/spec/mod.rs
+++ b/src/api/spec/mod.rs
@@ -1,6 +1,7 @@
 pub mod connectors;
 pub mod operators;
 pub mod pipeline;
+pub mod resources;
 pub mod storage;
 pub mod worker_runtime;
 

--- a/src/api/spec/pipeline.rs
+++ b/src/api/spec/pipeline.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::api::LogicalGraph;
 use crate::api::spec::connectors::{RequestSourceSinkSpec, SinkSpec, SourceBindingSpec};
 use crate::api::spec::operators::{OperatorOverride, OperatorOverrides};
+use crate::api::spec::resources::{ResourceProfile, ResourceProfiles, ResourceStrategy};
 use crate::api::spec::worker_runtime::WorkerRuntimeSpec;
 use crate::api::spec::storage::StorageSpec;
 use crate::runtime::operators::sink::sink_operator::SinkConfig;
@@ -34,6 +35,8 @@ pub struct PipelineSpec {
     pub execution_profile: ExecutionProfile,
     pub execution_mode: ExecutionMode,
     pub parallelism: usize,
+    pub resource_strategy: ResourceStrategy,
+    pub resource_profiles: ResourceProfiles,
     pub worker_runtime: WorkerRuntimeSpec,
     /// Per-operator-type storage overrides (shared across all instances of that operator type in a worker).
     /// Key is a stable operator-type string (e.g. "window").
@@ -73,6 +76,8 @@ impl PipelineSpecBuilder {
                 },
                 execution_mode: ExecutionMode::Streaming,
                 parallelism: 1,
+                resource_strategy: ResourceStrategy::PerWorker,
+                resource_profiles: ResourceProfiles::default(),
                 worker_runtime: WorkerRuntimeSpec::default(),
                 operator_type_storage: HashMap::new(),
                 operator_overrides: OperatorOverrides::default(),
@@ -101,6 +106,16 @@ impl PipelineSpecBuilder {
 
     pub fn with_execution_profile(mut self, profile: ExecutionProfile) -> Self {
         self.spec.execution_profile = profile;
+        self
+    }
+
+    pub fn with_resource_strategy(mut self, strategy: ResourceStrategy) -> Self {
+        self.spec.resource_strategy = strategy;
+        self
+    }
+
+    pub fn with_worker_resource_profile(mut self, profile: ResourceProfile) -> Self {
+        self.spec.resource_profiles.worker_default = profile;
         self
     }
 

--- a/src/api/spec/resources.rs
+++ b/src/api/spec/resources.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceProfile {
+    pub cpu_millis: Option<u32>,
+    pub memory_bytes: Option<u64>,
+}
+
+impl Default for ResourceProfile {
+    fn default() -> Self {
+        Self {
+            cpu_millis: None,
+            memory_bytes: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ResourceStrategy {
+    PerWorker,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResourceProfiles {
+    pub worker_default: ResourceProfile,
+}
+
+impl Default for ResourceProfiles {
+    fn default() -> Self {
+        Self {
+            worker_default: ResourceProfile::default(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add resource spec module with `ResourceProfile`, `ResourceStrategy::PerWorker`, and `ResourceProfiles`
- wire resource strategy/profiles into `PipelineSpec` with defaults
- expose resource model from `api` and add builder helpers for worker profile overrides

## Test plan
- [ ] `cargo check` (blocked in this environment by rustc 1.86 vs deps requiring >=1.88)
- [ ] validate existing PipelineSpec builder callsites continue to compile with defaulted resource fields

Made with [Cursor](https://cursor.com)