### PR TITLE
Introduce K8s adapter module scaffold

### DIFF
--- a/src/executor/k8s_runtime_adapter.rs
+++ b/src/executor/k8s_runtime_adapter.rs
@@ -1,0 +1,47 @@
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+
+use crate::executor::placement::TaskPlacementStrategyName;
+use crate::executor::runtime_adapter::{AttemptHandle, RuntimeAdapter, StartAttemptRequest};
+
+#[derive(Clone, Debug)]
+pub struct K8sRuntimeConfig {
+    pub namespace: String,
+    pub master_image: String,
+    pub worker_image: String,
+}
+
+impl Default for K8sRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            namespace: "default".to_string(),
+            master_image: "volga-master:latest".to_string(),
+            worker_image: "volga-worker:latest".to_string(),
+        }
+    }
+}
+
+pub struct K8sRuntimeAdapter {
+    pub config: K8sRuntimeConfig,
+}
+
+impl K8sRuntimeAdapter {
+    pub fn new(config: K8sRuntimeConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait]
+impl RuntimeAdapter for K8sRuntimeAdapter {
+    async fn start_attempt(&self, _req: StartAttemptRequest) -> Result<AttemptHandle> {
+        bail!("K8s runtime adapter start lifecycle is not implemented yet")
+    }
+
+    async fn stop_attempt(&self, _handle: &AttemptHandle) -> Result<()> {
+        Ok(())
+    }
+
+    fn supported_task_placement_strategies(&self) -> &'static [TaskPlacementStrategyName] {
+        &[TaskPlacementStrategyName::SingleWorker]
+    }
+}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -1,3 +1,4 @@
 pub mod runtime_adapter;
 pub mod local_runtime_adapter;
+pub mod k8s_runtime_adapter;
 pub mod placement;


### PR DESCRIPTION
## Summary
- add `K8sRuntimeConfig` and `K8sRuntimeAdapter` module in executor layer
- wire K8s adapter into executor module exports
- implement runtime adapter trait surface with explicit not-yet-implemented start lifecycle behavior

## Test plan
- [ ] `cargo check` (blocked in this environment by rustc 1.86 vs deps requiring >=1.88)
- [ ] add and validate real k8s lifecycle integration in subsequent PR

Made with [Cursor](https://cursor.com)