### PR TITLE
Add execution plan model and standalone bootstrap entrypoints

### DIFF
--- a/src/entrypoints/mod.rs
+++ b/src/entrypoints/mod.rs
@@ -1,0 +1,2 @@
+pub mod volga_master;
+pub mod volga_worker;

--- a/src/entrypoints/volga_master.rs
+++ b/src/entrypoints/volga_master.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+
+use crate::runtime::master_server::MasterServer;
+
+pub async fn run_volga_master(bind_addr: &str) -> Result<()> {
+    let mut server = MasterServer::new();
+    server.start(bind_addr).await?;
+    Ok(())
+}

--- a/src/entrypoints/volga_worker.rs
+++ b/src/entrypoints/volga_worker.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+
+use crate::runtime::entrypoints::standalone::fetch_worker_bootstrap;
+
+pub async fn run_volga_worker(master_addr: &str, worker_id: &str) -> Result<()> {
+    let _bootstrap = fetch_worker_bootstrap(master_addr, worker_id).await?;
+    Ok(())
+}

--- a/src/executor/bootstrap.rs
+++ b/src/executor/bootstrap.rs
@@ -1,16 +1,18 @@
 use serde::{Deserialize, Serialize};
 
 use crate::control_plane::types::ExecutionIds;
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct WorkerBootstrapPayload {
-    pub worker_id: String,
-    pub execution_ids: ExecutionIds,
-    pub payload_bytes: Vec<u8>,
-}
+use crate::runtime::execution_plan::ExecutionPlan;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MasterBootstrapPayload {
     pub execution_ids: ExecutionIds,
-    pub worker_payloads: Vec<WorkerBootstrapPayload>,
+    pub plan: ExecutionPlan,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WorkerBootstrapPayload {
+    pub execution_ids: ExecutionIds,
+    pub plan: ExecutionPlan,
+    pub worker_id: String,
+    pub assigned_task_ids: Vec<String>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod api;
 pub mod cluster;
 pub mod storage;
 pub mod executor;
+pub mod entrypoints;
 pub mod sql_testing;
 pub mod control_plane;

--- a/src/runtime/entrypoints/mod.rs
+++ b/src/runtime/entrypoints/mod.rs
@@ -1,0 +1,1 @@
+pub mod standalone;

--- a/src/runtime/entrypoints/standalone.rs
+++ b/src/runtime/entrypoints/standalone.rs
@@ -1,0 +1,22 @@
+use anyhow::{anyhow, Result};
+
+use crate::executor::bootstrap::WorkerBootstrapPayload;
+use crate::runtime::master_server::master_service::master_service_client::MasterServiceClient;
+use crate::runtime::master_server::master_service::GetWorkerBootstrapRequest;
+
+pub async fn fetch_worker_bootstrap(master_addr: &str, worker_id: &str) -> Result<WorkerBootstrapPayload> {
+    let mut client = MasterServiceClient::connect(format!("http://{}", master_addr)).await?;
+    let resp = client
+        .get_worker_bootstrap(tonic::Request::new(GetWorkerBootstrapRequest {
+            worker_id: worker_id.to_string(),
+        }))
+        .await?
+        .into_inner();
+
+    if !resp.has_payload || resp.payload_bytes.is_empty() {
+        return Err(anyhow!("worker bootstrap payload is not available yet"));
+    }
+
+    let payload: WorkerBootstrapPayload = bincode::deserialize(&resp.payload_bytes)?;
+    Ok(payload)
+}

--- a/src/runtime/execution_plan.rs
+++ b/src/runtime/execution_plan.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::api::{PipelineSpec, WorkerRuntimeSpec};
+use crate::control_plane::types::ExecutionIds;
+use crate::executor::placement::TaskPlacementMapping;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExecutionPlan {
+    pub execution_ids: ExecutionIds,
+    pub pipeline_spec: PipelineSpec,
+    pub worker_runtime: WorkerRuntimeSpec,
+    pub task_placement_mapping: HashMap<String, String>,
+    pub worker_task_ids: HashMap<String, Vec<String>>,
+}
+
+impl ExecutionPlan {
+    pub fn from_spec(
+        execution_ids: ExecutionIds,
+        pipeline_spec: PipelineSpec,
+        task_placement_mapping: TaskPlacementMapping,
+        worker_task_ids: HashMap<String, Vec<String>>,
+    ) -> Self {
+        let worker_runtime = pipeline_spec.worker_runtime.clone();
+        let task_placement_mapping = task_placement_mapping
+            .into_iter()
+            .map(|(vertex_id, cluster_node)| (vertex_id, cluster_node.node_id))
+            .collect();
+        Self {
+            execution_ids,
+            pipeline_spec,
+            worker_runtime,
+            task_placement_mapping,
+            worker_task_ids,
+        }
+    }
+}

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,5 +1,7 @@
 pub mod runtime_context;
 pub mod execution_graph;
+pub mod execution_plan;
+pub mod entrypoints;
 pub mod operators;
 pub mod stream_task;
 pub mod stream_task_actor;


### PR DESCRIPTION
## Summary
- add canonical `runtime::execution_plan::ExecutionPlan` model for runtime handoff
- align bootstrap payloads to carry `ExecutionPlan` directly
- add standalone runtime entrypoint bootstrap fetch path and `entrypoints` module wiring

## Test plan
- [ ] `cargo check` (blocked in this environment by rustc 1.86 vs deps requiring >=1.88)
- [ ] validate worker bootstrap RPC fetch path using `fetch_worker_bootstrap`

Made with [Cursor](https://cursor.com)