### PR TITLE
Add worker bootstrap RPC and master payload serving

### DIFF
--- a/proto/master_service.proto
+++ b/proto/master_service.proto
@@ -7,6 +7,7 @@ service MasterService {
   rpc GetTaskCheckpoint(GetTaskCheckpointRequest) returns (GetTaskCheckpointResponse);
   rpc GetLatestCompleteCheckpoint(GetLatestCompleteCheckpointRequest) returns (GetLatestCompleteCheckpointResponse);
   rpc GetLatestSnapshot(GetLatestSnapshotRequest) returns (GetLatestSnapshotResponse);
+  rpc GetWorkerBootstrap(GetWorkerBootstrapRequest) returns (GetWorkerBootstrapResponse);
 }
 
 message StateBlob {
@@ -56,6 +57,15 @@ message GetLatestSnapshotResponse {
   bytes snapshot_bytes = 2;
   uint64 ts_ms = 3;
   uint64 seq = 4;
+}
+
+message GetWorkerBootstrapRequest {
+  string worker_id = 1;
+}
+
+message GetWorkerBootstrapResponse {
+  bool has_payload = 1;
+  bytes payload_bytes = 2;
 }
 
 

--- a/src/executor/bootstrap.rs
+++ b/src/executor/bootstrap.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+use crate::control_plane::types::ExecutionIds;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WorkerBootstrapPayload {
+    pub worker_id: String,
+    pub execution_ids: ExecutionIds,
+    pub payload_bytes: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MasterBootstrapPayload {
+    pub execution_ids: ExecutionIds,
+    pub worker_payloads: Vec<WorkerBootstrapPayload>,
+}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -2,3 +2,4 @@ pub mod runtime_adapter;
 pub mod local_runtime_adapter;
 pub mod k8s_runtime_adapter;
 pub mod placement;
+pub mod bootstrap;

--- a/src/runtime/master_server.rs
+++ b/src/runtime/master_server.rs
@@ -14,6 +14,7 @@ use master_service::{
     GetTaskCheckpointRequest, GetTaskCheckpointResponse, StateBlob,
     GetLatestCompleteCheckpointRequest, GetLatestCompleteCheckpointResponse,
     GetLatestSnapshotRequest, GetLatestSnapshotResponse,
+    GetWorkerBootstrapRequest, GetWorkerBootstrapResponse,
 };
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -75,6 +76,7 @@ pub struct MasterLatestSnapshot {
 pub struct MasterServiceImpl {
     registry: Arc<Mutex<MasterCheckpointRegistry>>,
     latest_snapshot: Arc<Mutex<Option<MasterLatestSnapshot>>>,
+    worker_bootstrap_payload: Arc<Mutex<Option<Vec<u8>>>>,
 }
 
 impl MasterServiceImpl {
@@ -82,11 +84,17 @@ impl MasterServiceImpl {
         Self {
             registry: Arc::new(Mutex::new(MasterCheckpointRegistry::default())),
             latest_snapshot: Arc::new(Mutex::new(None)),
+            worker_bootstrap_payload: Arc::new(Mutex::new(None)),
         }
     }
 
     pub fn snapshot_sink(&self) -> Arc<Mutex<Option<MasterLatestSnapshot>>> {
         self.latest_snapshot.clone()
+    }
+
+    pub async fn set_worker_bootstrap_payload(&self, payload: Vec<u8>) {
+        let mut guard = self.worker_bootstrap_payload.lock().await;
+        *guard = Some(payload);
     }
 }
 
@@ -192,6 +200,24 @@ impl MasterService for MasterServiceImpl {
             }))
         }
     }
+
+    async fn get_worker_bootstrap(
+        &self,
+        _request: Request<GetWorkerBootstrapRequest>,
+    ) -> Result<Response<GetWorkerBootstrapResponse>, Status> {
+        let guard = self.worker_bootstrap_payload.lock().await;
+        if let Some(payload) = guard.as_ref() {
+            Ok(Response::new(GetWorkerBootstrapResponse {
+                has_payload: true,
+                payload_bytes: payload.clone(),
+            }))
+        } else {
+            Ok(Response::new(GetWorkerBootstrapResponse {
+                has_payload: false,
+                payload_bytes: Vec::new(),
+            }))
+        }
+    }
 }
 
 /// Server that hosts MasterService
@@ -217,6 +243,10 @@ impl MasterServer {
     pub async fn set_checkpointable_tasks(&mut self, tasks: Vec<TaskKey>) {
         let mut registry = self.service.registry.lock().await;
         registry.expected_tasks = tasks.into_iter().collect();
+    }
+
+    pub async fn set_worker_bootstrap_payload(&self, payload: Vec<u8>) {
+        self.service.set_worker_bootstrap_payload(payload).await;
     }
 
     pub async fn start(&mut self, addr: &str) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- add `GetWorkerBootstrap` RPC and request/response messages to `master_service.proto`
- add master-side in-memory bootstrap payload storage and RPC handler in `MasterServiceImpl`
- add bootstrap payload model module in executor layer and export it from `executor::mod`

## Test plan
- [ ] `cargo check` (blocked in this environment by rustc 1.86 vs deps requiring >=1.88)
- [ ] validate generated tonic client/server include `GetWorkerBootstrap`

Made with [Cursor](https://cursor.com)