### PR TITLE
Add bootstrap payload tests and V2 docs

### DIFF
--- a/docs/k8s_runtime_adapter_v2.md
+++ b/docs/k8s_runtime_adapter_v2.md
@@ -1,0 +1,21 @@
+# K8s Runtime Adapter V2 Notes
+
+This document summarizes the V2 stack intent and current layering:
+
+- `RuntimeAdapter` owns lifecycle (`start_attempt`, `stop_attempt`) for adapter-backed modes.
+- Placement concerns live in `executor::placement` and expose a minimal strategy surface.
+- Resource surface is intentionally minimal (`ResourceStrategy::PerWorker`).
+- Bootstrap handoff is served by master via `GetWorkerBootstrap`.
+- Runtime handoff is represented by `runtime::execution_plan::ExecutionPlan`.
+
+## Current execution split
+
+- In-process profile keeps direct worker execution.
+- Adapter-backed profiles go through `PipelineContext` adapter helper path.
+- Local adapter is the reference path for placement mapping and attempt lifecycle.
+
+## Follow-up focus
+
+- Complete K8s lifecycle internals behind existing adapter/module boundaries.
+- Wire full worker bootstrap consumption into worker runtime startup path.
+- Extend integration tests to cover K8s bootstrap and stop lifecycle end-to-end.

--- a/src/runtime/tests/bootstrap_payload_test.rs
+++ b/src/runtime/tests/bootstrap_payload_test.rs
@@ -1,0 +1,42 @@
+#![cfg(test)]
+
+use std::collections::HashMap;
+
+use crate::api::PipelineSpecBuilder;
+use crate::control_plane::types::{AttemptId, ExecutionIds};
+use crate::executor::bootstrap::{MasterBootstrapPayload, WorkerBootstrapPayload};
+use crate::runtime::execution_plan::ExecutionPlan;
+
+#[test]
+fn bootstrap_payload_roundtrip_bincode() {
+    let execution_ids = ExecutionIds::fresh(AttemptId(7));
+    let spec = PipelineSpecBuilder::new().build();
+    let plan = ExecutionPlan::from_spec(
+        execution_ids.clone(),
+        spec,
+        HashMap::new(),
+        HashMap::new(),
+    );
+
+    let master = MasterBootstrapPayload {
+        execution_ids: execution_ids.clone(),
+        plan: plan.clone(),
+    };
+    let worker = WorkerBootstrapPayload {
+        execution_ids,
+        plan,
+        worker_id: "worker-0".to_string(),
+        assigned_task_ids: vec!["task-0".to_string()],
+    };
+
+    let master_bytes = bincode::serialize(&master).expect("serialize master payload");
+    let worker_bytes = bincode::serialize(&worker).expect("serialize worker payload");
+
+    let master_decoded: MasterBootstrapPayload =
+        bincode::deserialize(&master_bytes).expect("deserialize master payload");
+    let worker_decoded: WorkerBootstrapPayload =
+        bincode::deserialize(&worker_bytes).expect("deserialize worker payload");
+
+    assert_eq!(master_decoded.plan.worker_task_ids.len(), 0);
+    assert_eq!(worker_decoded.worker_id, "worker-0");
+}

--- a/src/runtime/tests/mod.rs
+++ b/src/runtime/tests/mod.rs
@@ -13,3 +13,4 @@ pub mod checkpoint_recovery_test;
 pub mod watermark_streaming_e2e_test;
 pub mod watermark_streaming_benchmark_test;
 pub mod test_utils;
+pub mod bootstrap_payload_test;


### PR DESCRIPTION
## Summary
- add V2 runtime adapter architecture notes under `docs/`
- add bootstrap payload serialization roundtrip test
- register bootstrap payload test module in runtime test tree

## Test plan
- [ ] `cargo check` (blocked in this environment by rustc 1.86 vs deps requiring >=1.88)
- [ ] run runtime unit tests once toolchain is upgraded

Made with [Cursor](https://cursor.com)