### PR TITLE
use bitmask-oriented id abstractions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ metrics-exporter-tcp = "0.11.1"
 metrics-util = "0.20.0"
 prometheus-parse = "0.2.5"
 indexmap = "2.11.4"
+num_enum = "0.7"
 axum = "0.7"
 hyper = "1.0"
 reqwest = { version = "0.11", features = ["json"] }

--- a/proto/master_service.proto
+++ b/proto/master_service.proto
@@ -16,7 +16,7 @@ message StateBlob {
 
 message ReportCheckpointRequest {
   uint64 checkpoint_id = 1;
-  string vertex_id = 2;
+  fixed32 vertex_id = 2;
   int32 task_index = 3;
   repeated StateBlob blobs = 4;
 }
@@ -28,7 +28,7 @@ message ReportCheckpointResponse {
 
 message GetTaskCheckpointRequest {
   uint64 checkpoint_id = 1;
-  string vertex_id = 2;
+  fixed32 vertex_id = 2;
   int32 task_index = 3;
 }
 

--- a/proto/message_stream.proto
+++ b/proto/message_stream.proto
@@ -9,7 +9,7 @@ service MessageStreamService {
 
 message GrpcMessage {
   bytes message_data = 1;
-  string channel_id = 2;
+  fixed64 channel_id = 2;
 }
 
 message EmptyResponse {

--- a/src/api/logical_graph.rs
+++ b/src/api/logical_graph.rs
@@ -5,6 +5,8 @@ use arrow::datatypes::Schema as ArrowSchema;
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::prelude::EdgeRef;
 use petgraph::Direction;
+use crate::common::ids::{OperatorTypeCode, VertexId};
+use crate::common::OperatorId;
 use crate::runtime::operators::chained::chained_operator::group_operators_for_chaining;
 use crate::runtime::operators::operator::OperatorConfig;
 use crate::runtime::execution_graph::{ExecutionGraph, ExecutionVertex, ExecutionEdge};
@@ -17,7 +19,7 @@ use crate::runtime::watermark::{TimeHint, WatermarkAssignConfig};
 
 #[derive(Debug, Clone)]
 pub struct LogicalNode {
-    pub operator_id: String, // unique id for the node/operator
+    pub operator_id: OperatorId, // unique human-readable id for the node/operator, e.g. "Map_1"
     pub operator_config: OperatorConfig,
     pub parallelism: usize,
     pub in_schema: Option<Arc<ArrowSchema>>,
@@ -27,8 +29,9 @@ pub struct LogicalNode {
 
 impl LogicalNode {
     pub fn new(operator_config: OperatorConfig, parallelism: usize, in_schema: Option<Arc<ArrowSchema>>, out_schema: Option<Arc<ArrowSchema>>) -> Self {
+        let op_type_code = OperatorTypeCode::from(&operator_config);
         Self {
-            operator_id: String::new(), // Will be set by add_node
+            operator_id: OperatorId::new(op_type_code, 0), // Will be set by add_node
             operator_config,
             parallelism,
             in_schema,
@@ -36,7 +39,7 @@ impl LogicalNode {
             watermark_assign: None,
         }
     }
-} 
+}
 
 /// Connector configuration for sources and sinks
 #[derive(Debug, Clone)]
@@ -47,15 +50,17 @@ pub struct ConnectorConfig {
 
 #[derive(Debug, Clone)]
 pub struct LogicalEdge {
-    pub source_node_id: String,
-    pub target_node_id: String,
+    pub source_node_id: OperatorId,
+    pub target_node_id: OperatorId,
     pub partition_type: PartitionType,
 }
 
 #[derive(Debug, Clone)]
 pub struct LogicalGraph {
     graph: DiGraph<LogicalNode, LogicalEdge>,
-    operator_type_counters: HashMap<String, u32>,
+    /// Per-op-type counter; assigns 1-based instance ids that fit in `u8`.
+    /// Panics in `add_node` if more than 255 instances of the same type are created.
+    operator_type_counters: HashMap<OperatorTypeCode, u8>,
     root_node_index: Option<NodeIndex>,
     watermarks_enabled: bool,
 }
@@ -86,9 +91,9 @@ impl LogicalGraph {
     }
     
     /// Get node index by operator_id
-    pub fn get_node_index(&self, operator_id: &String) -> Option<NodeIndex> {
+    pub fn get_node_index(&self, operator_id: OperatorId) -> Option<NodeIndex> {
         self.graph.node_indices()
-            .find(|&idx| self.graph[idx].operator_id == *operator_id)
+            .find(|&idx| self.graph[idx].operator_id == operator_id)
     }
 
     pub fn get_all_node_indices(&self) -> Vec<NodeIndex> {
@@ -111,14 +116,19 @@ impl LogicalGraph {
     }
 
     pub fn add_node(&mut self, mut node: LogicalNode) -> NodeIndex {
-        // Generate unique operator_id based on operator configtype
-        let operator_config_type = format!("{}", node.operator_config);
-        let counter = self.operator_type_counters.entry(operator_config_type.clone()).or_insert(0);
-        *counter += 1;
-        node.operator_id = format!("{}_{}", operator_config_type, counter);
-        
-        let node_index = self.graph.add_node(node);
-        node_index
+        let op_type_code = node.operator_id.op_type();
+        let counter = self.operator_type_counters.entry(op_type_code).or_insert(0);
+        let next = counter.checked_add(1).unwrap_or_else(|| {
+            panic!(
+                "More than 127 instances of operator type {:?} in one pipeline — \
+                 bump the instance_id width if this is ever a real limit",
+                op_type_code
+            )
+        });
+        *counter = next;
+        node.operator_id = OperatorId::new(op_type_code, next);
+
+        self.graph.add_node(node)
     }
 
     pub fn add_edge(&mut self, source: NodeIndex, target: NodeIndex) -> petgraph::graph::EdgeIndex {
@@ -126,15 +136,15 @@ impl LogicalGraph {
         let target_node = &self.graph[target];
         let partition_type = determine_partition_type(&source_node.operator_config, &target_node.operator_config);
         let edge = LogicalEdge {
-            source_node_id: source_node.operator_id.clone(),
-            target_node_id: target_node.operator_id.clone(),
+            source_node_id: source_node.operator_id,
+            target_node_id: target_node.operator_id,
             partition_type,
         };
         
         self.graph.add_edge(source, target, edge)
     }
 
-    pub fn get_node(&self, operator_id: String) -> Option<&LogicalNode> {
+    pub fn get_node(&self, operator_id: OperatorId) -> Option<&LogicalNode> {
         self.graph.node_weights().find(|node| node.operator_id == operator_id)
     }
 
@@ -166,7 +176,7 @@ impl LogicalGraph {
         //
         // TODO: extend placement for joins/unions (multiple-input operators), where "closest window" is ambiguous
         // and per-input watermark generation needs careful handling.
-        let mut auto_watermark_assign: HashMap<String, WatermarkAssignConfig> = HashMap::new();
+        let mut auto_watermark_assign: HashMap<OperatorId, WatermarkAssignConfig> = HashMap::new();
         if self.watermarks_enabled {
             let source_nodes: Vec<NodeIndex> = self
                 .graph
@@ -224,7 +234,7 @@ impl LogicalGraph {
         }
 
         let mut execution_graph = ExecutionGraph::new();
-        let mut logical_to_execution_mapping: HashMap<NodeIndex, Vec<String>> = HashMap::new();
+        let mut logical_to_execution_mapping: HashMap<NodeIndex, Vec<VertexId>> = HashMap::new();
 
         // Create execution vertices for each logical node
         for logical_node in self.graph.node_weights() {
@@ -234,19 +244,25 @@ impl LogicalGraph {
 
             let mut execution_vertex_ids = Vec::new();
             let parallelism = logical_node.parallelism;
+            assert!(
+                parallelism <= u16::MAX as usize,
+                "parallelism {} exceeds u16::MAX for operator {}",
+                parallelism, logical_node.operator_id
+            );
 
             // Create parallel execution vertices for this logical node
             for i in 0..parallelism {
-                let execution_vertex_id = format!("{}_{}", logical_node.operator_id, i);
-
-                let execution_vertex = ExecutionVertex::new(
-                    execution_vertex_id.clone(),
-                    logical_node.operator_id.clone(),
-                    logical_node.operator_config.clone(),
-                    parallelism as i32,
-                    i as i32,
+                let execution_vertex_id = VertexId::new(
+                    logical_node.operator_id.op_type(),
+                    logical_node.operator_id.instance(),
+                    i as u16,
                 );
-                let mut execution_vertex = execution_vertex;
+
+                let mut execution_vertex = ExecutionVertex::new(
+                    execution_vertex_id,
+                    logical_node.operator_config.clone(),
+                    parallelism as i32
+                );
                 execution_vertex.watermark_assign = logical_node
                     .watermark_assign
                     .clone()
@@ -274,9 +290,8 @@ impl LogicalGraph {
             for source_execution_vertex_id in source_execution_vertices {
                 for target_execution_vertex_id in target_execution_vertices {
                     let execution_edge = ExecutionEdge::new(
-                        source_execution_vertex_id.clone(),
-                        target_execution_vertex_id.clone(),
-                        self.graph[target_logical_node_index].operator_id.clone(),
+                        *source_execution_vertex_id,
+                        *target_execution_vertex_id,
                         partition_type.clone(),
                         None, // No channel initially
                     );
@@ -694,9 +709,9 @@ mod tests {
         // Verify partition types
         for edge in edges.values() {
             assert!(matches!(edge.partition_type, PartitionType::RoundRobin),
-                "Edge {} -> {} should use RoundRobin partitioning", edge.source_vertex_id, edge.target_vertex_id);
+                "Edge {} -> {} should use RoundRobin partitioning", edge.edge_id.source(), edge.edge_id.target());
             // Verify channels are not set initially
-            assert!(edge.channel.is_none(), "Edge {} -> {} should not have channel set initially", edge.source_vertex_id, edge.target_vertex_id);
+            assert!(edge.channel.is_none(), "Edge {} -> {} should not have channel set initially", edge.edge_id.source(), edge.edge_id.target());
         }
     }
 
@@ -757,8 +772,8 @@ mod tests {
         // Verify that edges between different nodes use remote channels
         for edge in edges.values() {
             // Get source and target nodes from the mapping
-            let source_node = vertex_to_node.get(edge.source_vertex_id.as_ref()).expect("Source vertex should be mapped");
-            let target_node = vertex_to_node.get(edge.target_vertex_id.as_ref()).expect("Target vertex should be mapped");
+            let source_node = vertex_to_node.get(&edge.edge_id.source()).expect("Source vertex should be mapped");
+            let target_node = vertex_to_node.get(&edge.edge_id.target()).expect("Target vertex should be mapped");
             
             // Check if vertices are on different nodes
             if source_node.node_id != target_node.node_id {
@@ -770,12 +785,12 @@ mod tests {
                         assert_eq!(*target_port, target_node.node_port as i32);
                     }
                     Some(Channel::Local { .. }) => {
-                        panic!("Expected remote channel for cross-node edge {} -> {}", 
-                               edge.source_vertex_id, edge.target_vertex_id);
+                        panic!("Expected remote channel for cross-node edge {} -> {}",
+                               edge.edge_id.source(), edge.edge_id.target());
                     }
                     None => {
-                        panic!("Expected channel to be set for edge {} -> {}", 
-                               edge.source_vertex_id, edge.target_vertex_id);
+                        panic!("Expected channel to be set for edge {} -> {}",
+                               edge.edge_id.source(), edge.edge_id.target());
                     }
                 }
             } else {
@@ -841,7 +856,7 @@ mod tests {
             // chain_source->map1->keyby -> chain_map2->sink should use Hash partitioning
             // because keyby is the last operator in the source chain
             assert!(matches!(edge.partition_type, crate::runtime::partition::PartitionType::Hash),
-                "Edge {} -> {} should use Hash partitioning (keyby -> map2)", edge.source_vertex_id, edge.target_vertex_id);
+                "Edge {} -> {} should use Hash partitioning (keyby -> map2)", edge.edge_id.source(), edge.edge_id.target());
         }
     }
 
@@ -866,26 +881,26 @@ mod tests {
 
         // Check partition types for all edges
         for edge in graph.get_edges().values() {
-            let source_vertex = graph.get_vertex(&edge.source_vertex_id).unwrap();
-            let target_vertex = graph.get_vertex(&edge.target_vertex_id).unwrap();
+            let source_vertex = graph.get_vertex(edge.edge_id.source()).unwrap();
+            let target_vertex = graph.get_vertex(edge.edge_id.target()).unwrap();
 
             match (&source_vertex.operator_config, &target_vertex.operator_config) {
                 (OperatorConfig::SourceConfig(_), OperatorConfig::KeyByConfig(_)) => {
                     // source -> keyby should use RoundRobin
                     assert!(matches!(edge.partition_type, crate::runtime::partition::PartitionType::RoundRobin),
-                        "Edge {} -> {} should use RoundRobin partitioning", edge.source_vertex_id, edge.target_vertex_id);
+                        "Edge {} -> {} should use RoundRobin partitioning", edge.edge_id.source(), edge.edge_id.target());
                 }
                 (OperatorConfig::KeyByConfig(_), OperatorConfig::MapConfig(_)) => {
                     // keyby -> map should use Hash partitioning
                     assert!(matches!(edge.partition_type, crate::runtime::partition::PartitionType::Hash),
-                        "Edge {} -> {} should use Hash partitioning", edge.source_vertex_id, edge.target_vertex_id);
+                        "Edge {} -> {} should use Hash partitioning", edge.edge_id.source(), edge.edge_id.target());
                 }
                 (OperatorConfig::MapConfig(_), OperatorConfig::SinkConfig(_)) => {
                     // map -> sink should use RoundRobin
                     assert!(matches!(edge.partition_type, crate::runtime::partition::PartitionType::RoundRobin),
-                        "Edge {} -> {} should use RoundRobin partitioning", edge.source_vertex_id, edge.target_vertex_id);
+                        "Edge {} -> {} should use RoundRobin partitioning", edge.edge_id.source(), edge.edge_id.target());
                 }
-                _ => panic!("Unexpected edge: {} -> {}", edge.source_vertex_id, edge.target_vertex_id)
+                _ => panic!("Unexpected edge: {} -> {}", edge.edge_id.source(), edge.edge_id.target())
             }
         }
     }

--- a/src/api/planner.rs
+++ b/src/api/planner.rs
@@ -1010,7 +1010,7 @@ mod tests {
         let window_node = nodes_after.iter()
             .find(|n| matches!(n.operator_config, OperatorConfig::WindowConfig(_)))
             .expect("Should have window node");
-        let window_node_idx = graph.get_node_index(&window_node.operator_id)
+        let window_node_idx = graph.get_node_index(window_node.operator_id)
             .expect("Should find window node index");
         let outgoing_after = graph.get_neighbors(window_node_idx, Direction::Outgoing);
         assert_eq!(outgoing_after.len(), 0, "Window should have no outgoing edges after conversion");

--- a/src/api/spec/operators/overrides.rs
+++ b/src/api/spec/operators/overrides.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::transport::transport_spec::OperatorTransportSpec;
 use crate::api::spec::operators::tuning::OperatorTuningSpec;
+use crate::common::OperatorId;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct OperatorOverride {
@@ -14,6 +15,6 @@ pub struct OperatorOverride {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct OperatorOverrides {
     pub defaults: OperatorOverride,
-    pub per_operator: HashMap<String, OperatorOverride>,
+    pub per_operator: HashMap<OperatorId, OperatorOverride>,
 }
 

--- a/src/api/spec/pipeline.rs
+++ b/src/api/spec/pipeline.rs
@@ -9,6 +9,7 @@ use crate::api::spec::connectors::{RequestSourceSinkSpec, SinkSpec, SourceBindin
 use crate::api::spec::operators::{OperatorOverride, OperatorOverrides};
 use crate::api::spec::worker_runtime::WorkerRuntimeSpec;
 use crate::api::spec::storage::StorageSpec;
+use crate::common::OperatorId;
 use crate::runtime::operators::sink::sink_operator::SinkConfig;
 use crate::runtime::operators::source::source_operator::SourceConfig;
 use crate::transport::transport_spec::OperatorTransportSpec;
@@ -109,9 +110,9 @@ impl PipelineSpecBuilder {
         self
     }
 
-    pub fn with_operator_transport_queue_records(mut self, operator_id: &str, queue_records: u32) -> Self {
+    pub fn with_operator_transport_queue_records(mut self, operator_id: OperatorId, queue_records: u32) -> Self {
         self.spec.operator_overrides.per_operator
-            .entry(operator_id.to_string())
+            .entry(operator_id)
             .or_insert_with(OperatorOverride::default)
             .transport = Some(OperatorTransportSpec { queue_records: Some(queue_records.max(1)) });
         self
@@ -158,11 +159,11 @@ impl PipelineSpecBuilder {
         self
     }
 
-    pub fn with_operator_override(mut self, operator_id: &str, override_spec: OperatorOverride) -> Self {
+    pub fn with_operator_override(mut self, operator_id: OperatorId, override_spec: OperatorOverride) -> Self {
         self.spec
             .operator_overrides
             .per_operator
-            .insert(operator_id.to_string(), override_spec);
+            .insert(operator_id, override_spec);
         self
     }
 
@@ -215,7 +216,7 @@ impl PipelineSpecBuilder {
 }
 
 impl PipelineSpec {
-    pub fn transport_overrides_queue_records(&self) -> HashMap<String, u32> {
+    pub fn transport_overrides_queue_records(&self) -> HashMap<OperatorId, u32> {
         let mut out = HashMap::new();
         for (op_id, ov) in &self.operator_overrides.per_operator {
             if let Some(v) = operator_override_transport_queue_records(ov) {

--- a/src/cluster/node_assignment.rs
+++ b/src/cluster/node_assignment.rs
@@ -1,14 +1,16 @@
 use std::collections::HashMap;
+use crate::common::ids::VertexId;
 use crate::runtime::execution_graph::ExecutionGraph;
 use crate::cluster::cluster_provider::ClusterNode;
+use crate::common::OperatorId;
 
 /// Mapping from execution vertex ID to cluster node
-pub type ExecutionVertexNodeMapping = HashMap<String, ClusterNode>;
+pub type ExecutionVertexNodeMapping = HashMap<VertexId, ClusterNode>;
 
-pub fn node_to_vertex_ids(mapping: &ExecutionVertexNodeMapping) -> HashMap<String, Vec<String>> {
+pub fn node_to_vertex_ids(mapping: &ExecutionVertexNodeMapping) -> HashMap<String, Vec<VertexId>> {
     let mut node_to_vertex_ids = HashMap::new();
     for (vertex_id, node) in mapping {
-        node_to_vertex_ids.entry(node.node_id.clone()).or_insert_with(Vec::new).push(vertex_id.clone());
+        node_to_vertex_ids.entry(node.node_id.clone()).or_insert_with(Vec::new).push(*vertex_id);
     }
     node_to_vertex_ids
 }
@@ -30,7 +32,7 @@ impl NodeAssignStrategy for SingleNodeStrategy {
         }
         let node = cluster_nodes[0].clone();
         for vertex_id in execution_graph.get_vertices().keys() {
-            mapping.insert(vertex_id.as_ref().to_string(), node.clone());
+            mapping.insert(*vertex_id, node.clone());
         }
         mapping
     }
@@ -48,7 +50,7 @@ impl NodeAssignStrategy for SingleWorkerStrategy {
         }
         let worker_node = cluster_nodes[1].clone();
         for vertex_id in execution_graph.get_vertices().keys() {
-            mapping.insert(vertex_id.as_ref().to_string(), worker_node.clone());
+            mapping.insert(*vertex_id, worker_node.clone());
         }
         mapping
     }
@@ -60,21 +62,21 @@ pub struct OperatorPerNodeStrategy;
 impl NodeAssignStrategy for OperatorPerNodeStrategy {
     fn assign_nodes(&self, execution_graph: &ExecutionGraph, cluster_nodes: &[ClusterNode]) -> ExecutionVertexNodeMapping {
         let mut mapping = ExecutionVertexNodeMapping::new();
-        
+
         if cluster_nodes.is_empty() {
             return mapping;
         }
 
         // Group vertices by operator_id
-        let mut operator_to_vertices: HashMap<String, Vec<String>> = HashMap::new();
-        
+        let mut operator_to_vertices: HashMap<OperatorId, Vec<VertexId>> = HashMap::new();
+
         for vertex_id in execution_graph.get_vertices().keys() {
-            let vertex = execution_graph.get_vertices().get(vertex_id).expect("vertex should exist");
-            let operator_id = vertex.operator_id.clone();
+            let execution_vertex = execution_graph.get_vertices().get(vertex_id).expect("vertex should exist");
+            let operator_id = execution_vertex.vertex_id.operator_id();
             operator_to_vertices
                 .entry(operator_id)
                 .or_insert_with(Vec::new)
-                .push(vertex_id.as_ref().to_string());
+                .push(*vertex_id);
         }
 
         // Check if we have enough nodes for all operators
@@ -86,12 +88,12 @@ impl NodeAssignStrategy for OperatorPerNodeStrategy {
         let mut node_index = 0;
         for (_operator_id, vertex_ids) in operator_to_vertices {
             let cluster_node = &cluster_nodes[node_index % cluster_nodes.len()];
-            
+
             // Assign all vertices of this operator to the same node
             for vertex_id in vertex_ids {
                 mapping.insert(vertex_id, cluster_node.clone());
             }
-            
+
             node_index += 1;
         }
 
@@ -103,6 +105,7 @@ impl NodeAssignStrategy for OperatorPerNodeStrategy {
 mod tests {
     use super::*;
     use crate::cluster::cluster_provider::create_test_cluster_nodes;
+    use crate::common::OperatorId;
     use crate::runtime::operators::source::source_operator::{SourceConfig, VectorSourceConfig};
     use crate::runtime::execution_graph::ExecutionGraph;
 
@@ -111,24 +114,24 @@ mod tests {
         use datafusion::execution::context::SessionContext;
         use arrow::datatypes::{Schema, Field, DataType};
         use std::sync::Arc;
-        
+
         let ctx = SessionContext::new();
         let mut planner = Planner::new(PlanningContext::new(ctx));
-        
+
         // Register test table
         planner.register_source(
-            "test_table".to_string(), 
-            SourceConfig::VectorSourceConfig(VectorSourceConfig::new(vec![])), 
+            "test_table".to_string(),
+            SourceConfig::VectorSourceConfig(VectorSourceConfig::new(vec![])),
             Arc::new(Schema::new(vec![
                 Field::new("id", DataType::Int32, false),
                 Field::new("value", DataType::Float64, false),
             ]))
         );
-        
+
         // Create logical graph from SQL
         let sql = "SELECT id FROM test_table WHERE value > 3.0";
         let logical_graph = planner.sql_to_graph(sql).unwrap();
-        
+
         // Convert to execution graph
         logical_graph.to_execution_graph()
     }
@@ -138,12 +141,12 @@ mod tests {
         let execution_graph = create_test_execution_graph();
 
         // Group vertices by operator_id
-        let mut operator_to_vertices: HashMap<String, Vec<String>> = HashMap::new();
-        for (vertex_id, vertex) in execution_graph.get_vertices() {
+        let mut operator_to_vertices: HashMap<OperatorId, Vec<VertexId>> = HashMap::new();
+        for (vertex_id, execution_vertex) in execution_graph.get_vertices() {
             operator_to_vertices
-                .entry(vertex.operator_id.clone())
+                .entry(execution_vertex.vertex_id.operator_id())
                 .or_insert_with(Vec::new)
-                .push(vertex_id.as_ref().to_string());
+                .push(*vertex_id);
         }
 
         let num_operators = operator_to_vertices.len();
@@ -157,34 +160,34 @@ mod tests {
         assert_eq!(mapping.len(), execution_graph.get_vertices().len());
 
         // Group vertices by assigned node
-        let mut node_to_vertices: HashMap<String, Vec<String>> = HashMap::new();
+        let mut node_to_vertices: HashMap<String, Vec<VertexId>> = HashMap::new();
         for (vertex_id, cluster_node) in &mapping {
             node_to_vertices
                 .entry(cluster_node.node_id.clone())
                 .or_insert_with(Vec::new)
-                .push(vertex_id.clone());
+                .push(*vertex_id);
         }
 
         // Verify that each node contains vertices with the same operator_id
         for (node_id, vertex_ids) in &node_to_vertices {
             let mut operator_ids = std::collections::HashSet::new();
             for vertex_id in vertex_ids {
-                let vertex = execution_graph.get_vertices().get(vertex_id.as_str()).unwrap();
-                operator_ids.insert(vertex.operator_id.clone());
+                let execution_vertex = execution_graph.get_vertices().get(vertex_id).unwrap();
+                operator_ids.insert(execution_vertex.vertex_id.operator_id());
             }
             // All vertices on the same node should have the same operator_id
             assert_eq!(operator_ids.len(), 1, "Node {} contains vertices with different operator_ids: {:?}", node_id, operator_ids);
         }
 
         // Verify that each operator_id maps to exactly one node
-        let mut operator_to_node: HashMap<String, String> = HashMap::new();
+        let mut operator_to_node: HashMap<OperatorId, String> = HashMap::new();
         for (vertex_id, cluster_node) in &mapping {
-            let vertex = execution_graph.get_vertices().get(vertex_id.as_str()).unwrap();
-            let operator_id = &vertex.operator_id;
-            
+            let vertex = execution_graph.get_vertices().get(vertex_id).unwrap();
+            let operator_id = &vertex.vertex_id.operator_id();
+
             if let Some(existing_node) = operator_to_node.get(operator_id) {
-                assert_eq!(existing_node, &cluster_node.node_id, 
-                    "Operator {} is assigned to multiple nodes: {} and {}", 
+                assert_eq!(existing_node, &cluster_node.node_id,
+                    "Operator {} is assigned to multiple nodes: {} and {}",
                     operator_id, existing_node, cluster_node.node_id);
             } else {
                 operator_to_node.insert(operator_id.clone(), cluster_node.node_id.clone());
@@ -194,9 +197,9 @@ mod tests {
         // Verify that all operator_ids from the execution graph are present
         let expected_operator_ids: std::collections::HashSet<_> = execution_graph.get_vertices()
             .values()
-            .map(|v| v.operator_id.clone())
+            .map(|v| v.vertex_id.operator_id())
             .collect();
         let mapped_operator_ids: std::collections::HashSet<_> = operator_to_node.keys().cloned().collect();
         assert_eq!(expected_operator_ids, mapped_operator_ids);
     }
-} 
+}

--- a/src/common/ids.rs
+++ b/src/common/ids.rs
@@ -331,32 +331,13 @@ mod tests {
     #[test]
     fn op_type_code_roundtrip_covers_all_variants() {
         // Exhaustively iterate via from_u8 across the assigned range.
-        let all = [
-            OperatorTypeCode::Invalid,
-            OperatorTypeCode::SourceVector,
-            OperatorTypeCode::SourceWordCount,
-            OperatorTypeCode::SourceDatagen,
-            OperatorTypeCode::SourceHttpRequest,
-            OperatorTypeCode::SourceKafka,
-            OperatorTypeCode::SourceParquet,
-            OperatorTypeCode::SinkInMemoryStorageGrpc,
-            OperatorTypeCode::SinkRequest,
-            OperatorTypeCode::SinkParquet,
-            OperatorTypeCode::Map,
-            OperatorTypeCode::KeyBy,
-            OperatorTypeCode::Reduce,
-            OperatorTypeCode::Aggregate,
-            OperatorTypeCode::Window,
-            OperatorTypeCode::WindowRequest,
-            OperatorTypeCode::Join,
-            OperatorTypeCode::Chained,
-        ];
-
+        let all: Vec<_> = (0u8..=u8::MAX)
+            .filter_map(OperatorTypeCode::from_u8)
+            .collect();
         for code in all {
             let byte = code.as_u8();
             assert_eq!(OperatorTypeCode::from_u8(byte), Some(code), "code {byte:#x}");
         }
-
         // Unassigned bytes return None.
         assert_eq!(OperatorTypeCode::from_u8(0x12), None);
         assert_eq!(OperatorTypeCode::from_u8(0xFF), None);

--- a/src/common/ids.rs
+++ b/src/common/ids.rs
@@ -9,6 +9,7 @@
 //! - up to 255 instances of the same operator type within one pipeline
 //! - up to 65535 parallel partitions per operator instance
 
+use num_enum::TryFromPrimitive;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -18,33 +19,42 @@ use crate::runtime::operators::source::source_operator::SourceConfig;
 
 /// Stable u8 code per concrete operator variant.
 ///
-/// New codes must be appended (never inserted in the middle, never renumbered)
-/// so existing checkpoints and serialized vertex ids remain interpretable.
+/// Codes are partitioned into ranges so new variants always land in the right
+/// logical group. Never renumber existing codes — serialized vertex ids and
+/// checkpoints depend on stability.
+///
+/// Ranges:
+///   0x00        — Invalid (sentinel)
+///   0x01–0x1F   — Sources
+///   0x20–0x3F   — Sinks
+///   0x40–0xFF   — Operators
 #[repr(u8)]
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize, TryFromPrimitive)]
 pub enum OperatorTypeCode {
     Invalid = 0x00,
 
-    SourceVector = 0x01,
-    SourceWordCount = 0x02,
-    SourceDatagen = 0x03,
+    // Sources: 0x01–0x1F
+    SourceVector      = 0x01,
+    SourceWordCount   = 0x02,
+    SourceDatagen     = 0x03,
     SourceHttpRequest = 0x04,
-    SourceKafka = 0x05,
-    SourceParquet = 0x06,
+    SourceKafka       = 0x05,
+    SourceParquet     = 0x06,
 
-    SinkInMemoryStorageGrpc = 0x07,
-    SinkRequest = 0x08,
-    SinkParquet = 0x09,
+    // Sinks: 0x20–0x3F
+    SinkInMemoryStorageGrpc = 0x20,
+    SinkRequest             = 0x21,
+    SinkParquet             = 0x22,
 
-    Map = 0x0A,
-    KeyBy = 0x0B,
-    Reduce = 0x0C,
-    Aggregate = 0x0D,
-    Window = 0x0E,
-    WindowRequest = 0x0F,
-    Join = 0x10,
-
-    Chained = 0x11,
+    // Operators: 0x40–0xFF
+    Map           = 0x40,
+    KeyBy         = 0x41,
+    Reduce        = 0x42,
+    Aggregate     = 0x43,
+    Window        = 0x44,
+    WindowRequest = 0x45,
+    Join          = 0x46,
+    Chained       = 0x47,
 }
 
 impl OperatorTypeCode {
@@ -53,27 +63,7 @@ impl OperatorTypeCode {
     }
 
     pub fn from_u8(byte: u8) -> Option<Self> {
-        match byte {
-            0x00 => Some(Self::Invalid),
-            0x01 => Some(Self::SourceVector),
-            0x02 => Some(Self::SourceWordCount),
-            0x03 => Some(Self::SourceDatagen),
-            0x04 => Some(Self::SourceHttpRequest),
-            0x05 => Some(Self::SourceKafka),
-            0x06 => Some(Self::SourceParquet),
-            0x07 => Some(Self::SinkInMemoryStorageGrpc),
-            0x08 => Some(Self::SinkRequest),
-            0x09 => Some(Self::SinkParquet),
-            0x0A => Some(Self::Map),
-            0x0B => Some(Self::KeyBy),
-            0x0C => Some(Self::Reduce),
-            0x0D => Some(Self::Aggregate),
-            0x0E => Some(Self::Window),
-            0x0F => Some(Self::WindowRequest),
-            0x10 => Some(Self::Join),
-            0x11 => Some(Self::Chained),
-            _ => None,
-        }
+        Self::try_from(byte).ok()
     }
 
     pub fn short_name(self) -> &'static str {
@@ -349,7 +339,7 @@ mod tests {
         assert_eq!(v.op_type(), OperatorTypeCode::Map);
         assert_eq!(v.instance(), 7);
         assert_eq!(v.task_index(), 42);
-        assert_eq!(v.raw(), 0x0A_07_00_2A);
+        assert_eq!(v.raw(), 0x40_07_00_2A);
     }
 
     #[test]
@@ -395,7 +385,7 @@ mod tests {
         let o = OperatorId::new(OperatorTypeCode::Map, 7);
         assert_eq!(o.op_type(), OperatorTypeCode::Map);
         assert_eq!(o.instance(), 7);
-        assert_eq!(o.raw(), 0x0A_07);
+        assert_eq!(o.raw(), 0x40_07);
     }
 
     #[test]

--- a/src/common/ids.rs
+++ b/src/common/ids.rs
@@ -1,0 +1,459 @@
+//! Numeric identifiers for runtime entities (vertices and channels).
+//!
+//! Replaces string-based ids on the hot path. The layout encodes operator
+//! semantics directly into the id so a `VertexId` is self-describing
+//! (operator type, per-type instance, parallel index) without a side table.
+//!
+//! Architectural limits (enforced by construction):
+//! - up to 255 distinct operator types in the system
+//! - up to 255 instances of the same operator type within one pipeline
+//! - up to 65535 parallel partitions per operator instance
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use crate::runtime::operators::operator::OperatorConfig;
+use crate::runtime::operators::sink::sink_operator::SinkConfig;
+use crate::runtime::operators::source::source_operator::SourceConfig;
+
+/// Stable u8 code per concrete operator variant.
+///
+/// New codes must be appended (never inserted in the middle, never renumbered)
+/// so existing checkpoints and serialized vertex ids remain interpretable.
+#[repr(u8)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
+pub enum OperatorTypeCode {
+    Invalid = 0x00,
+
+    SourceVector = 0x01,
+    SourceWordCount = 0x02,
+    SourceDatagen = 0x03,
+    SourceHttpRequest = 0x04,
+    SourceKafka = 0x05,
+    SourceParquet = 0x06,
+
+    SinkInMemoryStorageGrpc = 0x07,
+    SinkRequest = 0x08,
+    SinkParquet = 0x09,
+
+    Map = 0x0A,
+    KeyBy = 0x0B,
+    Reduce = 0x0C,
+    Aggregate = 0x0D,
+    Window = 0x0E,
+    WindowRequest = 0x0F,
+    Join = 0x10,
+
+    Chained = 0x11,
+}
+
+impl OperatorTypeCode {
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    pub fn from_u8(byte: u8) -> Option<Self> {
+        match byte {
+            0x00 => Some(Self::Invalid),
+            0x01 => Some(Self::SourceVector),
+            0x02 => Some(Self::SourceWordCount),
+            0x03 => Some(Self::SourceDatagen),
+            0x04 => Some(Self::SourceHttpRequest),
+            0x05 => Some(Self::SourceKafka),
+            0x06 => Some(Self::SourceParquet),
+            0x07 => Some(Self::SinkInMemoryStorageGrpc),
+            0x08 => Some(Self::SinkRequest),
+            0x09 => Some(Self::SinkParquet),
+            0x0A => Some(Self::Map),
+            0x0B => Some(Self::KeyBy),
+            0x0C => Some(Self::Reduce),
+            0x0D => Some(Self::Aggregate),
+            0x0E => Some(Self::Window),
+            0x0F => Some(Self::WindowRequest),
+            0x10 => Some(Self::Join),
+            0x11 => Some(Self::Chained),
+            _ => None,
+        }
+    }
+
+    pub fn short_name(self) -> &'static str {
+        match self {
+            Self::Invalid => "Invalid",
+            Self::SourceVector => "SourceVector",
+            Self::SourceWordCount => "SourceWordCount",
+            Self::SourceDatagen => "SourceDatagen",
+            Self::SourceHttpRequest => "SourceHttpRequest",
+            Self::SourceKafka => "SourceKafka",
+            Self::SourceParquet => "SourceParquet",
+            Self::SinkInMemoryStorageGrpc => "SinkInMemoryStorageGrpc",
+            Self::SinkRequest => "SinkRequest",
+            Self::SinkParquet => "SinkParquet",
+            Self::Map => "Map",
+            Self::KeyBy => "KeyBy",
+            Self::Reduce => "Reduce",
+            Self::Aggregate => "Aggregate",
+            Self::Window => "Window",
+            Self::WindowRequest => "WindowRequest",
+            Self::Join => "Join",
+            Self::Chained => "Chained",
+        }
+    }
+}
+
+impl fmt::Display for OperatorTypeCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.short_name())
+    }
+}
+
+impl From<&OperatorConfig> for OperatorTypeCode {
+    fn from(cfg: &OperatorConfig) -> Self {
+        match cfg {
+            OperatorConfig::MapConfig(_) => Self::Map,
+            OperatorConfig::JoinConfig(_) => Self::Join,
+            OperatorConfig::KeyByConfig(_) => Self::KeyBy,
+            OperatorConfig::ReduceConfig(_, _) => Self::Reduce,
+            OperatorConfig::AggregateConfig(_) => Self::Aggregate,
+            OperatorConfig::WindowConfig(_) => Self::Window,
+            OperatorConfig::WindowRequestConfig(_) => Self::WindowRequest,
+            OperatorConfig::ChainedConfig(_) => Self::Chained,
+            OperatorConfig::SourceConfig(src) => match src {
+                SourceConfig::VectorSourceConfig(_) => Self::SourceVector,
+                SourceConfig::WordCountSourceConfig(_) => Self::SourceWordCount,
+                SourceConfig::DatagenSourceConfig(_) => Self::SourceDatagen,
+                SourceConfig::HttpRequestSourceConfig(_) => Self::SourceHttpRequest,
+                SourceConfig::KafkaSourceConfig(_) => Self::SourceKafka,
+                SourceConfig::ParquetSourceConfig(_) => Self::SourceParquet,
+            },
+            OperatorConfig::SinkConfig(snk) => match snk {
+                SinkConfig::InMemoryStorageGrpcSinkConfig(_) => Self::SinkInMemoryStorageGrpc,
+                SinkConfig::RequestSinkConfig => Self::SinkRequest,
+                SinkConfig::ParquetSinkConfig(_) => Self::SinkParquet,
+            },
+        }
+    }
+}
+
+const VERTEX_OP_TYPE_SHIFT: u32 = 24;
+const VERTEX_INSTANCE_SHIFT: u32 = 16;
+const VERTEX_OP_TYPE_MASK: u32 = 0xFF00_0000;
+const VERTEX_INSTANCE_MASK: u32 = 0x00FF_0000;
+const VERTEX_PARALLEL_MASK: u32 = 0x0000_FFFF;
+
+const OPERATOR_OP_TYPE_SHIFT: u16 = 8;
+const OPERATOR_OP_TYPE_MASK: u16 = 0xFF00;
+const OPERATOR_INSTANCE_MASK: u16 = 0x00FF;
+
+/// Logical identifier for an operator instance (one node of the LogicalGraph).
+///
+/// Layout: `[op_type: u8 | instance: u8]`.
+///
+/// Identifies "this operator type + this instance among that type" — the upper
+/// 16 bits of a `VertexId`. All parallel partitions of one operator share the
+/// same `OperatorId`.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
+pub struct OperatorId(u16);
+
+impl OperatorId {
+    pub const INVALID: OperatorId = OperatorId(0);
+
+    pub fn new(op: OperatorTypeCode, instance: u8) -> Self {
+        debug_assert!(
+            op != OperatorTypeCode::Invalid,
+            "OperatorId constructed with Invalid op type"
+        );
+        Self::from_parts(op, instance)
+    }
+
+    pub const fn from_parts(op: OperatorTypeCode, instance: u8) -> Self {
+        let raw = ((op.as_u8() as u16) << OPERATOR_OP_TYPE_SHIFT) | (instance as u16);
+        OperatorId(raw)
+    }
+
+    pub const fn from_raw(raw: u16) -> Self {
+        OperatorId(raw)
+    }
+
+    pub const fn raw(self) -> u16 {
+        self.0
+    }
+
+    pub fn op_type(self) -> OperatorTypeCode {
+        let byte = ((self.0 & OPERATOR_OP_TYPE_MASK) >> OPERATOR_OP_TYPE_SHIFT) as u8;
+        OperatorTypeCode::from_u8(byte).unwrap_or(OperatorTypeCode::Invalid)
+    }
+
+    pub const fn instance(self) -> u8 {
+        (self.0 & OPERATOR_INSTANCE_MASK) as u8
+    }
+
+    pub const fn is_invalid(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl fmt::Display for OperatorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.op_type(), self.instance())
+    }
+}
+
+impl fmt::Debug for OperatorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (0x{:04X})", self, self.0)
+    }
+}
+
+/// Runtime identifier for an execution vertex (one partition of an operator).
+///
+/// Layout: `[op_type: u8 | instance: u8 | parallel: u16]`.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
+pub struct VertexId(u32);
+
+impl VertexId {
+    pub const INVALID: VertexId = VertexId(0);
+
+    pub fn new(op: OperatorTypeCode, instance: u8, parallel: u16) -> Self {
+        debug_assert!(
+            op != OperatorTypeCode::Invalid,
+            "VertexId constructed with Invalid op type"
+        );
+        Self::from_parts(op, instance, parallel)
+    }
+
+    pub const fn from_parts(op: OperatorTypeCode, instance: u8, parallel: u16) -> Self {
+        let raw = ((op.as_u8() as u32) << VERTEX_OP_TYPE_SHIFT)
+            | ((instance as u32) << VERTEX_INSTANCE_SHIFT)
+            | (parallel as u32);
+        VertexId(raw)
+    }
+
+    pub const fn from_raw(raw: u32) -> Self {
+        VertexId(raw)
+    }
+
+    pub const fn raw(self) -> u32 {
+        self.0
+    }
+
+    pub fn op_type(self) -> OperatorTypeCode {
+        let byte = ((self.0 & VERTEX_OP_TYPE_MASK) >> VERTEX_OP_TYPE_SHIFT) as u8;
+        OperatorTypeCode::from_u8(byte).unwrap_or(OperatorTypeCode::Invalid)
+    }
+
+    pub const fn instance(self) -> u8 {
+        ((self.0 & VERTEX_INSTANCE_MASK) >> VERTEX_INSTANCE_SHIFT) as u8
+    }
+
+    pub const fn task_index(self) -> u16 {
+        (self.0 & VERTEX_PARALLEL_MASK) as u16
+    }
+
+    /// Derive the logical `OperatorId` for this vertex (upper 16 bits of the layout).
+    /// All parallel partitions of the same operator instance share this id.
+    pub const fn operator_id(self) -> OperatorId {
+        OperatorId::from_raw((self.0 >> VERTEX_INSTANCE_SHIFT) as u16)
+    }
+
+    pub const fn is_invalid(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl fmt::Display for VertexId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}.{}#{}",
+            self.op_type(),
+            self.instance(),
+            self.task_index()
+        )
+    }
+}
+
+impl fmt::Debug for VertexId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (0x{:08X})", self, self.0)
+    }
+}
+
+const CHANNEL_SOURCE_SHIFT: u64 = 32;
+const CHANNEL_TARGET_MASK: u64 = 0x0000_0000_FFFF_FFFF;
+
+/// Runtime identifier for a directed channel between two vertices.
+///
+/// Layout: `[source: VertexId | target: VertexId]`.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default, Serialize, Deserialize)]
+pub struct ChannelId(u64);
+
+impl ChannelId {
+    pub const INVALID: ChannelId = ChannelId(0);
+
+    pub const fn new(source: VertexId, target: VertexId) -> Self {
+        let raw = ((source.raw() as u64) << CHANNEL_SOURCE_SHIFT) | (target.raw() as u64);
+        ChannelId(raw)
+    }
+
+    pub const fn from_raw(raw: u64) -> Self {
+        ChannelId(raw)
+    }
+
+    pub const fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub const fn source(self) -> VertexId {
+        VertexId::from_raw((self.0 >> CHANNEL_SOURCE_SHIFT) as u32)
+    }
+
+    pub const fn target(self) -> VertexId {
+        VertexId::from_raw((self.0 & CHANNEL_TARGET_MASK) as u32)
+    }
+}
+
+impl fmt::Display for ChannelId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}->{}", self.source(), self.target())
+    }
+}
+
+impl fmt::Debug for ChannelId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} (0x{:016X})", self, self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn op_type_code_roundtrip_covers_all_variants() {
+        // Exhaustively iterate via from_u8 across the assigned range.
+        let all = [
+            OperatorTypeCode::Invalid,
+            OperatorTypeCode::SourceVector,
+            OperatorTypeCode::SourceWordCount,
+            OperatorTypeCode::SourceDatagen,
+            OperatorTypeCode::SourceHttpRequest,
+            OperatorTypeCode::SourceKafka,
+            OperatorTypeCode::SourceParquet,
+            OperatorTypeCode::SinkInMemoryStorageGrpc,
+            OperatorTypeCode::SinkRequest,
+            OperatorTypeCode::SinkParquet,
+            OperatorTypeCode::Map,
+            OperatorTypeCode::KeyBy,
+            OperatorTypeCode::Reduce,
+            OperatorTypeCode::Aggregate,
+            OperatorTypeCode::Window,
+            OperatorTypeCode::WindowRequest,
+            OperatorTypeCode::Join,
+            OperatorTypeCode::Chained,
+        ];
+
+        for code in all {
+            let byte = code.as_u8();
+            assert_eq!(OperatorTypeCode::from_u8(byte), Some(code), "code {byte:#x}");
+        }
+
+        // Unassigned bytes return None.
+        assert_eq!(OperatorTypeCode::from_u8(0x12), None);
+        assert_eq!(OperatorTypeCode::from_u8(0xFF), None);
+    }
+
+    #[test]
+    fn vertex_id_layout_packs_and_unpacks() {
+        let v = VertexId::new(OperatorTypeCode::Map, 7, 42);
+        assert_eq!(v.op_type(), OperatorTypeCode::Map);
+        assert_eq!(v.instance(), 7);
+        assert_eq!(v.task_index(), 42);
+        assert_eq!(v.raw(), 0x0A_07_00_2A);
+    }
+
+    #[test]
+    fn vertex_id_max_values() {
+        let v = VertexId::new(OperatorTypeCode::Join, u8::MAX, u16::MAX);
+        assert_eq!(v.op_type(), OperatorTypeCode::Join);
+        assert_eq!(v.instance(), u8::MAX);
+        assert_eq!(v.task_index(), u16::MAX);
+    }
+
+    #[test]
+    fn vertex_id_invalid_default() {
+        assert!(VertexId::default().is_invalid());
+        assert_eq!(VertexId::default().op_type(), OperatorTypeCode::Invalid);
+    }
+
+    #[test]
+    fn vertex_id_display() {
+        let v = VertexId::new(OperatorTypeCode::SourceKafka, 1, 0);
+        assert_eq!(format!("{}", v), "SourceKafka.1#0");
+        assert_eq!(format!("{:?}", v), "SourceKafka.1#0 (0x05010000)");
+    }
+
+    #[test]
+    fn channel_id_layout_packs_and_unpacks() {
+        let src = VertexId::new(OperatorTypeCode::SourceKafka, 1, 0);
+        let tgt = VertexId::new(OperatorTypeCode::Map, 2, 7);
+        let c = ChannelId::new(src, tgt);
+        assert_eq!(c.source(), src);
+        assert_eq!(c.target(), tgt);
+    }
+
+    #[test]
+    fn channel_id_display() {
+        let src = VertexId::new(OperatorTypeCode::SourceKafka, 1, 0);
+        let tgt = VertexId::new(OperatorTypeCode::Map, 2, 7);
+        let c = ChannelId::new(src, tgt);
+        assert_eq!(format!("{}", c), "SourceKafka.1#0->Map.2#7");
+    }
+
+    #[test]
+    fn operator_id_layout_packs_and_unpacks() {
+        let o = OperatorId::new(OperatorTypeCode::Map, 7);
+        assert_eq!(o.op_type(), OperatorTypeCode::Map);
+        assert_eq!(o.instance(), 7);
+        assert_eq!(o.raw(), 0x0A_07);
+    }
+
+    #[test]
+    fn operator_id_max_values() {
+        let o = OperatorId::new(OperatorTypeCode::Join, u8::MAX);
+        assert_eq!(o.op_type(), OperatorTypeCode::Join);
+        assert_eq!(o.instance(), u8::MAX);
+    }
+
+    #[test]
+    fn operator_id_invalid_default() {
+        assert!(OperatorId::default().is_invalid());
+        assert_eq!(OperatorId::default().op_type(), OperatorTypeCode::Invalid);
+    }
+
+    #[test]
+    fn operator_id_display() {
+        let o = OperatorId::new(OperatorTypeCode::SourceKafka, 1);
+        assert_eq!(format!("{}", o), "SourceKafka.1");
+        assert_eq!(format!("{:?}", o), "SourceKafka.1 (0x0501)");
+    }
+
+    #[test]
+    fn vertex_id_derives_operator_id() {
+        // All parallel partitions of the same operator instance share the OperatorId.
+        let v0 = VertexId::new(OperatorTypeCode::Window, 3, 0);
+        let v1 = VertexId::new(OperatorTypeCode::Window, 3, 42);
+        let v2 = VertexId::new(OperatorTypeCode::Window, 3, u16::MAX);
+        let op = OperatorId::new(OperatorTypeCode::Window, 3);
+        assert_eq!(v0.operator_id(), op);
+        assert_eq!(v1.operator_id(), op);
+        assert_eq!(v2.operator_id(), op);
+
+        // Different instances of the same op type produce different OperatorIds.
+        let other = VertexId::new(OperatorTypeCode::Window, 4, 0);
+        assert_ne!(other.operator_id(), op);
+
+        // Different op types with the same instance number also differ.
+        let same_instance_diff_type = VertexId::new(OperatorTypeCode::Map, 3, 0);
+        assert_ne!(same_instance_diff_type.operator_id(), op);
+    }
+}

--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -4,6 +4,7 @@ use serde::{Serialize, Deserialize};
 use std::io::{Cursor, Read, Write};
 use std::collections::HashMap;
 
+use super::ids::VertexId;
 use super::Key;
 
 #[derive(Debug, Clone)]
@@ -13,7 +14,7 @@ pub struct BaseMessage {
 }
 
 impl BaseMessage {
-    pub fn new(upstream_vertex_id: Option<String>, record_batch: RecordBatch, ingest_timestamp: Option<u64>, extras: Option<HashMap<String, String>>) -> Self {
+    pub fn new(upstream_vertex_id: Option<VertexId>, record_batch: RecordBatch, ingest_timestamp: Option<u64>, extras: Option<HashMap<String, String>>) -> Self {
         Self {
             record_batch,
             metadata: MessageMetadata { upstream_vertex_id, ingest_timestamp, extras }
@@ -24,7 +25,7 @@ impl BaseMessage {
         self.metadata.ingest_timestamp = Some(ingest_timestamp);
     }
 
-    pub fn set_upstream_vertex_id(&mut self, upstream_vertex_id: String) {
+    pub fn set_upstream_vertex_id(&mut self, upstream_vertex_id: VertexId) {
         self.metadata.upstream_vertex_id = Some(upstream_vertex_id);
     }
 
@@ -98,19 +99,16 @@ impl BaseMessage {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageMetadata {
-    pub upstream_vertex_id: Option<String>,
+    pub upstream_vertex_id: Option<VertexId>,
     pub ingest_timestamp: Option<u64>,
     pub extras: Option<HashMap<String, String>>,
 }
 
 impl MessageMetadata {
     pub fn get_memory_size(&self) -> usize {
-        // Option<u64> = 8 bytes, Option<String> = 24 bytes + string length
+        // VertexId is u32 -> Option<VertexId> = 8 bytes (with niche).
         let mut len = 0;
-        if let Some(ref vertex_id) = self.upstream_vertex_id {
-            len += vertex_id.len();
-        }
-        
+
         // Add memory for extras HashMap
         if let Some(ref extras) = self.extras {
             len += 24; // HashMap overhead
@@ -118,8 +116,8 @@ impl MessageMetadata {
                 len += key.len() + value.len() + 48; // String overhead for each entry
             }
         }
-        
-        8 + 24 + 24 + len // u64 + Option<String> + Option<HashMap> + content
+
+        8 + 8 + 24 + len // ingest_timestamp + upstream_vertex_id + Option<HashMap> + content
     }
 }
 
@@ -199,7 +197,7 @@ pub struct WatermarkMessage {
 }
 
 impl WatermarkMessage {
-    pub fn new(upstream_vertex_id: String, watermark_value: u64, ingest_timestamp: Option<u64>) -> Self {
+    pub fn new(upstream_vertex_id: VertexId, watermark_value: u64, ingest_timestamp: Option<u64>) -> Self {
         Self {
             watermark_value,
             metadata: MessageMetadata {
@@ -214,7 +212,7 @@ impl WatermarkMessage {
         self.metadata.ingest_timestamp = Some(ingest_timestamp);
     }
 
-    pub fn set_upstream_vertex_id(&mut self, upstream_vertex_id: String) {
+    pub fn set_upstream_vertex_id(&mut self, upstream_vertex_id: VertexId) {
         self.metadata.upstream_vertex_id = Some(upstream_vertex_id);
     }
 
@@ -242,7 +240,7 @@ pub struct CheckpointBarrierMessage {
 }
 
 impl CheckpointBarrierMessage {
-    pub fn new(upstream_vertex_id: String, checkpoint_id: u64, ingest_timestamp: Option<u64>) -> Self {
+    pub fn new(upstream_vertex_id: VertexId, checkpoint_id: u64, ingest_timestamp: Option<u64>) -> Self {
         Self {
             checkpoint_id,
             metadata: MessageMetadata {
@@ -257,7 +255,7 @@ impl CheckpointBarrierMessage {
         self.metadata.ingest_timestamp = Some(ingest_timestamp);
     }
 
-    pub fn set_upstream_vertex_id(&mut self, upstream_vertex_id: String) {
+    pub fn set_upstream_vertex_id(&mut self, upstream_vertex_id: VertexId) {
         self.metadata.upstream_vertex_id = Some(upstream_vertex_id);
     }
 
@@ -284,23 +282,23 @@ pub enum Message {
 
 impl Message {
 
-    pub fn new(upstream_vertex_id: Option<String>, record_batch: RecordBatch, ingest_timestamp: Option<u64>, extras: Option<HashMap<String, String>>) -> Self {
+    pub fn new(upstream_vertex_id: Option<VertexId>, record_batch: RecordBatch, ingest_timestamp: Option<u64>, extras: Option<HashMap<String, String>>) -> Self {
         Message::Regular(BaseMessage::new(upstream_vertex_id, record_batch, ingest_timestamp, extras))
     }
 
-    pub fn new_keyed(upstream_vertex_id: Option<String>, record_batch: RecordBatch, key: Key, ingest_timestamp: Option<u64>, extras: Option<HashMap<String, String>>) -> Self {
+    pub fn new_keyed(upstream_vertex_id: Option<VertexId>, record_batch: RecordBatch, key: Key, ingest_timestamp: Option<u64>, extras: Option<HashMap<String, String>>) -> Self {
         Message::Keyed(KeyedMessage::new(
             BaseMessage::new(upstream_vertex_id, record_batch, ingest_timestamp, extras),
             key,
         ))
     }
 
-    pub fn upstream_vertex_id(&self) -> Option<String> {
+    pub fn upstream_vertex_id(&self) -> Option<VertexId> {
         match self {
-            Message::Regular(message) => message.metadata.upstream_vertex_id.clone(),
-            Message::Keyed(message) => message.base.metadata.upstream_vertex_id.clone(),
-            Message::Watermark(message) => message.metadata.upstream_vertex_id.clone(),
-            Message::CheckpointBarrier(message) => message.metadata.upstream_vertex_id.clone(),
+            Message::Regular(message) => message.metadata.upstream_vertex_id,
+            Message::Keyed(message) => message.base.metadata.upstream_vertex_id,
+            Message::Watermark(message) => message.metadata.upstream_vertex_id,
+            Message::CheckpointBarrier(message) => message.metadata.upstream_vertex_id,
         }
     }
 
@@ -341,7 +339,7 @@ impl Message {
         }
     }
 
-    pub fn set_upstream_vertex_id(&mut self, upstream_vertex_id: String) {
+    pub fn set_upstream_vertex_id(&mut self, upstream_vertex_id: VertexId) {
         match self {
             Message::Regular(message) => message.set_upstream_vertex_id(upstream_vertex_id),
             Message::Keyed(message) => message.base.set_upstream_vertex_id(upstream_vertex_id),
@@ -361,7 +359,7 @@ impl Message {
         metadata.extras.clone()
     }
 
-    pub fn append_trace(&mut self, vertex_id: &str) {
+    pub fn append_trace(&mut self, vertex_id: VertexId) {
         let extras = match self {
             Message::Regular(m) => m.metadata.extras.get_or_insert_with(HashMap::new),
             Message::Keyed(m) => m.base.metadata.extras.get_or_insert_with(HashMap::new),
@@ -374,7 +372,7 @@ impl Message {
             *entry = vertex_id.to_string();
         } else {
             entry.push(',');
-            entry.push_str(vertex_id);
+            entry.push_str(vertex_id.to_string().as_str());
         }
     }
 
@@ -504,7 +502,7 @@ mod tests {
 
         // Create a regular message
         let original_message = Message::new(
-            Some("upstream_vertex".to_string()),
+            Some(VertexId::new(crate::common::ids::OperatorTypeCode::Map, 1, 0)),
             record_batch,
             Some(1234567890),
             None
@@ -554,7 +552,7 @@ mod tests {
 
         // Create a keyed message
         let original_message = Message::new_keyed(
-            Some("upstream_vertex".to_string()),
+            Some(VertexId::new(crate::common::ids::OperatorTypeCode::Map, 1, 0)),
             record_batch,
             key.clone(),
             Some(1234567890),
@@ -585,7 +583,7 @@ mod tests {
     fn test_watermark_message_serialization() {
         // Create a watermark message
         let mut original_message = Message::Watermark(WatermarkMessage::new(
-            "source_vertex".to_string(),
+            VertexId::new(crate::common::ids::OperatorTypeCode::SourceVector, 1, 0),
             9876543210,
             None
         ));

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,6 +1,8 @@
+pub mod ids;
 pub mod message;
 pub mod test_utils;
 pub mod key;
 
 pub use message::*;
 pub use key::Key;
+pub use ids::{ChannelId, OperatorId, OperatorTypeCode, VertexId};

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -9,7 +9,7 @@ use std::sync::Mutex;
 use lazy_static::lazy_static;
 use async_trait::async_trait;
 
-use crate::common::Message;
+use crate::common::{Message, OperatorId, VertexId};
 use crate::runtime::functions::map::MapFunctionTrait;
 use crate::runtime::observability::PipelineSnapshot;
 use crate::runtime::metrics::{PipelineStateHistory, ThroughputRates};
@@ -45,7 +45,7 @@ pub fn gen_unique_grpc_port() -> u16 {
 
 pub fn print_pipeline_state(
     pipeline_state: &PipelineSnapshot,
-    operator_ids: Option<&[String]>,
+    operator_ids: Option<&[OperatorId]>,
     tasks_only: bool,
     operators_only: bool,
     history: Option<&PipelineStateHistory>,
@@ -54,7 +54,7 @@ pub fn print_pipeline_state(
     println!("\n=== Pipeline State ===");
     
     // Calculate throughput rates if history is provided
-    let throughput_rates: Option<HashMap<String, ThroughputRates>> = if let (Some(hist), Some(window_secs)) = (history, throughput_window_seconds) {
+    let throughput_rates: Option<HashMap<VertexId, ThroughputRates>> = if let (Some(hist), Some(window_secs)) = (history, throughput_window_seconds) {
         if !hist.samples.is_empty() {
             Some(hist.calculate_throughput_rates(window_secs))
         } else {
@@ -65,29 +65,31 @@ pub fn print_pipeline_state(
     };
     
     // Helper function to check if an operator_id should be included
-    let should_include_operator = |operator_id: &str| -> bool {
-        operator_ids.map_or(true, |ids| ids.contains(&operator_id.to_string()))
+    let should_include_operator = |operator_id: OperatorId| -> bool {
+        operator_ids.map_or(true, |ids| ids.contains(&operator_id))
     };
     
-    // Helper function to check if a vertex_id (task) should be included
-    // Vertex IDs are typically formatted as "operator_id_parallel_index"
-    let should_include_task = |vertex_id: &str| -> bool {
+    // Helper function to check if a vertex_id (task) should be included.
+    // The Display form encodes operator_type and instance, so substring match
+    // against operator_id (e.g. "Map_3") still works.
+    let should_include_task = |vertex_label: VertexId| -> bool {
         if let Some(operator_ids) = operator_ids {
-            operator_ids.iter().any(|op_id| vertex_id.starts_with(op_id))
+            operator_ids.iter().any(|op_id| vertex_label.operator_id() == *op_id)
         } else {
             true
         }
     };
-    
+
     for (worker_id, worker_state) in &pipeline_state.worker_states {
         println!("\n--- Worker: {} ---", worker_id);
-        
+
         if !operators_only {
             println!("Task Statuses:");
             let mut has_task_statuses = false;
             for (vertex_id, status) in &worker_state.task_statuses {
-                if should_include_task(vertex_id) {
-                    println!("  {}: {:?}", vertex_id, status);
+                let label = vertex_id;
+                if should_include_task(vertex_id.clone()) {
+                    println!("  {}: {:?}", label, status);
                     has_task_statuses = true;
                 }
             }
@@ -101,7 +103,7 @@ pub fn print_pipeline_state(
             println!("\nOperator Metrics:");
             let mut has_operator_metrics = false;
             for (operator_id, operator_metrics) in &worker_metrics.operator_metrics {
-                if should_include_operator(operator_id) {
+                if should_include_operator(operator_id.clone()) {
                     println!("  Operator: {}", operator_id);
                     println!("    Throughput:");
                     println!("      Messages Sent: {} (total)", operator_metrics.throughput_metrics.messages_sent);
@@ -127,7 +129,7 @@ pub fn print_pipeline_state(
             println!("\nTask Metrics:");
             let mut has_task_metrics = false;
             for (vertex_id, task_metrics) in &worker_metrics.tasks_metrics {
-                if should_include_task(vertex_id) {
+                if should_include_task(vertex_id.clone()) {
                     println!("  Task: {}", vertex_id);
                     println!("    Throughput:");
                     println!("      Messages Sent: {} (total)", task_metrics.throughput_stast.messages_sent);

--- a/src/control_plane/types.rs
+++ b/src/control_plane/types.rs
@@ -20,10 +20,6 @@ pub struct WorkerId(pub String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct OperatorId(pub String);
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
 pub struct TaskId(pub String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/executor/local_runtime_adapter.rs
+++ b/src/executor/local_runtime_adapter.rs
@@ -47,8 +47,7 @@ impl RuntimeAdapter for LocalRuntimeAdapter {
             .values()
             .filter(|v| operator_config_requires_checkpoint(&v.operator_config))
             .map(|v| TaskKey {
-                vertex_id: v.vertex_id.as_ref().to_string(),
-                task_index: v.task_index,
+                vertex_id: v.vertex_id
             })
             .collect::<Vec<_>>();
         master_server.set_checkpointable_tasks(expected_tasks).await;
@@ -69,7 +68,7 @@ impl RuntimeAdapter for LocalRuntimeAdapter {
             // - if any edge touching this worker's vertices is remote, use gRPC transport backend
             // - otherwise, prefer in-memory transport backend (single-node / single-worker fast path)
             let has_remote_channels = vertex_ids.iter().any(|vertex_id| {
-                if let Some((in_edges, out_edges)) = req.execution_graph.get_edges_for_vertex(vertex_id) {
+                if let Some((in_edges, out_edges)) = req.execution_graph.get_edges_for_vertex(*vertex_id) {
                     in_edges
                         .iter()
                         .chain(out_edges.iter())
@@ -88,10 +87,7 @@ impl RuntimeAdapter for LocalRuntimeAdapter {
                 node_id.clone(),
                 req.execution_ids.clone(),
                 req.execution_graph.clone(),
-                vertex_ids
-                    .into_iter()
-                    .map(|v| std::sync::Arc::<str>::from(v))
-                    .collect(),
+                vertex_ids,
                 1,
                 transport_backend_type,
             )

--- a/src/executor/runtime_adapter.rs
+++ b/src/executor/runtime_adapter.rs
@@ -9,6 +9,7 @@ use crate::runtime::execution_graph::ExecutionGraph;
 use crate::runtime::observability::PipelineSnapshot;
 use crate::api::WorkerRuntimeSpec;
 use crate::api::StorageSpec;
+use crate::common::OperatorId;
 
 #[derive(Clone)]
 pub struct StartAttemptRequest {
@@ -17,7 +18,7 @@ pub struct StartAttemptRequest {
     pub num_workers_per_operator: usize,
     pub cluster_provider: std::sync::Arc<dyn ClusterProvider>,
     pub node_assign: std::sync::Arc<dyn NodeAssignStrategy>,
-    pub transport_overrides_queue_records: std::collections::HashMap<String, u32>,
+    pub transport_overrides_queue_records: std::collections::HashMap<OperatorId, u32>,
     pub worker_runtime: WorkerRuntimeSpec,
     pub operator_type_storage_overrides: std::collections::HashMap<String, StorageSpec>,
 }

--- a/src/runtime/collector.rs
+++ b/src/runtime/collector.rs
@@ -6,6 +6,7 @@ use crate::runtime::partition::Partition;
 use crate::runtime::partition::PartitionTrait;
 use futures::future::join_all;
 use tokio::sync::mpsc;
+use crate::common::OperatorId;
 
 // Routes messages to multiple channels based on the partition strategy
 #[derive(Clone)]
@@ -86,10 +87,10 @@ impl Collector {
     }
 
     pub async fn write_message_to_operators(
-        collectors: &mut HashMap<String, Collector>,
+        collectors: &mut HashMap<OperatorId, Collector>,
         message: &Message,
-        channels_per_operator: HashMap<String, Vec<Channel>>
-    ) -> HashMap<String, HashMap<Channel, (bool, u32)>> {
+        channels_per_operator: HashMap<OperatorId, Vec<Channel>>
+    ) -> HashMap<OperatorId, HashMap<Channel, (bool, u32)>> {
         let mut futures = Vec::new();
         for (operator_id, collector) in collectors.iter_mut() {
             let operator_id = operator_id.clone();

--- a/src/runtime/execution_graph.rs
+++ b/src/runtime/execution_graph.rs
@@ -1,37 +1,30 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 use crate::cluster::node_assignment::ExecutionVertexNodeMapping;
+use crate::common::ids::{ChannelId, VertexId};
+use crate::common::OperatorId;
 use crate::runtime::operators::operator::{get_operator_type_from_config, OperatorConfig};
 use crate::runtime::partition::PartitionType;
 use crate::transport::channel::Channel;
 use crate::transport::transport_spec::TransportSpec;
 use crate::runtime::operators::operator::OperatorType;
-use crate::runtime::VertexId;
 use crate::runtime::watermark::WatermarkAssignConfig;
 
 #[derive(Debug, Clone)]
 pub struct ExecutionEdge {
-    pub source_vertex_id: VertexId,
-    pub target_vertex_id: VertexId,
-    pub edge_id: String,
-    pub target_operator_id: String,
+    pub edge_id: ChannelId,
     pub partition_type: PartitionType,
     pub channel: Option<Channel>,
 }
- 
+
 impl ExecutionEdge {
     pub fn new(
-        source_vertex_id: String,
-        target_vertex_id: String,
-        target_operator_id: String,
+        source_vertex_id: VertexId,
+        target_vertex_id: VertexId,
         partition_type: PartitionType,
         channel: Option<Channel>,
     ) -> Self {
         Self {
-            source_vertex_id: Arc::<str>::from(source_vertex_id.as_str()),
-            target_vertex_id: Arc::<str>::from(target_vertex_id.as_str()),
-            edge_id: gen_edge_id(&source_vertex_id, &target_vertex_id),
-            target_operator_id: target_operator_id.clone(),
+            edge_id: ChannelId::new(source_vertex_id, target_vertex_id),
             partition_type,
             channel,
         }
@@ -42,47 +35,37 @@ impl ExecutionEdge {
     }
 }
 
-pub fn gen_edge_id(source_vertex_id: &str, target_vertex_id: &str) -> String {
-    format!("{}-{}", source_vertex_id, target_vertex_id)
-}
-
 #[derive(Debug, Clone)]
 pub struct ExecutionVertex {
     pub vertex_id: VertexId,
-    pub operator_id: String,
     pub operator_config: OperatorConfig,
-    pub input_edges: Vec<String>,
-    pub output_edges: Vec<String>,
+    pub input_edges: Vec<ChannelId>,
+    pub output_edges: Vec<ChannelId>,
     pub parallelism: i32,
-    pub task_index: i32,
     pub watermark_assign: Option<WatermarkAssignConfig>,
 }
 
 impl ExecutionVertex {
     pub fn new(
-        vertex_id: String,
-        operator_id: String,
+        vertex_id: VertexId,
         operator_config: OperatorConfig,
         parallelism: i32,
-        task_index: i32,
     ) -> Self {
         Self {
-            vertex_id: Arc::<str>::from(vertex_id),
-            operator_id,
+            vertex_id,
             operator_config,
             input_edges: Vec::new(),
             output_edges: Vec::new(),
             parallelism,
-            task_index,
             watermark_assign: None,
         }
     }
 
-    pub fn add_input_edge(&mut self, edge_id: String) {
+    pub fn add_input_edge(&mut self, edge_id: ChannelId) {
         self.input_edges.push(edge_id);
     }
 
-    pub fn add_output_edge(&mut self, edge_id: String) {
+    pub fn add_output_edge(&mut self, edge_id: ChannelId) {
         self.output_edges.push(edge_id);
     }
 }
@@ -90,7 +73,7 @@ impl ExecutionVertex {
 #[derive(Debug, Clone)]
 pub struct ExecutionGraph {
     vertices: HashMap<VertexId, ExecutionVertex>,
-    edges: HashMap<String, ExecutionEdge>,
+    edges: HashMap<ChannelId, ExecutionEdge>,
     // Optional pipeline execution mode. Used for runtime invariants (e.g. disabling watermark assigners in Batch).
     execution_mode: Option<String>,
 }
@@ -113,13 +96,13 @@ impl ExecutionGraph {
     }
 
     pub fn add_vertex(&mut self, vertex: ExecutionVertex) {
-        self.vertices.insert(vertex.vertex_id.clone(), vertex);
+        self.vertices.insert(vertex.vertex_id, vertex);
     }
 
     pub fn add_edge(&mut self, edge: ExecutionEdge) {
-        let source_id = edge.source_vertex_id.clone();
-        let target_id = edge.target_vertex_id.clone();
-        let edge_id = edge.edge_id.clone();
+        let source_id = edge.edge_id.source();
+        let target_id = edge.edge_id.target();
+        let edge_id = edge.edge_id;
 
         // Verify both vertices exist
         if !self.vertices.contains_key(&source_id) {
@@ -130,50 +113,50 @@ impl ExecutionGraph {
         }
 
         // Add edge to the graph
-        self.edges.insert(edge_id.clone(), edge);
+        self.edges.insert(edge_id, edge);
 
         // Update vertex connections
         if let Some(source_vertex) = self.vertices.get_mut(&source_id) {
-            source_vertex.add_output_edge(edge_id.clone());
+            source_vertex.add_output_edge(edge_id);
         }
         if let Some(target_vertex) = self.vertices.get_mut(&target_id) {
             target_vertex.add_input_edge(edge_id);
         }
     }
 
-    pub fn get_vertex(&self, vertex_id: &str) -> Option<&ExecutionVertex> {
-        self.vertices.get(vertex_id)
+    pub fn get_vertex(&self, vertex_id: VertexId) -> Option<&ExecutionVertex> {
+        self.vertices.get(&vertex_id)
     }
 
-    pub fn get_vertex_mut(&mut self, vertex_id: &str) -> Option<&mut ExecutionVertex> {
-        self.vertices.get_mut(vertex_id)
+    pub fn get_vertex_mut(&mut self, vertex_id: VertexId) -> Option<&mut ExecutionVertex> {
+        self.vertices.get_mut(&vertex_id)
     }
 
-    pub fn get_edge(&self, edge_id: &str) -> Option<&ExecutionEdge> {
-        self.edges.get(edge_id)
+    pub fn get_edge(&self, edge_id: ChannelId) -> Option<&ExecutionEdge> {
+        self.edges.get(&edge_id)
     }
 
     pub fn get_vertices(&self) -> &HashMap<VertexId, ExecutionVertex> {
         &self.vertices
     }
 
-    pub fn get_edges(&self) -> &HashMap<String, ExecutionEdge> {
+    pub fn get_edges(&self) -> &HashMap<ChannelId, ExecutionEdge> {
         &self.edges
     }
 
-    pub fn get_edges_for_vertex(&self, vertex_id: &str) -> Option<(Vec<&ExecutionEdge>, Vec<&ExecutionEdge>)> {
-        let vertex = self.vertices.get(vertex_id)?;
-        
+    pub fn get_edges_for_vertex(&self, vertex_id: VertexId) -> Option<(Vec<&ExecutionEdge>, Vec<&ExecutionEdge>)> {
+        let vertex = self.vertices.get(&vertex_id)?;
+
         let input_edges: Vec<&ExecutionEdge> = vertex.input_edges
             .iter()
             .map(|edge_id| self.edges.get(edge_id).expect("Edge should exist"))
             .collect();
-            
+
         let output_edges: Vec<&ExecutionEdge> = vertex.output_edges
             .iter()
             .map(|edge_id| self.edges.get(edge_id).expect("Edge should exist"))
             .collect();
-            
+
         Some((input_edges, output_edges))
     }
 
@@ -184,16 +167,16 @@ impl ExecutionGraph {
             .collect()
     }
 
-    pub fn get_vertex_type(&self, vertex_id: &str) -> OperatorType {
-        let vertex = self.vertices.get(vertex_id).expect("vertex should exist");
+    pub fn get_vertex_type(&self, vertex_id: VertexId) -> OperatorType {
+        let vertex = self.vertices.get(&vertex_id).expect("vertex should exist");
         get_operator_type_from_config(&vertex.operator_config)
     }
 
-    pub fn get_sink_vertices(&self) -> Vec<String> {
+    pub fn get_sink_vertices(&self) -> Vec<VertexId> {
         self.vertices.iter()
             .filter_map(|(id, vertex)| {
                 match &vertex.operator_config {
-                    OperatorConfig::SinkConfig(_) => Some(id.as_ref().to_string()),
+                    OperatorConfig::SinkConfig(_) => Some(*id),
                     _ => None,
                 }
             })
@@ -202,7 +185,7 @@ impl ExecutionGraph {
 
     // TODO we should add topology verification for request mode (window+window_request and reques source+sink tasks on same nodes)
 
-    // TODO we should separate execution graph and channel configurations - 
+    // TODO we should separate execution graph and channel configurations -
     // execution graph should be static and compiled by planner,
     // channel mapping depends on cluster configuration and is defined at runtime
     pub fn update_channels_with_node_mapping(
@@ -220,21 +203,11 @@ impl ExecutionGraph {
         &mut self,
         execution_vertex_to_cluster_node: Option<&ExecutionVertexNodeMapping>,
         transport: &TransportSpec,
-        per_operator_queue_records: &HashMap<String, u32>,
+        per_operator_queue_records: &HashMap<OperatorId, u32>,
     ) {
         for edge in self.edges.values_mut() {
-            let source_operator_id = self
-                .vertices
-                .get(&edge.source_vertex_id)
-                .expect("source vertex should exist")
-                .operator_id
-                .clone();
-            let target_operator_id = self
-                .vertices
-                .get(&edge.target_vertex_id)
-                .expect("target vertex should exist")
-                .operator_id
-                .clone();
+            let source_operator_id = edge.edge_id.source().operator_id();
+            let target_operator_id = edge.edge_id.target().operator_id();
             let mut queue_size_records = transport.default_queue_records.max(1);
             if let Some(v) = per_operator_queue_records.get(&source_operator_id) {
                 queue_size_records = queue_size_records.max((*v).max(1));
@@ -246,37 +219,37 @@ impl ExecutionGraph {
             let channel = if let Some(vertex_to_node) = execution_vertex_to_cluster_node {
                 // Check if vertices are on different nodes
                 let source_node = vertex_to_node
-                    .get(edge.source_vertex_id.as_ref())
-                    .expect(&format!("Node with id {} expected", edge.source_vertex_id));
+                    .get(&edge.edge_id.source())
+                    .expect(&format!("Node with id {} expected", edge.edge_id.source()));
                 let target_node = vertex_to_node
-                    .get(edge.target_vertex_id.as_ref())
-                    .expect(&format!("Node with id {} expected", edge.target_vertex_id));
-                
+                    .get(&edge.edge_id.target())
+                    .expect(&format!("Node with id {} expected", edge.edge_id.target()));
+
                 if source_node.node_id != target_node.node_id {
                     // Vertices are on different nodes, create remote channel
                     Channel::new_remote_with_queue(
-                        edge.source_vertex_id.as_ref().to_string(),
-                        edge.target_vertex_id.as_ref().to_string(),
-                        source_node.node_ip.clone(), 
-                        source_node.node_id.clone(), 
-                        target_node.node_ip.clone(), 
-                        target_node.node_id.clone(), 
+                        edge.edge_id.source(),
+                        edge.edge_id.target(),
+                        source_node.node_ip.clone(),
+                        source_node.node_id.clone(),
+                        target_node.node_ip.clone(),
+                        target_node.node_id.clone(),
                         target_node.node_port as i32,
                         queue_size_records,
                     )
                 } else {
                     // Vertices are on same node, use local channel
                     Channel::new_local_with_queue(
-                        edge.source_vertex_id.as_ref().to_string(),
-                        edge.target_vertex_id.as_ref().to_string(),
+                        edge.edge_id.source(),
+                        edge.edge_id.target(),
                         queue_size_records,
                     )
                 }
             } else {
                 // No cluster mapping provided, use local channels
                 Channel::new_local_with_queue(
-                    edge.source_vertex_id.as_ref().to_string(),
-                    edge.target_vertex_id.as_ref().to_string(),
+                    edge.edge_id.source(),
+                    edge.edge_id.target(),
                     queue_size_records,
                 )
             };

--- a/src/runtime/functions/reduce/reduce_function.rs
+++ b/src/runtime/functions/reduce/reduce_function.rs
@@ -12,6 +12,7 @@ use arrow::record_batch::RecordBatch;
 use crate::runtime::runtime_context::RuntimeContext;
 use crate::runtime::functions::function_trait::FunctionTrait;
 use std::any::Any;
+use crate::runtime::VertexId;
 
 #[derive(Debug, Clone)]
 pub struct Accumulator {
@@ -68,7 +69,7 @@ pub trait ReduceFunctionTrait: Send + Sync + fmt::Debug {
 
 /// Trait for extracting final results from aggregated data
 pub trait AggregationResultExtractorTrait: Send + Sync + fmt::Debug {
-    fn extract_result(&self, key: &Key, result: &AggregationResult, upstream_vertex_id: Option<String>, ingest_timestamp: Option<u64>) -> Message;
+    fn extract_result(&self, key: &Key, result: &AggregationResult, upstream_vertex_id: Option<VertexId>, ingest_timestamp: Option<u64>) -> Message;
 }
 
 /// Default implementation of ResultExtractor that includes all aggregation values
@@ -76,7 +77,7 @@ pub trait AggregationResultExtractorTrait: Send + Sync + fmt::Debug {
 pub struct AllAggregationsResultExtractor;
 
 impl AggregationResultExtractorTrait for AllAggregationsResultExtractor {
-    fn extract_result(&self, key: &Key, result: &AggregationResult, upstream_vertex_id: Option<String>, ingest_timestamp: Option<u64>) -> Message {
+    fn extract_result(&self, key: &Key, result: &AggregationResult, upstream_vertex_id: Option<VertexId>, ingest_timestamp: Option<u64>) -> Message {
         // Create a schema with all aggregation fields
         let schema = Arc::new(Schema::new(vec![
             Field::new("min", DataType::Float64, false),
@@ -136,7 +137,7 @@ impl SingleAggregationResultExtractor {
 }
 
 impl AggregationResultExtractorTrait for SingleAggregationResultExtractor {
-    fn extract_result(&self, key: &Key, result: &AggregationResult, upstream_vertex_id: Option<String>, ingest_timestamp: Option<u64>) -> Message {
+    fn extract_result(&self, key: &Key, result: &AggregationResult, upstream_vertex_id: Option<VertexId>, ingest_timestamp: Option<u64>) -> Message {
         let value = match self.aggregation_type {
             AggregationType::Min => result.min,
             AggregationType::Max => result.max,
@@ -173,7 +174,7 @@ pub enum AggregationResultExtractor {
 }
 
 impl AggregationResultExtractorTrait for AggregationResultExtractor {
-    fn extract_result(&self, key: &Key, result: &AggregationResult, upstream_vertex_id: Option<String>, ingest_timestamp: Option<u64>) -> Message {
+    fn extract_result(&self, key: &Key, result: &AggregationResult, upstream_vertex_id: Option<VertexId>, ingest_timestamp: Option<u64>) -> Message {
         match self {
             AggregationResultExtractor::All(e) => e.extract_result(key, result, upstream_vertex_id, ingest_timestamp),
             AggregationResultExtractor::Single(e) => e.extract_result(key, result, upstream_vertex_id, ingest_timestamp),

--- a/src/runtime/functions/sink/in_memory_storage_sink.rs
+++ b/src/runtime/functions/sink/in_memory_storage_sink.rs
@@ -127,7 +127,7 @@ impl FunctionTrait for InMemoryStorageSinkFunction {
         
         // Final flush
         if let Some(ref client) = self.storage_client {
-            let vertex_id = self.runtime_context.as_ref().map(|ctx| ctx.vertex_id());
+            let vertex_id = self.runtime_context.as_ref().map(|ctx| ctx.vertex_id().to_string());
             Self::flush_buffers(client, &self.buffer, &self.keyed_buffer, vertex_id.as_deref()).await?;
         }
     
@@ -147,7 +147,7 @@ impl FunctionTrait for InMemoryStorageSinkFunction {
 mod tests {
     use super::*;
     use crate::common::test_utils::{create_test_string_batch, gen_unique_grpc_port};
-    use crate::common::Key;
+    use crate::common::{Key, OperatorTypeCode, VertexId};
     use tokio::runtime::Runtime;
     use arrow::array::StringArray;
     use crate::common::message::{KeyedMessage, BaseMessage};
@@ -197,8 +197,7 @@ mod tests {
 
             // Open sink function
             let context = RuntimeContext::new(
-                "test_sink".to_string().into(),
-                0,
+                VertexId::new(OperatorTypeCode::SinkInMemoryStorageGrpc, 1, 1),
                 1,
                 None,
                 None,

--- a/src/runtime/functions/sink/parquet/mod.rs
+++ b/src/runtime/functions/sink/parquet/mod.rs
@@ -59,7 +59,7 @@ pub struct ParquetSinkFunction {
     config: ParquetSinkConfig,
     store: Option<Arc<dyn ObjectStore>>,
     base_prefix: ObjectPath,
-    task_index: Option<i32>,
+    task_index: Option<u16>,
     writers: HashMap<String, ParquetWriterState>,
 }
 
@@ -358,7 +358,7 @@ impl ParquetSinkConfig {
 fn build_part_path(
     base_prefix: &ObjectPath,
     partition_path: &str,
-    task_index: i32,
+    task_index: u16,
     part: u64,
 ) -> ObjectPath {
     let file = format!("part-{}-{}-{}.parquet", task_index, Uuid::new_v4(), part);

--- a/src/runtime/functions/sink/parquet/unit_tests.rs
+++ b/src/runtime/functions/sink/parquet/unit_tests.rs
@@ -4,6 +4,7 @@ use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use std::fs;
 use uuid::Uuid;
+use crate::common::{OperatorTypeCode, VertexId};
 
 #[tokio::test]
 async fn sink_enforces_max_buffer_bytes() {
@@ -21,7 +22,7 @@ async fn sink_enforces_max_buffer_bytes() {
         partition_fields: Some(vec!["k".to_string()]),
     };
     let mut sink = ParquetSinkFunction::new(ParquetSinkConfig::new(spec));
-    let ctx = RuntimeContext::new("sink".to_string().into(), 0, 1, None, None, None);
+    let ctx = RuntimeContext::new(VertexId::new(OperatorTypeCode::Map, 1, 1),  1, None, None, None);
     sink.open(&ctx).await.unwrap();
 
     let schema = Arc::new(Schema::new(vec![

--- a/src/runtime/functions/source/datagen_source.rs
+++ b/src/runtime/functions/source/datagen_source.rs
@@ -109,8 +109,8 @@ pub struct DatagenSourceFunction {
     config: DatagenSourceConfig,
     
     // Runtime state
-    task_index: Option<i32>,
-    parallelism: Option<i32>,
+    task_index: Option<u16>,
+    parallelism: Option<u16>,
     vertex_id: Option<String>,
     
     // Rate coordination state
@@ -653,6 +653,7 @@ mod tests {
     use arrow::array::{Array, StringArray, Int64Array, Float64Array, TimestampMillisecondArray};
     use arrow::datatypes::{DataType, Field, TimeUnit};
     use crate::common::message::Message;
+    use crate::common::{OperatorTypeCode, VertexId};
 
     fn create_test_config() -> DatagenSourceConfig {
         let schema = Arc::new(Schema::new(vec![
@@ -712,8 +713,7 @@ mod tests {
             let mut source = DatagenSourceFunction::new(config.clone());
             
             let ctx = RuntimeContext::new(
-                "test".to_string().into(),
-                task_index,
+                VertexId::new(OperatorTypeCode::Map, 1, task_index),
                 parallelism,
                 None,
                 None,
@@ -853,16 +853,15 @@ mod tests {
                 let mut source = DatagenSourceFunction::new(config_clone);
                 
                 let ctx = RuntimeContext::new(
-                    "test".to_string().into(),
-                    task_index,
+                    VertexId::new(OperatorTypeCode::Map, 1, task_index),
                     parallelism,
                     None,
                     None,
                     None
                 );
-                
+
                 source.open(&ctx).await.unwrap();
-                
+
                 let mut task_timestamps = Vec::new();
                 let mut batch_count = 0;
                 
@@ -1043,8 +1042,7 @@ mod tests {
             // Baseline: uninterrupted run
             let mut baseline = DatagenSourceFunction::new(cfg.clone());
             let ctx = RuntimeContext::new(
-                "test".to_string().into(),
-                task_index,
+                VertexId::new(OperatorTypeCode::SourceDatagen, 1, task_index),
                 parallelism,
                 None,
                 None,
@@ -1056,8 +1054,7 @@ mod tests {
             // Interrupted: run until checkpoint, snapshot, restart, restore, continue
             let mut first = DatagenSourceFunction::new(cfg.clone());
             let ctx_first = RuntimeContext::new(
-                "test".to_string().into(),
-                task_index,
+                VertexId::new(OperatorTypeCode::SourceDatagen, 1, task_index),
                 parallelism,
                 None,
                 None,
@@ -1069,8 +1066,7 @@ mod tests {
 
             let mut second = DatagenSourceFunction::new(cfg.clone());
             let ctx_second = RuntimeContext::new(
-                "test".to_string().into(),
-                task_index,
+                VertexId::new(OperatorTypeCode::SourceDatagen, 1, task_index),
                 parallelism,
                 None,
                 None,

--- a/src/runtime/functions/source/kafka/integration_tests.rs
+++ b/src/runtime/functions/source/kafka/integration_tests.rs
@@ -14,6 +14,7 @@ use testcontainers::core::WaitFor;
 use testcontainers::{GenericImage, RunnableImage};
 
 use crate::common::message::Message;
+use crate::common::{OperatorTypeCode, VertexId};
 use crate::runtime::functions::function_trait::FunctionTrait;
 use crate::runtime::functions::source::source_function::SourceFunctionTrait;
 use crate::runtime::runtime_context::RuntimeContext;
@@ -156,8 +157,7 @@ async fn kafka_source_reads_arrow_ipc() {
     let mut source = build_source(bootstrap_servers, schema, KafkaOffsetSpec::Earliest);
 
     let ctx = RuntimeContext::new(
-        "kafka_source".to_string().into(),
-        0,
+        VertexId::new(OperatorTypeCode::SourceKafka, 1, 1),
         1,
         None,
         None,
@@ -201,8 +201,7 @@ async fn kafka_source_checkpoint_restore_replays_from_saved_offsets() {
 
     let mut source = build_source(bootstrap_servers.clone(), schema.clone(), KafkaOffsetSpec::Earliest);
     let ctx = RuntimeContext::new(
-        "kafka_source".to_string().into(),
-        0,
+        VertexId::new(OperatorTypeCode::SourceKafka, 1, 1),
         1,
         None,
         None,
@@ -287,16 +286,14 @@ async fn kafka_source_parallel_tasks_consume_all_partitions() {
     };
 
     let ctx_a = RuntimeContext::new(
-        "kafka_source".to_string().into(),
-        0,
+        VertexId::new(OperatorTypeCode::SourceKafka, 1, 2),
         2,
         None,
         None,
         None,
     );
     let ctx_b = RuntimeContext::new(
-        "kafka_source".to_string().into(),
-        1,
+        VertexId::new(OperatorTypeCode::SourceKafka, 2, 2),
         2,
         None,
         None,

--- a/src/runtime/functions/source/kafka/mod.rs
+++ b/src/runtime/functions/source/kafka/mod.rs
@@ -188,8 +188,8 @@ impl KafkaSourceFunction {
 
     fn compute_assigned_partitions(
         total_partitions: usize,
-        task_index: i32,
-        parallelism: i32,
+        task_index: u16,
+        parallelism: u16,
     ) -> Vec<i32> {
         (0..total_partitions)
             .filter(|i| i % parallelism as usize == task_index as usize)

--- a/src/runtime/functions/source/parquet/integration_tests.rs
+++ b/src/runtime/functions/source/parquet/integration_tests.rs
@@ -15,6 +15,7 @@ use object_store::throttle::{ThrottleConfig, ThrottledStore};
 use testcontainers::{clients::Cli, GenericImage, RunnableImage};
 use testcontainers::core::WaitFor;
 use uuid::Uuid;
+use crate::common::{OperatorTypeCode, VertexId};
 
 fn write_parquet_file(path: &Path, schema: SchemaRef, batch: RecordBatch) {
     let file = File::create(path).unwrap();
@@ -60,7 +61,7 @@ async fn parquet_roundtrip_via_sink_and_source(
     };
     let sink_config = ParquetSinkConfig::new(sink_spec);
     let mut sink = ParquetSinkFunction::new(sink_config);
-    let sink_ctx = RuntimeContext::new("sink".to_string().into(), 0, 1, None, None, None);
+    let sink_ctx = RuntimeContext::new(VertexId::new(OperatorTypeCode::SinkParquet, 2, 0),  1, None, None, None);
     sink.open(&sink_ctx).await.unwrap();
 
     let mut input_batches = Vec::new();
@@ -94,7 +95,7 @@ async fn parquet_roundtrip_via_sink_and_source(
     };
     let source_config = ParquetSourceConfig::new(schema.clone(), source_spec);
     let mut source = ParquetSourceFunction::new(source_config);
-    let source_ctx = RuntimeContext::new("src".to_string().into(), 0, 1, None, None, None);
+    let source_ctx = RuntimeContext::new(VertexId::new(OperatorTypeCode::SourceParquet, 1, 0),  1, None, None, None);
     source.open(&source_ctx).await.unwrap();
 
     let mut output_rows = Vec::new();
@@ -180,7 +181,7 @@ async fn parquet_parallel_tasks_consume_all_files() {
     let mut rows = Vec::new();
     for task_index in 0..2 {
         let mut source = ParquetSourceFunction::new(config.clone());
-        let ctx = RuntimeContext::new("src".to_string().into(), task_index, 2, None, None, None);
+        let ctx = RuntimeContext::new(VertexId::new(OperatorTypeCode::SourceParquet, 1, task_index), 2, None, None, None);
         source.open(&ctx).await.unwrap();
         while let Some(msg) = source.fetch().await {
             let batch = msg.record_batch();
@@ -233,7 +234,7 @@ async fn parquet_projection_pushdown_roundtrip() {
     config.set_projection(projection, projected_schema.clone());
 
     let mut source = ParquetSourceFunction::new(config);
-    let ctx = RuntimeContext::new("src".to_string().into(), 0, 1, None, None, None);
+    let ctx = RuntimeContext::new(VertexId::new(OperatorTypeCode::SourceParquet, 1, 0),  1, None, None, None);
     source.open(&ctx).await.unwrap();
 
     let msg = source.fetch().await.expect("expected batch");
@@ -270,7 +271,7 @@ async fn parquet_partitioned_sink_writes_directories() {
     };
     let sink_config = ParquetSinkConfig::new(sink_spec);
     let mut sink = ParquetSinkFunction::new(sink_config);
-    let sink_ctx = RuntimeContext::new("sink".to_string().into(), 0, 1, None, None, None);
+    let sink_ctx = RuntimeContext::new(VertexId::new(OperatorTypeCode::SinkParquet, 1, 0),  1, None, None, None);
     sink.open(&sink_ctx).await.unwrap();
     sink.sink(Message::new(None, batch, None, None)).await.unwrap();
     sink.close().await.unwrap();
@@ -315,7 +316,7 @@ async fn parquet_sink_bounded_concurrency_backpressure() {
     };
     let sink_config = ParquetSinkConfig::new(sink_spec);
     let mut sink = ParquetSinkFunction::new_with_store(sink_config, store.clone(), ObjectPath::from(""));
-    let sink_ctx = RuntimeContext::new("sink".to_string().into(), 0, 1, None, None, None);
+    let sink_ctx = RuntimeContext::new(VertexId::new(OperatorTypeCode::SinkParquet, 1, 0),  1, None, None, None);
     sink.open(&sink_ctx).await.unwrap();
 
     let schema = test_schema();

--- a/src/runtime/functions/source/parquet/unit_tests.rs
+++ b/src/runtime/functions/source/parquet/unit_tests.rs
@@ -7,6 +7,8 @@ use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use parquet::arrow::ArrowWriter;
 use uuid::Uuid;
+use crate::common::OperatorTypeCode;
+use crate::runtime::VertexId;
 
 fn write_parquet(path: &Path, schema: SchemaRef, batch: RecordBatch) {
     let file = File::create(path).unwrap();
@@ -50,8 +52,7 @@ async fn parquet_source_applies_projection_mask() {
 
     let mut source = ParquetSourceFunction::new(config);
     let ctx = RuntimeContext::new(
-        "parquet_source".to_string().into(),
-        0,
+        VertexId::new(OperatorTypeCode::SourceParquet, 1, 0),
         1,
         None,
         None,

--- a/src/runtime/functions/source/request_source.rs
+++ b/src/runtime/functions/source/request_source.rs
@@ -448,8 +448,8 @@ mod tests {
     use tokio::time::{sleep, Duration};
     use futures::FutureExt;
     use std::sync::Arc;
+    use crate::common::{OperatorTypeCode, VertexId};
 
-    
     fn create_test_config(schema: SchemaRef) -> RequestSourceConfig {
         let port = gen_unique_grpc_port();
 
@@ -466,7 +466,7 @@ mod tests {
     }
 
     fn create_test_runtime_context() -> RuntimeContext {
-        RuntimeContext::new(Arc::<str>::from("test_vertex"), 0, 1, None, None, None)
+        RuntimeContext::new(VertexId::new(OperatorTypeCode::Map, 1, 0),  1, None, None, None)
     }
     
     async fn create_test_processor_and_source(schema: SchemaRef) -> (RequestSourceProcessor, HttpRequestSourceFunction) {
@@ -572,7 +572,7 @@ mod tests {
         for i in 0..record_batch.num_rows() {
             let record_batch_slice = record_batch.slice(i, 1);
             let response_message = Message::new(
-                Some("processor".to_string()),
+                Some(VertexId::new(OperatorTypeCode::Map, 1, 1)),
                 record_batch_slice,
                 Some(12345),
                 Some(extras.clone())

--- a/src/runtime/functions/source/word_count_source.rs
+++ b/src/runtime/functions/source/word_count_source.rs
@@ -15,6 +15,8 @@ use std::collections::HashMap;
 
 #[cfg(test)]
 use arrow::array::Array;
+#[cfg(test)]
+use crate::common::{OperatorTypeCode, VertexId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BatchingMode {
@@ -286,7 +288,7 @@ async fn test_word_count_source(
         batching_mode,
     );
 
-    source.open(&RuntimeContext::new(Arc::<str>::from("test"), 0, 1, None, None, None)).await.unwrap();
+    source.open(&RuntimeContext::new(VertexId::new(OperatorTypeCode::Map, 1, 0),  1, None, None, None)).await.unwrap();
 
     let mut word_counts = HashMap::new();
     

--- a/src/runtime/master_server.rs
+++ b/src/runtime/master_server.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tonic::{Request, Response, Status};
 
+use crate::common::ids::VertexId;
+
 pub mod master_service {
     tonic::include_proto!("master_service");
 }
@@ -16,10 +18,9 @@ use master_service::{
     GetLatestSnapshotRequest, GetLatestSnapshotResponse,
 };
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct TaskKey {
-    pub vertex_id: String,
-    pub task_index: i32,
+    pub vertex_id: VertexId,
 }
 
 #[derive(Debug, Default)]
@@ -99,8 +100,7 @@ impl MasterService for MasterServiceImpl {
         let req = request.into_inner();
         let checkpoint_id = req.checkpoint_id;
         let task = TaskKey {
-            vertex_id: req.vertex_id,
-            task_index: req.task_index,
+            vertex_id: VertexId::from_raw(req.vertex_id)
         };
 
         let blobs = req
@@ -110,7 +110,7 @@ impl MasterService for MasterServiceImpl {
             .collect::<Vec<_>>();
 
         let mut registry = self.registry.lock().await;
-        registry.store.put(checkpoint_id, task.clone(), blobs);
+        registry.store.put(checkpoint_id, task, blobs);
         let expected_count = registry.expected_tasks.len();
         registry.coordinator.ack(checkpoint_id, task, expected_count);
 
@@ -127,8 +127,7 @@ impl MasterService for MasterServiceImpl {
         let req = request.into_inner();
         let checkpoint_id = req.checkpoint_id;
         let task = TaskKey {
-            vertex_id: req.vertex_id,
-            task_index: req.task_index,
+            vertex_id: VertexId::from_raw(req.vertex_id)
         };
 
         let registry = self.registry.lock().await;

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -14,12 +14,10 @@ pub mod state;
 pub mod utils;
 pub mod watermark;
 
-use std::sync::Arc;
-
 /// Operator/task identity within a worker.
 ///
 /// In this codebase `vertex_id` is effectively the task namespace (unique per operator task).
-pub type VertexId = Arc<str>;
+pub use crate::common::ids::VertexId;
 pub type TaskId = VertexId;
 
 pub mod partition;

--- a/src/runtime/observability/metrics/mod.rs
+++ b/src/runtime/observability/metrics/mod.rs
@@ -270,25 +270,16 @@ pub struct WorkerAggregateMetrics {
 
 impl WorkerAggregateMetrics {
 
-    pub fn new(worker_id: String, execution_ids: ExecutionIds, tasks_metrics: HashMap<VertexId, TaskMetrics>, graph: &ExecutionGraph) -> Self {
+    pub fn new(worker_id: String, execution_ids: ExecutionIds, tasks_metrics: HashMap<VertexId, TaskMetrics>) -> Self {
         let mut metrics_by_operator: HashMap<OperatorId, Vec<TaskMetrics>> = HashMap::new();
 
         // Group task metrics by operator_id.
-        // The HashMap is keyed by vertex_id rendered via Display; iterate vertices in the graph
-        // and reverse-match by Display form to recover their operator_id.
-        let by_label: HashMap<VertexId, &TaskMetrics> = tasks_metrics
-            .iter()
-            .map(|(k, v)| (k.clone(), v))
-            .collect();
-        for vertex in graph.get_vertices().values() {
-            let vertex_id = vertex.vertex_id;
-            if let Some(task_metrics) = by_label.get(&vertex_id) {
-                let operator_id = vertex_id.operator_id();
-                metrics_by_operator
-                    .entry(operator_id)
-                    .or_insert_with(Vec::new)
-                    .push((*task_metrics).clone());
-            }
+        for (vertex_id, task_metrics) in tasks_metrics.iter() {
+            let operator_id = vertex_id.operator_id();
+            metrics_by_operator
+                .entry(operator_id)
+                .or_insert_with(Vec::new)
+                .push(task_metrics.clone());
         }
 
         // Create OperatorMetrics for each operator by merging its task metrics

--- a/src/runtime/observability/metrics/mod.rs
+++ b/src/runtime/observability/metrics/mod.rs
@@ -5,7 +5,7 @@ use metrics_exporter_tcp::TcpBuilder;
 use metrics_util::layers::FanoutBuilder;
 use prometheus_parse::{Scrape, Value, HistogramCount};
 use std::{collections::HashMap, sync::{Once, OnceLock}};
-
+use crate::common::OperatorId;
 use crate::runtime::VertexId;
 use crate::runtime::execution_graph::ExecutionGraph;
 use crate::control_plane::types::ExecutionIds;
@@ -233,7 +233,7 @@ impl ThroughputMetrics {
 // per-task metrics (task/vertex scope)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskMetrics {
-    pub vertex_id: String,
+    pub vertex_id: VertexId,
     pub latency_stats: LatencyMetrics,
     pub throughput_stast: ThroughputMetrics,
     pub backpressure_per_peer: HashMap<String, f64>,
@@ -242,13 +242,13 @@ pub struct TaskMetrics {
 // aggregated metrics for an operator_id over all its tasks
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OperatorAggregateMetrics {
-    pub operator_id: String,
+    pub operator_id: OperatorId,
     pub latency_metrics: LatencyMetrics,
     pub throughput_metrics: ThroughputMetrics,
 }
 
 impl OperatorAggregateMetrics {
-    pub fn new(operator_id: String, task_metrics: Vec<TaskMetrics>) -> Self {
+    pub fn new(operator_id: OperatorId, task_metrics: Vec<TaskMetrics>) -> Self {
         let latency_stats = LatencyMetrics::merge(task_metrics.iter().map(|m| &m.latency_stats).collect());
         let throughput_stats = ThroughputMetrics::merge(task_metrics.iter().map(|m| &m.throughput_stast).collect());
 
@@ -264,23 +264,30 @@ impl OperatorAggregateMetrics {
 pub struct WorkerAggregateMetrics {
     pub worker_id: String,
     pub execution_ids: ExecutionIds,
-    pub operator_metrics: HashMap<String, OperatorAggregateMetrics>,
-    pub tasks_metrics: HashMap<String, TaskMetrics>
+    pub operator_metrics: HashMap<OperatorId, OperatorAggregateMetrics>,
+    pub tasks_metrics: HashMap<VertexId, TaskMetrics>
 }
 
 impl WorkerAggregateMetrics {
 
-    pub fn new(worker_id: String, execution_ids: ExecutionIds, tasks_metrics: HashMap<String, TaskMetrics>, graph: &ExecutionGraph) -> Self {
-        let mut metrics_by_operator: HashMap<String, Vec<TaskMetrics>> = HashMap::new();
+    pub fn new(worker_id: String, execution_ids: ExecutionIds, tasks_metrics: HashMap<VertexId, TaskMetrics>, graph: &ExecutionGraph) -> Self {
+        let mut metrics_by_operator: HashMap<OperatorId, Vec<TaskMetrics>> = HashMap::new();
 
-        // Group task metrics by operator_id
-        for (vertex_id, task_metrics) in tasks_metrics.iter() {
-            if let Some(vertex) = graph.get_vertex(vertex_id) {
-                let operator_id = vertex.operator_id.clone();
+        // Group task metrics by operator_id.
+        // The HashMap is keyed by vertex_id rendered via Display; iterate vertices in the graph
+        // and reverse-match by Display form to recover their operator_id.
+        let by_label: HashMap<VertexId, &TaskMetrics> = tasks_metrics
+            .iter()
+            .map(|(k, v)| (k.clone(), v))
+            .collect();
+        for vertex in graph.get_vertices().values() {
+            let vertex_id = vertex.vertex_id;
+            if let Some(task_metrics) = by_label.get(&vertex_id) {
+                let operator_id = vertex_id.operator_id();
                 metrics_by_operator
                     .entry(operator_id)
                     .or_insert_with(Vec::new)
-                    .push(task_metrics.clone());
+                    .push((*task_metrics).clone());
             }
         }
 
@@ -307,10 +314,11 @@ impl WorkerAggregateMetrics {
         let attempt_id = self.execution_ids.attempt_id.0.to_string();
 
         for (operator_id, operator_metrics) in self.operator_metrics.iter() {
+            let operator_id_label = operator_id.to_string();
             // Record throughput metrics
             counter!(
                 METRIC_OPERATOR_MESSAGES_SENT,
-                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_OPERATOR_ID => operator_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -318,7 +326,7 @@ impl WorkerAggregateMetrics {
             ).increment(operator_metrics.throughput_metrics.messages_sent);
             counter!(
                 METRIC_OPERATOR_MESSAGES_RECV,
-                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_OPERATOR_ID => operator_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -326,7 +334,7 @@ impl WorkerAggregateMetrics {
             ).increment(operator_metrics.throughput_metrics.messages_recv);
             counter!(
                 METRIC_OPERATOR_RECORDS_SENT,
-                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_OPERATOR_ID => operator_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -334,7 +342,7 @@ impl WorkerAggregateMetrics {
             ).increment(operator_metrics.throughput_metrics.records_sent);
             counter!(
                 METRIC_OPERATOR_RECORDS_RECV,
-                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_OPERATOR_ID => operator_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -342,7 +350,7 @@ impl WorkerAggregateMetrics {
             ).increment(operator_metrics.throughput_metrics.records_recv);
             counter!(
                 METRIC_OPERATOR_BYTES_SENT,
-                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_OPERATOR_ID => operator_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -350,17 +358,17 @@ impl WorkerAggregateMetrics {
             ).increment(operator_metrics.throughput_metrics.bytes_sent);
             counter!(
                 METRIC_OPERATOR_BYTES_RECV,
-                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_OPERATOR_ID => operator_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
                 LABEL_ATTEMPT_ID => attempt_id.clone()
             ).increment(operator_metrics.throughput_metrics.bytes_recv);
-            
+
             // Record latency metrics
             gauge!(
                 METRIC_OPERATOR_LATENCY_99,
-                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_OPERATOR_ID => operator_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -368,7 +376,7 @@ impl WorkerAggregateMetrics {
             ).set(operator_metrics.latency_metrics.p99);
             gauge!(
                 METRIC_OPERATOR_LATENCY_95,
-                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_OPERATOR_ID => operator_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -376,7 +384,7 @@ impl WorkerAggregateMetrics {
             ).set(operator_metrics.latency_metrics.p95);
             gauge!(
                 METRIC_OPERATOR_LATENCY_50,
-                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_OPERATOR_ID => operator_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -384,19 +392,20 @@ impl WorkerAggregateMetrics {
             ).set(operator_metrics.latency_metrics.p50);
             gauge!(
                 METRIC_OPERATOR_LATENCY_AVG,
-                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_OPERATOR_ID => operator_id_label,
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
                 LABEL_ATTEMPT_ID => attempt_id.clone()
             ).set(operator_metrics.latency_metrics.avg);
         }
-        
+
         // Record stream task latency metrics
         for (vertex_id, task_metrics) in self.tasks_metrics.iter() {
+            let vertex_id_label = vertex_id.to_string();
             gauge!(
                 METRIC_STREAM_TASK_LATENCY_99,
-                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_VERTEX_ID => vertex_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -404,7 +413,7 @@ impl WorkerAggregateMetrics {
             ).set(task_metrics.latency_stats.p99);
             gauge!(
                 METRIC_STREAM_TASK_LATENCY_95,
-                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_VERTEX_ID => vertex_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -412,7 +421,7 @@ impl WorkerAggregateMetrics {
             ).set(task_metrics.latency_stats.p95);
             gauge!(
                 METRIC_STREAM_TASK_LATENCY_50,
-                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_VERTEX_ID => vertex_id_label.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -420,7 +429,7 @@ impl WorkerAggregateMetrics {
             ).set(task_metrics.latency_stats.p50);
             gauge!(
                 METRIC_STREAM_TASK_LATENCY_AVG,
-                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_VERTEX_ID => vertex_id_label,
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -450,7 +459,7 @@ pub fn emit_poll_derived_gauges(worker_metrics: &WorkerAggregateMetrics) {
 
         gauge!(
             METRIC_STREAM_TASK_BACKPRESSURE_MAX,
-            LABEL_VERTEX_ID => vertex_id.clone(),
+            LABEL_VERTEX_ID => vertex_id.to_string(),
             LABEL_WORKER_ID => worker_metrics.worker_id.clone(),
             LABEL_PIPELINE_SPEC_ID => pipeline_spec_id.clone(),
             LABEL_PIPELINE_ID => pipeline_id.clone(),
@@ -615,8 +624,8 @@ pub struct TaskThroughputStats {
 
 #[derive(Debug, Clone)]
 pub struct FinalStats {
-    pub throughput_per_task: HashMap<String, TaskThroughputStats>,
-    pub latency_per_task: HashMap<String, LatencyMetrics>,
+    pub throughput_per_task: HashMap<VertexId, TaskThroughputStats>,
+    pub latency_per_task: HashMap<VertexId, LatencyMetrics>,
 }
 
 impl PipelineStateHistory {
@@ -630,7 +639,7 @@ impl PipelineStateHistory {
         self.samples.push((timestamp, pipeline_state));
     }
 
-    pub fn calculate_throughput_rates(&self, window_seconds: u64) -> HashMap<String, ThroughputRates> {
+    pub fn calculate_throughput_rates(&self, window_seconds: u64) -> HashMap<VertexId, ThroughputRates> {
         let mut rates = HashMap::new();
         
         if self.samples.is_empty() {
@@ -700,8 +709,8 @@ impl PipelineStateHistory {
     }
 
     pub fn final_stats(&self) -> FinalStats {
-        let mut throughput_per_task: HashMap<String, TaskThroughputStats> = HashMap::new();
-        let mut latency_per_task: HashMap<String, LatencyMetrics> = HashMap::new();
+        let mut throughput_per_task: HashMap<VertexId, TaskThroughputStats> = HashMap::new();
+        let mut latency_per_task: HashMap<VertexId, LatencyMetrics> = HashMap::new();
         
         if self.samples.len() < 2 {
             return FinalStats {
@@ -711,7 +720,7 @@ impl PipelineStateHistory {
         }
         
         // Calculate throughput rates for each consecutive pair of samples
-        let mut all_rates_per_task: HashMap<String, Vec<ThroughputRates>> = HashMap::new();
+        let mut all_rates_per_task: HashMap<VertexId, Vec<ThroughputRates>> = HashMap::new();
         
         for i in 1..self.samples.len() {
             let (start_timestamp, start_state) = &self.samples[i - 1];
@@ -786,7 +795,7 @@ impl PipelineStateHistory {
         }
         
         // Aggregate latency histograms per task across all samples
-        let mut latency_histograms_per_task: HashMap<String, Vec<&LatencyMetrics>> = HashMap::new();
+        let mut latency_histograms_per_task: HashMap<VertexId, Vec<&LatencyMetrics>> = HashMap::new();
         
         for (_timestamp, pipeline_state) in &self.samples {
             for (_worker_id, worker_state) in &pipeline_state.worker_states {
@@ -898,11 +907,11 @@ fn _init_metrics() -> Result<(), Box<dyn std::error::Error>> {
 pub fn get_stream_task_metrics(vertex_id: VertexId, labels: Option<&MetricsLabels>) -> TaskMetrics {
     let handle = PROMETHEUS_HANDLE.get().expect("Metrics not initialized");
     let prometheus_text = handle.render();
-    
-    parse_stream_task_metrics(&prometheus_text, vertex_id.as_ref(), labels)
+
+    parse_stream_task_metrics(&prometheus_text, vertex_id.clone(), labels)
 }
 
-fn parse_stream_task_metrics(prometheus_text: &str, vertex_id: &str, labels: Option<&MetricsLabels>) -> TaskMetrics {
+fn parse_stream_task_metrics(prometheus_text: &str, vertex_id: VertexId, labels: Option<&MetricsLabels>) -> TaskMetrics {
     let scrape = Scrape::parse(prometheus_text.lines().map(|line| Ok(line.to_string())))
         .expect("Failed to parse Prometheus metrics");
     
@@ -915,10 +924,12 @@ fn parse_stream_task_metrics(prometheus_text: &str, vertex_id: &str, labels: Opt
     let mut latency_histogram = vec![0u64; LATENCY_BUCKET_BOUNDARIES.len()];
     let mut backpressure_per_peer = HashMap::new();
 
+    let vertex_id_label = vertex_id.to_string();
+
     for sample in scrape.samples {
         // Check if this metric belongs to our vertex_id
         if let Some(sample_vertex_id) = sample.labels.get(LABEL_VERTEX_ID) {
-            if sample_vertex_id != vertex_id {
+            if sample_vertex_id != vertex_id_label.as_str() {
                 continue;
             }
         } else {
@@ -972,7 +983,7 @@ fn parse_stream_task_metrics(prometheus_text: &str, vertex_id: &str, labels: Opt
     let throughput_stats = ThroughputMetrics::new(messages_sent, messages_recv, records_sent, records_recv, bytes_sent, bytes_recv);
     
     TaskMetrics {
-        vertex_id: vertex_id.to_string(),
+        vertex_id,
         latency_stats,
         throughput_stast: throughput_stats,
         backpressure_per_peer
@@ -990,10 +1001,9 @@ fn convert_histogram_counts_to_buckets(histogram_counts: &[HistogramCount]) -> V
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
     use metrics::{counter, histogram};
+    use crate::common::OperatorTypeCode;
 
     /// Helper function to manually build a histogram from latency measurements
     fn build_expected_histogram(latencies: &[f64], boundaries: &[f64]) -> Vec<u64> {
@@ -1018,7 +1028,7 @@ mod tests {
     fn test_stream_task_metrics_prometheus_parsing() {
         init_metrics();
         
-        let vertex_id = "test_task_123".to_string();
+        let vertex_id = VertexId::new(OperatorTypeCode::Map, 1, 1);
         let labels = MetricsLabels {
             pipeline_spec_id: "spec".to_string(),
             pipeline_id: "pipe".to_string(),
@@ -1029,7 +1039,7 @@ mod tests {
         // Record stream task metrics
         counter!(
             METRIC_STREAM_TASK_MESSAGES_SENT,
-            LABEL_VERTEX_ID => vertex_id.clone(),
+            LABEL_VERTEX_ID => vertex_id.to_string(),
             LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -1037,7 +1047,7 @@ mod tests {
         ).increment(5);
         counter!(
             METRIC_STREAM_TASK_MESSAGES_RECV,
-            LABEL_VERTEX_ID => vertex_id.clone(),
+            LABEL_VERTEX_ID => vertex_id.to_string(),
             LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -1045,7 +1055,7 @@ mod tests {
         ).increment(3);
         counter!(
             METRIC_STREAM_TASK_RECORDS_SENT,
-            LABEL_VERTEX_ID => vertex_id.clone(),
+            LABEL_VERTEX_ID => vertex_id.to_string(),
             LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -1053,7 +1063,7 @@ mod tests {
         ).increment(25);
         counter!(
             METRIC_STREAM_TASK_RECORDS_RECV,
-            LABEL_VERTEX_ID => vertex_id.clone(),
+            LABEL_VERTEX_ID => vertex_id.to_string(),
             LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -1061,7 +1071,7 @@ mod tests {
         ).increment(15);
         counter!(
             METRIC_STREAM_TASK_BYTES_SENT,
-            LABEL_VERTEX_ID => vertex_id.clone(),
+            LABEL_VERTEX_ID => vertex_id.to_string(),
             LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -1069,7 +1079,7 @@ mod tests {
         ).increment(1024);
         counter!(
             METRIC_STREAM_TASK_BYTES_RECV,
-            LABEL_VERTEX_ID => vertex_id.clone(),
+            LABEL_VERTEX_ID => vertex_id.to_string(),
             LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -1083,7 +1093,7 @@ mod tests {
         for &latency in &latency_measurements {
             histogram!(
                 METRIC_STREAM_TASK_LATENCY,
-                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_VERTEX_ID => vertex_id.to_string(),
                 LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                 LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                 LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -1094,8 +1104,8 @@ mod tests {
         // Build expected histogram manually
         let expected_histogram = build_expected_histogram(&latency_measurements, &LATENCY_BUCKET_BOUNDARIES);
         
-        let parsed_metrics = get_stream_task_metrics(Arc::<str>::from(vertex_id.clone()), Some(&labels));
-        
+        let parsed_metrics = get_stream_task_metrics(vertex_id.clone(), Some(&labels));
+
         // Verify the parsed stream task metrics
         assert_eq!(parsed_metrics.vertex_id, vertex_id);
         assert_eq!(parsed_metrics.throughput_stast.messages_sent, 5);
@@ -1129,10 +1139,10 @@ mod tests {
                    "Should have recorded {} latency measurements", latency_measurements.len());
         
         // Test vertex isolation with a second vertex
-        let vertex_b = "task_b".to_string();
+        let vertex_b = VertexId::new(OperatorTypeCode::Map, 1, 0);
         counter!(
             METRIC_STREAM_TASK_MESSAGES_SENT,
-            LABEL_VERTEX_ID => vertex_b.clone(),
+            LABEL_VERTEX_ID => vertex_b.to_string(),
             LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -1140,23 +1150,23 @@ mod tests {
         ).increment(1);
         counter!(
             METRIC_STREAM_TASK_RECORDS_SENT,
-            LABEL_VERTEX_ID => vertex_b.clone(),
+            LABEL_VERTEX_ID => vertex_b.to_string(),
             LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
             LABEL_WORKER_ID => labels.worker_id.clone()
         ).increment(50);
-        
-        let metrics_b = get_stream_task_metrics(Arc::<str>::from(vertex_b.clone()), Some(&labels));
-        
+
+        let metrics_b = get_stream_task_metrics(vertex_b.clone(), Some(&labels));
+
         // Verify isolation - vertex B should only see its own metrics
-        assert_eq!(metrics_b.vertex_id, vertex_b);
+        assert_eq!(metrics_b.vertex_id.to_string(), vertex_b.to_string());
         assert_eq!(metrics_b.throughput_stast.messages_sent, 1);
         assert_eq!(metrics_b.throughput_stast.records_sent, 50);
         assert_eq!(metrics_b.throughput_stast.messages_recv, 0); // Not set for vertex B
-        
+
         // Verify original vertex still has correct metrics
-        let metrics_a_again = get_stream_task_metrics(Arc::<str>::from(vertex_id.clone()), Some(&labels));
+        let metrics_a_again = get_stream_task_metrics(vertex_id.clone(), Some(&labels));
         assert_eq!(metrics_a_again.throughput_stast.messages_sent, 5);
         assert_eq!(metrics_a_again.throughput_stast.records_sent, 25);
     }

--- a/src/runtime/operators/aggregate/aggregate_operator.rs
+++ b/src/runtime/operators/aggregate/aggregate_operator.rs
@@ -74,11 +74,12 @@ impl AggregateOperator {
         }
 
         // Debug: Print vertex_id and emission info
-        let vertex_id = if let Some(ctx) = &self.base.runtime_context {
-            ctx.vertex_id()
-        } else {
-            "unknown_vertex"
-        };
+        let vertex_id = self
+            .base
+            .runtime_context
+            .as_ref()
+            .map(|ctx| ctx.vertex_id().to_string())
+            .unwrap_or_else(|| "unknown_vertex".to_string());
         
         let mut words_being_emitted = Vec::new();
 
@@ -281,6 +282,7 @@ impl OperatorTrait for AggregateOperator {
 
 #[cfg(test)]
 mod tests {
+    use crate::common::{OperatorTypeCode, VertexId};
     use super::*;
 
     #[tokio::test]
@@ -364,7 +366,7 @@ mod tests {
         
         // Add max watermark to finalize aggregation
         messages_to_process.push(Message::Watermark(crate::common::WatermarkMessage::new(
-            "test".to_string(),
+            VertexId::new(OperatorTypeCode::Map, 1, 1),
             MAX_WATERMARK_VALUE,
             Some(0)
         )));

--- a/src/runtime/operators/chained/chained_operator_test.rs
+++ b/src/runtime/operators/chained/chained_operator_test.rs
@@ -13,6 +13,7 @@ use async_trait::async_trait;
 use arrow::array::StringArray;
 use arrow::datatypes::{Field, Schema};
 use std::sync::Arc;
+use crate::common::{OperatorTypeCode, VertexId};
 
 // Simple test map functions
 #[derive(Debug, Clone)]
@@ -75,14 +76,14 @@ async fn test_chained_operator_map_map() {
         OperatorConfig::MapConfig(MapFunction::new_custom(ToUpperCaseMapFunction)),
     ];
     let mut chained_operator = ChainedOperator::new(OperatorConfig::ChainedConfig(configs));
-    let context = RuntimeContext::new("test_vertex".to_string().into(), 0, 1, None, None, None);
+    let context = RuntimeContext::new(VertexId::new(OperatorTypeCode::Map, 1, 1),  1, None, None, None);
     
     chained_operator.open(&context).await.unwrap();
     
     // Set up input stream
     let input_batch = create_test_string_batch(vec!["hello".to_string(), "world".to_string()]);
     let input_message = Message::new(None, input_batch, None, None);
-    let watermark = Message::Watermark(WatermarkMessage::new("test".to_string(), 1000, None));
+    let watermark = Message::Watermark(WatermarkMessage::new(VertexId::new(OperatorTypeCode::Map, 1, 1), 1000, None));
     
     let input_stream = Box::pin(futures::stream::iter(vec![input_message, watermark]));
     chained_operator.set_input(Some(input_stream));
@@ -106,7 +107,7 @@ async fn test_chained_operator_source_map() {
     let test_messages = vec![
         Message::new(None, create_test_string_batch(vec!["hello".to_string()]), None, None),
         Message::new(None, create_test_string_batch(vec!["world".to_string()]), None, None),
-        Message::Watermark(WatermarkMessage::new("source".to_string(), MAX_WATERMARK_VALUE, None)),
+        Message::Watermark(WatermarkMessage::new(VertexId::new(OperatorTypeCode::Map, 1, 1), MAX_WATERMARK_VALUE, None)),
     ];
     let configs = vec![
         OperatorConfig::SourceConfig(SourceConfig::VectorSourceConfig(VectorSourceConfig::new(test_messages))),
@@ -114,7 +115,7 @@ async fn test_chained_operator_source_map() {
     ];
 
     let mut chained_operator = ChainedOperator::new(OperatorConfig::ChainedConfig(configs));
-    let context = RuntimeContext::new("test_vertex".to_string().into(), 0, 1, None, None, None);
+    let context = RuntimeContext::new(VertexId::new(OperatorTypeCode::Map, 1, 1), 1, None, None, None);
     
     // Test open
     chained_operator.open(&context).await.unwrap();
@@ -156,7 +157,7 @@ async fn test_chained_operator_source_keyby() {
     
     let test_messages = vec![
         Message::new(None, batch, None, None),
-        Message::Watermark(WatermarkMessage::new("source".to_string(), MAX_WATERMARK_VALUE, None)),
+        Message::Watermark(WatermarkMessage::new(VertexId::new(OperatorTypeCode::Map, 1, 1), MAX_WATERMARK_VALUE, None)),
     ];
     
     let configs = vec![
@@ -165,7 +166,7 @@ async fn test_chained_operator_source_keyby() {
     ];
     
     let mut chained_operator = ChainedOperator::new(OperatorConfig::ChainedConfig(configs));
-    let context = RuntimeContext::new("test_vertex".to_string().into(), 0, 1, None, None, None);
+    let context = RuntimeContext::new(VertexId::new(OperatorTypeCode::Map, 1, 1), 1, None, None, None);
     
     // Test open
     chained_operator.open(&context).await.unwrap();
@@ -219,7 +220,7 @@ async fn test_chained_operator_source_map_keyby() {
     
     let test_messages = vec![
         Message::new(None, batch, None, None),
-        Message::Watermark(WatermarkMessage::new("source".to_string(), MAX_WATERMARK_VALUE, None)),
+        Message::Watermark(WatermarkMessage::new(VertexId::new(OperatorTypeCode::Map, 1, 1), MAX_WATERMARK_VALUE, None)),
     ];
     
     let configs = vec![
@@ -229,7 +230,7 @@ async fn test_chained_operator_source_map_keyby() {
     ];
     
     let mut chained_operator = ChainedOperator::new(OperatorConfig::ChainedConfig(configs));
-    let context = RuntimeContext::new("test_vertex".to_string().into(), 0, 1, None, None, None);
+    let context = RuntimeContext::new(VertexId::new(OperatorTypeCode::Map, 1, 1), 1, None, None, None);
     
     // Test open
     chained_operator.open(&context).await.unwrap();
@@ -336,7 +337,7 @@ async fn test_chained_operator_source_map_sink() {
     // Verify operator type is ChainedSourceSink
     assert_eq!(chained_operator.operator_type(), OperatorType::ChainedSourceSink);
     
-    let context = RuntimeContext::new("test_vertex".to_string().into(), 0, 1, None, None, None);
+    let context = RuntimeContext::new(VertexId::new(OperatorTypeCode::Map, 1, 1), 1, None, None, None);
     
     // Test open
     chained_operator.open(&context).await.unwrap();

--- a/src/runtime/operators/join/join_operator.rs
+++ b/src/runtime/operators/join/join_operator.rs
@@ -59,7 +59,9 @@ impl OperatorTrait for JoinOperator {
             Some(message) => {
                 // TODO proper lookup for upstream_vertex_id position (left or right)
                 if let Some(upstream_id) = message.upstream_vertex_id() {
-                    if upstream_id.contains("left") {
+                    // Heuristic: route by parity of op-type code as a placeholder.
+                    // Real impl should look up left/right side from execution graph.
+                    if upstream_id.op_type().as_u8() % 2 == 0 {
                         self.left_buffer.push(message.clone());
                     } else {
                         self.right_buffer.push(message.clone());

--- a/src/runtime/operators/window/state/window_operator_state_tests.rs
+++ b/src/runtime/operators/window/state/window_operator_state_tests.rs
@@ -17,7 +17,7 @@ use datafusion::prelude::SessionContext;
 
 use crate::api::planner::{Planner, PlanningContext};
 use crate::common::message::Message;
-use crate::common::{MAX_WATERMARK_VALUE, WatermarkMessage};
+use crate::common::{MAX_WATERMARK_VALUE, WatermarkMessage, VertexId, OperatorTypeCode};
 use crate::runtime::functions::key_by::key_by_function::extract_datafusion_window_exec;
 use crate::runtime::operators::operator::{OperatorConfig, OperatorPollResult, OperatorTrait};
 use crate::runtime::operators::source::source_operator::{SourceConfig, VectorSourceConfig};
@@ -66,7 +66,7 @@ fn keyed_message(b: RecordBatch, partition: &str) -> Message {
 }
 
 fn watermark_message(wm: u64) -> Message {
-    Message::Watermark(WatermarkMessage::new("test".to_string(), wm, Some(0)))
+    Message::Watermark(WatermarkMessage::new(VertexId::new(OperatorTypeCode::Map, 1, 1), wm, Some(0)))
 }
 
 async fn window_exec_from_sql(sql: &str) -> Arc<BoundedWindowAggExec> {
@@ -88,8 +88,7 @@ fn runtime_context() -> RuntimeContext {
         WorkerStorageContext::new(store, StorageBudgetConfig::default()).expect("storage ctx");
 
     let mut ctx = RuntimeContext::new(
-        "test_vertex".to_string().into(),
-        0,
+        VertexId::new(OperatorTypeCode::Map, 1, 1),
         1,
         None,
         Some(Arc::new(OperatorStates::new())),
@@ -303,7 +302,7 @@ async fn test_ingest_triggers_pressure_relief_when_in_mem_over_limit() {
         build_window_operator_parts(false, &window_exec, &Vec::new(), false);
     let state = crate::runtime::operators::window::window_operator_state::WindowOperatorState::new(
         storage,
-        Arc::<str>::from("t"),
+        VertexId::new(OperatorTypeCode::Map, 1, 1),
         0, // timestamp column index
         Arc::new(windows),
         Vec::new(),

--- a/src/runtime/operators/window/window_operator_tests.rs
+++ b/src/runtime/operators/window/window_operator_tests.rs
@@ -24,7 +24,7 @@ use datafusion::prelude::SessionContext;
 
 use crate::api::planner::{Planner, PlanningContext};
 use crate::common::message::Message;
-use crate::common::{MAX_WATERMARK_VALUE, WatermarkMessage};
+use crate::common::{MAX_WATERMARK_VALUE, WatermarkMessage, VertexId, OperatorTypeCode};
 use crate::runtime::functions::key_by::key_by_function::extract_datafusion_window_exec;
 use crate::runtime::operators::operator::{OperatorConfig, OperatorPollResult, OperatorTrait};
 use crate::runtime::operators::source::source_operator::{SourceConfig, VectorSourceConfig};
@@ -74,7 +74,7 @@ fn keyed_message(b: RecordBatch, partition: &str) -> Message {
 }
 
 fn watermark_message(wm: u64) -> Message {
-    Message::Watermark(WatermarkMessage::new("test".to_string(), wm, Some(0)))
+    Message::Watermark(WatermarkMessage::new(VertexId::new(OperatorTypeCode::Map, 1, 1), wm, Some(0)))
 }
 
 async fn window_exec_from_sql(sql: &str) -> Arc<BoundedWindowAggExec> {
@@ -96,8 +96,7 @@ fn runtime_context() -> RuntimeContext {
         WorkerStorageContext::new(store, StorageBudgetConfig::default()).expect("storage ctx");
 
     let mut ctx = RuntimeContext::new(
-        "test_vertex".to_string().into(),
-        0,
+        VertexId::new(OperatorTypeCode::Map, 1, 1),
         1,
         None,
         Some(Arc::new(OperatorStates::new())),

--- a/src/runtime/operators/window/window_request_operator.rs
+++ b/src/runtime/operators/window/window_request_operator.rs
@@ -25,6 +25,7 @@ use crate::runtime::operators::window::window_tuning::WindowOperatorSpec;
 use crate::runtime::operators::window::state::sorted_range_view_loader::{load_sorted_ranges_views, RangesLoadPlan};
 use crate::runtime::runtime_context::RuntimeContext;
 use crate::runtime::state::OperatorState;
+use crate::runtime::VertexId;
 use tokio_rayon::rayon::ThreadPool;
 use tokio::time::Duration;
 
@@ -109,19 +110,19 @@ impl WindowRequestOperator {
     }
 
     // TODO use info from logical graph to get window_operator<->window_request_operator pair
-    fn get_peer_window_operator_vertex_id(&self, vertex_id: String, graph: &ExecutionGraph) -> String {
-        let current_vertex = graph.get_vertex(&vertex_id)
+    fn get_peer_window_operator_vertex_id(&self, vertex_id: VertexId, graph: &ExecutionGraph) -> VertexId {
+        let current_vertex = graph.get_vertex(vertex_id)
             .expect(&format!("Vertex {} not found in execution graph", vertex_id));
-        let task_index = current_vertex.task_index;
+        let task_index = current_vertex.vertex_id.task_index();
 
         // Collect all window operator vertices
         let mut window_operator_ids = HashSet::new();
         let mut window_vertices = Vec::new();
-        
+
         for (vid, vertex) in graph.get_vertices() {
             if let OperatorConfig::WindowConfig(_) = &vertex.operator_config {
-                window_operator_ids.insert(vertex.operator_id.clone());
-                window_vertices.push((vid.clone(), vertex));
+                window_operator_ids.insert(vertex.vertex_id.operator_id());
+                window_vertices.push((*vid, vertex));
             }
         }
 
@@ -136,12 +137,12 @@ impl WindowRequestOperator {
 
         // Find the window operator vertex with the same task_index
         for (vid, vertex) in window_vertices {
-            if vid.as_ref() == vertex_id.as_str() {
+            if vid == vertex_id {
                 continue;
             }
-            
-            if vertex.task_index == task_index {
-                return vid.as_ref().to_string();
+
+            if vertex.vertex_id.task_index() == task_index {
+                return vid;
             }
         }
 
@@ -433,14 +434,14 @@ impl OperatorTrait for WindowRequestOperator {
     async fn open(&mut self, context: &RuntimeContext) -> Result<()> {
         self.base.open(context).await?;
         
-        let vertex_id = context.vertex_id().to_string();
+        let vertex_id = context.vertex_id();
         let operator_states = context.operator_states();
-        let window_operator_vertex_id = self.get_peer_window_operator_vertex_id(vertex_id.clone(), context.execution_graph());
+        let window_operator_vertex_id = self.get_peer_window_operator_vertex_id(vertex_id, context.execution_graph());
 
         let timeout = Duration::from_secs(2);
         let state_arc = tokio::time::timeout(
             timeout,
-            operator_states.wait_for_operator_state(&window_operator_vertex_id),
+            operator_states.wait_for_operator_state(window_operator_vertex_id),
         )
         .await
         .unwrap_or_else(|_| {
@@ -532,7 +533,7 @@ mod tests {
     use crate::common::message::Message;
     use crate::runtime::runtime_context::RuntimeContext;
     use crate::runtime::state::OperatorStates;
-    use crate::common::Key;
+    use crate::common::{Key, OperatorTypeCode};
     use futures::stream;
 
     fn create_test_schema() -> SchemaRef {
@@ -548,7 +549,7 @@ mod tests {
         let timestamp_array = Arc::new(TimestampMillisecondArray::from(timestamps));
         let value_array = Arc::new(Float64Array::from(values));
         let partition_array = Arc::new(StringArray::from(partition_keys));
-        
+
         RecordBatch::try_new(schema, vec![timestamp_array, value_array, partition_array])
             .expect("Should be able to create test batch")
     }
@@ -557,11 +558,11 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![
             Field::new("partition", DataType::Utf8, false),
         ]));
-        
+
         let partition_array = StringArray::from(vec![partition_name]);
         let key_batch = RecordBatch::try_new(schema, vec![Arc::new(partition_array)])
             .expect("Failed to create key batch");
-        
+
         Key::new(key_batch).expect("Failed to create key")
     }
 
@@ -569,10 +570,10 @@ mod tests {
         let ctx = SessionContext::new();
         let mut planner = Planner::new(PlanningContext::new(ctx));
         let schema = create_test_schema();
-        
+
         planner.register_source(
-            "test_table".to_string(), 
-            SourceConfig::VectorSourceConfig(VectorSourceConfig::new(vec![])), 
+            "test_table".to_string(),
+            SourceConfig::VectorSourceConfig(VectorSourceConfig::new(vec![])),
             schema.clone()
         );
 
@@ -583,7 +584,7 @@ mod tests {
         let key = create_test_key(partition_key);
         Message::new_keyed(None, batch, key, None, None)
     }
-    
+
     #[tokio::test]
     async fn test_window_request_operator() {
         let sql = "SELECT 
@@ -597,7 +598,7 @@ mod tests {
             MAX(value) OVER w as max_val
         FROM test_table
         WINDOW w AS (PARTITION BY partition_key ORDER BY timestamp RANGE BETWEEN INTERVAL '2000' MILLISECOND PRECEDING AND CURRENT ROW)";
-        
+
         let window_exec = extract_window_exec_from_sql(sql).await;
         let mut window_config = WindowOperatorConfig::new(window_exec.clone());
         window_config.execution_mode = ExecutionMode::Request;
@@ -606,8 +607,8 @@ mod tests {
         window_config.spec.request_advance_policy = RequestAdvancePolicy::OnIngest;
 
         let operator_states = Arc::new(OperatorStates::new());
-        let window_operator_vertex_id: crate::runtime::VertexId = Arc::<str>::from("window_op");
-        let request_operator_vertex_id: crate::runtime::VertexId = Arc::<str>::from("window_request_op");
+        let window_operator_vertex_id = VertexId::new(OperatorTypeCode::Window, 1, 1);
+        let request_operator_vertex_id = VertexId::new(OperatorTypeCode::WindowRequest, 1, 1);
 
         let budgets = crate::storage::StorageBudgetConfig::default();
         let store = Arc::new(crate::storage::batch_store::InMemBatchStore::new(
@@ -622,7 +623,6 @@ mod tests {
         let mut window_operator = WindowOperator::new(OperatorConfig::WindowConfig(window_config.clone()));
         let mut window_context = RuntimeContext::new(
             window_operator_vertex_id.clone(),
-            0,
             1,
             None,
             Some(operator_states.clone()),
@@ -640,28 +640,23 @@ mod tests {
         // Create execution graph with both vertices
         use crate::runtime::execution_graph::ExecutionVertex;
         let mut execution_graph = ExecutionGraph::new();
-        
+
         let window_vertex = ExecutionVertex::new(
-            window_operator_vertex_id.as_ref().to_string(),
-            "window_op".to_string(),
+            window_operator_vertex_id,
             OperatorConfig::WindowConfig(window_config),
-            1,
-            0,
+            1
         );
         execution_graph.add_vertex(window_vertex);
-        
+
         let request_vertex = ExecutionVertex::new(
-            request_operator_vertex_id.as_ref().to_string(),
-            "window_request_op".to_string(),
+            request_operator_vertex_id,
             OperatorConfig::WindowRequestConfig(request_config),
-            1,
-            0,
+            1
         );
         execution_graph.add_vertex(request_vertex);
 
         let mut request_context = RuntimeContext::new(
             request_operator_vertex_id.clone(),
-            0,
             1,
             None,
             Some(operator_states.clone()),

--- a/src/runtime/runtime_context.rs
+++ b/src/runtime/runtime_context.rs
@@ -11,8 +11,7 @@ use crate::runtime::VertexId;
 #[derive(Clone, Debug)]
 pub struct RuntimeContext {
     vertex_id: VertexId,
-    task_index: i32,
-    parallelism: i32,
+    parallelism: u16,
     job_config: HashMap<String, Value>,
     operator_states: Option<Arc<OperatorStates>>,
     execution_graph: Option<ExecutionGraph>,
@@ -29,15 +28,13 @@ pub struct RuntimeContext {
 impl RuntimeContext {
     pub fn new(
         vertex_id: VertexId,
-        task_index: i32,
-        parallelism: i32,
+        parallelism: u16,
         job_config: Option<HashMap<String, Value>>,
         operator_states: Option<Arc<OperatorStates>>,
         execution_graph: Option<ExecutionGraph>,
     ) -> Self {
         Self {
             vertex_id,
-            task_index,
             parallelism,
             job_config: job_config.unwrap_or_default(),
             operator_states,
@@ -48,10 +45,10 @@ impl RuntimeContext {
         }
     }
 
-    pub fn vertex_id(&self) -> &str { self.vertex_id.as_ref() }
+    pub fn vertex_id(&self) -> VertexId { self.vertex_id.clone() }
     pub fn vertex_id_arc(&self) -> VertexId { self.vertex_id.clone() }
-    pub fn task_index(&self) -> i32 { self.task_index }
-    pub fn parallelism(&self) -> i32 { self.parallelism }
+    pub fn task_index(&self) -> u16 { self.vertex_id.task_index() }
+    pub fn parallelism(&self) -> u16 { self.parallelism }
     pub fn job_config(&self) -> &HashMap<String, Value> { &self.job_config }
     pub fn operator_states(&self) -> &Arc<OperatorStates> { self.operator_states.as_ref().expect("operator states should be set") }
     pub fn execution_graph(&self) -> &ExecutionGraph { self.execution_graph.as_ref().expect("execution graph should be set") }

--- a/src/runtime/state/operator_states.rs
+++ b/src/runtime/state/operator_states.rs
@@ -37,18 +37,18 @@ impl OperatorStates {
         }
     }
 
-    pub fn get_operator_state(&self, vertex_id: &str) -> Option<Arc<dyn OperatorState>> {
-        self.states.get(vertex_id).map(|entry| entry.value().clone())
+    pub fn get_operator_state(&self, vertex_id: VertexId) -> Option<Arc<dyn OperatorState>> {
+        self.states.get(&vertex_id).map(|entry| entry.value().clone())
     }
 
-    pub async fn wait_for_operator_state(&self, vertex_id: &str) -> Arc<dyn OperatorState> {
+    pub async fn wait_for_operator_state(&self, vertex_id: VertexId) -> Arc<dyn OperatorState> {
         loop {
             if let Some(state) = self.get_operator_state(vertex_id) {
                 return state;
             }
             let notify = self
                 .notifies
-                .entry(Arc::<str>::from(vertex_id))
+                .entry(vertex_id.clone())
                 .or_insert_with(|| Arc::new(Notify::new()))
                 .clone();
             // Re-check to avoid missed notifications between the first check and registration.
@@ -59,17 +59,16 @@ impl OperatorStates {
         }
     }
 
-    pub fn get_or_insert_operator_state<F>(&self, vertex_id: &str, factory: F) -> Arc<dyn OperatorState>
+    pub fn get_or_insert_operator_state<F>(&self, vertex_id: VertexId, factory: F) -> Arc<dyn OperatorState>
     where
         F: FnOnce() -> Arc<dyn OperatorState>,
     {
-        if let Some(state) = self.states.get(vertex_id) {
+        if let Some(state) = self.states.get(&vertex_id) {
             state.value().clone()
         } else {
             let new_state = factory();
-            let id: VertexId = Arc::<str>::from(vertex_id);
-            self.states.insert(id.clone(), new_state.clone());
-            if let Some(n) = self.notifies.get(vertex_id) {
+            self.states.insert(vertex_id.clone(), new_state.clone());
+            if let Some(n) = self.notifies.get(&vertex_id) {
                 n.notify_waiters();
             }
             new_state

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -32,6 +32,7 @@ use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, 
 // serde imports removed; this module does not define serializable DTOs directly.
 use crate::runtime::master_server::master_service::master_service_client::MasterServiceClient;
 use std::sync::atomic::AtomicBool;
+use crate::common::OperatorId;
 use crate::runtime::VertexId;
 use crate::runtime::watermark::WatermarkAssignConfig;
 use crate::runtime::watermark::WatermarkManager;
@@ -44,12 +45,12 @@ pub static MESSAGE_TRACE_ENABLED: AtomicBool = AtomicBool::new(false);
 pub(crate) struct CheckpointAligner {
     upstream_count: usize,
     current_checkpoint: Option<u64>,
-    seen_upstreams: HashSet<String>,
+    seen_upstreams: HashSet<VertexId>,
     reader_control: DataReaderControl,
 }
 
 impl CheckpointAligner {
-    pub(crate) fn new(upstream_vertices: &[String], reader_control: DataReaderControl) -> Self {
+    pub(crate) fn new(upstream_vertices: &[VertexId], reader_control: DataReaderControl) -> Self {
         Self {
             upstream_count: upstream_vertices.len(),
             current_checkpoint: None,
@@ -62,7 +63,6 @@ impl CheckpointAligner {
         let upstream_vertex_id = barrier
             .metadata
             .upstream_vertex_id
-            .clone()
             .expect("Barrier must have upstream vertex id");
 
         let checkpoint_id = barrier.checkpoint_id;
@@ -74,7 +74,7 @@ impl CheckpointAligner {
             return None;
         }
 
-        self.reader_control.block_upstream(&upstream_vertex_id);
+        self.reader_control.block_upstream(upstream_vertex_id);
         self.seen_upstreams.insert(upstream_vertex_id);
 
         if self.seen_upstreams.len() == self.upstream_count {
@@ -112,7 +112,7 @@ pub struct StreamTask {
     run_signal_sender: Option<watch::Sender<bool>>,
     close_signal_sender: Option<watch::Sender<bool>>,
     checkpoint_trigger_sender: Option<mpsc::UnboundedSender<u64>>,
-    upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>, // upstream_vertex_id -> watermark_value
+    upstream_watermarks: Arc<Mutex<HashMap<VertexId, u64>>>, // upstream_vertex_id -> watermark_value
     current_watermark: Arc<AtomicU64>,
     master_addr: Option<String>,
     restore_checkpoint_id: Option<u64>,
@@ -186,8 +186,7 @@ impl StreamTask {
         operator: &mut dyn OperatorTrait,
         master_client: &mut Option<MasterServiceClient<tonic::transport::Channel>>,
         restore_checkpoint_id: Option<u64>,
-        vertex_id: &str,
-        task_index: i32,
+        vertex_id: VertexId
     ) -> Result<()> {
         let Some(restore_checkpoint_id) = restore_checkpoint_id else {
             return Ok(());
@@ -198,13 +197,13 @@ impl StreamTask {
 
         println!(
             "[CHECKPOINT] {} task_index={} restoring from checkpoint_id={}",
-            vertex_id, task_index, restore_checkpoint_id
+            vertex_id, vertex_id.task_index(), restore_checkpoint_id
         );
 
         let req = crate::runtime::master_server::master_service::GetTaskCheckpointRequest {
             checkpoint_id: restore_checkpoint_id,
-            vertex_id: vertex_id.to_string(),
-            task_index,
+            vertex_id: vertex_id.raw(),
+            task_index: vertex_id.task_index() as i32,
         };
         let resp = client
             .get_task_checkpoint(tonic::Request::new(req))
@@ -241,13 +240,14 @@ impl StreamTask {
         labels: Option<&MetricsLabels>,
     ) {
         let is_control_message = matches!(message, Message::Watermark(_) | Message::CheckpointBarrier(_));
-        
+
         if !is_control_message {
+            let vid = vertex_id.to_string();
             if recv_or_send {
                 if let Some(labels) = labels {
                     counter!(
                         METRIC_STREAM_TASK_MESSAGES_RECV,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
+                        LABEL_VERTEX_ID => vid.clone(),
                         LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                         LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                         LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -255,7 +255,7 @@ impl StreamTask {
                     ).increment(1);
                     counter!(
                         METRIC_STREAM_TASK_RECORDS_RECV,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
+                        LABEL_VERTEX_ID => vid.clone(),
                         LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                         LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                         LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -263,18 +263,18 @@ impl StreamTask {
                     ).increment(message.num_records() as u64);
                     counter!(
                         METRIC_STREAM_TASK_BYTES_RECV,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
+                        LABEL_VERTEX_ID => vid.clone(),
                         LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                         LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                         LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
                         LABEL_WORKER_ID => labels.worker_id.clone()
                     ).increment(message.get_memory_size() as u64);
                 } else {
-                    counter!(METRIC_STREAM_TASK_MESSAGES_RECV, LABEL_VERTEX_ID => vertex_id.clone()).increment(1);
-                    counter!(METRIC_STREAM_TASK_RECORDS_RECV, LABEL_VERTEX_ID => vertex_id.clone()).increment(message.num_records() as u64);
-                    counter!(METRIC_STREAM_TASK_BYTES_RECV, LABEL_VERTEX_ID => vertex_id.clone()).increment(message.get_memory_size() as u64);
+                    counter!(METRIC_STREAM_TASK_MESSAGES_RECV, LABEL_VERTEX_ID => vid.clone()).increment(1);
+                    counter!(METRIC_STREAM_TASK_RECORDS_RECV, LABEL_VERTEX_ID => vid.clone()).increment(message.num_records() as u64);
+                    counter!(METRIC_STREAM_TASK_BYTES_RECV, LABEL_VERTEX_ID => vid.clone()).increment(message.get_memory_size() as u64);
                 }
-                
+
                 if let Some(ingest_timestamp) = message.ingest_timestamp() {
                     let current_time = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
@@ -284,7 +284,7 @@ impl StreamTask {
                     if let Some(labels) = labels {
                         histogram!(
                             METRIC_STREAM_TASK_LATENCY,
-                            LABEL_VERTEX_ID => vertex_id.clone(),
+                            LABEL_VERTEX_ID => vid.clone(),
                             LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                             LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -292,7 +292,7 @@ impl StreamTask {
                         )
                         .record(latency as f64);
                     } else {
-                        histogram!(METRIC_STREAM_TASK_LATENCY, LABEL_VERTEX_ID => vertex_id.clone())
+                        histogram!(METRIC_STREAM_TASK_LATENCY, LABEL_VERTEX_ID => vid.clone())
                             .record(latency as f64);
                     }
                 }
@@ -301,7 +301,7 @@ impl StreamTask {
                 if let Some(labels) = labels {
                     counter!(
                         METRIC_STREAM_TASK_MESSAGES_SENT,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
+                        LABEL_VERTEX_ID => vid.clone(),
                         LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                         LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                         LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -309,7 +309,7 @@ impl StreamTask {
                     ).increment(1);
                     counter!(
                         METRIC_STREAM_TASK_RECORDS_SENT,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
+                        LABEL_VERTEX_ID => vid.clone(),
                         LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                         LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                         LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -317,16 +317,16 @@ impl StreamTask {
                     ).increment(message.num_records() as u64);
                     counter!(
                         METRIC_STREAM_TASK_BYTES_SENT,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
+                        LABEL_VERTEX_ID => vid.clone(),
                         LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                         LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                         LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
                         LABEL_WORKER_ID => labels.worker_id.clone()
                     ).increment(message.get_memory_size() as u64);
                 } else {
-                    counter!(METRIC_STREAM_TASK_MESSAGES_SENT, LABEL_VERTEX_ID => vertex_id.clone()).increment(1);
-                    counter!(METRIC_STREAM_TASK_RECORDS_SENT, LABEL_VERTEX_ID => vertex_id.clone()).increment(message.num_records() as u64);
-                    counter!(METRIC_STREAM_TASK_BYTES_SENT, LABEL_VERTEX_ID => vertex_id.clone()).increment(message.get_memory_size() as u64);
+                    counter!(METRIC_STREAM_TASK_MESSAGES_SENT, LABEL_VERTEX_ID => vid.clone()).increment(1);
+                    counter!(METRIC_STREAM_TASK_RECORDS_SENT, LABEL_VERTEX_ID => vid.clone()).increment(message.num_records() as u64);
+                    counter!(METRIC_STREAM_TASK_BYTES_SENT, LABEL_VERTEX_ID => vid).increment(message.get_memory_size() as u64);
                 }
             }
         }
@@ -339,8 +339,8 @@ impl StreamTask {
         vertex_id: VertexId,
         operator_config: OperatorConfig,
         watermark_assign: Option<WatermarkAssignConfig>,
-        upstream_vertices: Vec<String>,
-        upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
+        upstream_vertices: Vec<VertexId>,
+        upstream_watermarks: Arc<Mutex<HashMap<VertexId, u64>>>,
         current_watermark: Arc<AtomicU64>,
         _status: Arc<AtomicU8>,
         mut aligner: CheckpointAligner,
@@ -356,7 +356,7 @@ impl StreamTask {
                 current_watermark.clone(),
             );
             while let Some(message) = input_stream.next().await {
-                Self::record_metrics(vertex_id.clone(), &message, true, labels.as_ref());
+                Self::record_metrics(vertex_id, &message, true, labels.as_ref());
 
                 match &message {
                     Message::Watermark(watermark) => {
@@ -367,7 +367,7 @@ impl StreamTask {
                         if let Some(new_watermark) = watermark_manager.merge_watermark(watermark.clone()).await {
                             let mut wm = watermark.clone();
                             wm.watermark_value = new_watermark;
-                            wm.metadata.upstream_vertex_id = Some(vertex_id.as_ref().to_string());
+                            wm.metadata.upstream_vertex_id = Some(vertex_id);
                             yield Message::Watermark(wm);
                         }
                     }
@@ -376,7 +376,7 @@ impl StreamTask {
                             // Once fully aligned, yield a single barrier downstream through the operator.
                             // StreamTask will intercept this barrier, do synchronous checkpointing, and forward it.
                             yield Message::CheckpointBarrier(crate::common::message::CheckpointBarrierMessage::new(
-                                vertex_id.as_ref().to_string(),
+                                vertex_id,
                                 checkpoint_id,
                                 None,
                             ));
@@ -387,15 +387,15 @@ impl StreamTask {
                         // then run it through the same min-upstream merge logic.
                         let upstream_for_msg = message
                             .upstream_vertex_id()
-                            .unwrap_or_else(|| vertex_id.as_ref().to_string());
-                        let injected = watermark_manager.on_data_message(&upstream_for_msg, &message);
+                            .unwrap_or(vertex_id);
+                        let injected = watermark_manager.on_data_message(upstream_for_msg, &message);
                         yield message;
                         if let Some(wm) = injected {
                             // Treat injected watermark exactly like an upstream watermark: merge and
                             // emit a task-local watermark only if it advances.
                             if let Some(new_watermark) = watermark_manager.merge_watermark(wm.clone()).await {
                                 yield Message::Watermark(WatermarkMessage::new(
-                                    vertex_id.as_ref().to_string(),
+                                    vertex_id,
                                     new_watermark,
                                     None,
                                 ));
@@ -409,7 +409,7 @@ impl StreamTask {
 
     // Helper function to send message to collectors (similar to original stream_task.rs)
     async fn send_to_collectors_if_needed(
-        mut collectors_per_target_operator: &mut HashMap<String, Collector>,
+        mut collectors_per_target_operator: &mut HashMap<OperatorId, Collector>,
         message: Message,
         vertex_id: VertexId,
         status: Arc<AtomicU8>
@@ -466,23 +466,23 @@ impl StreamTask {
     }
 
     pub async fn start(&mut self) {
-        let vertex_id = self.vertex_id.clone();
+        let vertex_id = self.vertex_id;
         let runtime_context = self.runtime_context.clone();
         let status = self.status.clone();
         let operator_config = self.operator_config.clone();
         let execution_graph = self.execution_graph.clone();
         let master_addr = self.master_addr.clone();
         let restore_checkpoint_id = self.restore_checkpoint_id;
-        
+
         let upstream_watermarks = self.upstream_watermarks.clone();
         let current_watermark = self.current_watermark.clone();
-        
-        let upstream_vertices: Vec<String> = execution_graph
-            .get_edges_for_vertex(vertex_id.as_ref())
+
+        let upstream_vertices: Vec<VertexId> = execution_graph
+            .get_edges_for_vertex(vertex_id)
             .map(|(input_edges, _)| {
                 input_edges
                     .iter()
-                    .map(|e| e.source_vertex_id.as_ref().to_string())
+                    .map(|e| e.edge_id.source())
                     .collect()
             })
             .unwrap_or_default();
@@ -502,18 +502,18 @@ impl StreamTask {
         let metrics_labels = self.metrics_labels.clone();
         let run_loop_handle = tokio::spawn(async move {
             let mut operator = create_operator(operator_config);
-            
-            let mut transport_client = TransportClient::new(vertex_id.clone(), transport_client_config);
-            
-            let mut collectors_per_target_operator: HashMap<String, Collector> = HashMap::new();
 
-            let (_, output_edges) = execution_graph.get_edges_for_vertex(&vertex_id).unwrap();
+            let mut transport_client = TransportClient::new(vertex_id, transport_client_config);
+
+            let mut collectors_per_target_operator: HashMap<OperatorId, Collector> = HashMap::new();
+
+            let (_, output_edges) = execution_graph.get_edges_for_vertex(vertex_id).unwrap();
             let num_output_edges = output_edges.len();
 
             for edge in output_edges {
                 let channel = edge.get_channel();
                 let partition_type = edge.partition_type.clone();
-                let target_operator_id = edge.target_operator_id.clone();
+                let target_operator_id = edge.edge_id.target().operator_id();
 
                 let writer = transport_client.writer.as_ref()
                     .unwrap_or_else(|| panic!("Writer not initialized"));
@@ -557,8 +557,7 @@ impl StreamTask {
                 &mut operator,
                 &mut master_client,
                 restore_checkpoint_id,
-                &vertex_id,
-                runtime_context.task_index(),
+                vertex_id
             )
             .await?;
 
@@ -581,7 +580,7 @@ impl StreamTask {
             let is_source = operator_type == OperatorType::Source || operator_type == OperatorType::ChainedSourceSink;
             let mut data_reader_control: Option<crate::transport::transport_client::DataReaderControl> = None;
             let vertex_meta = execution_graph
-                .get_vertex(&vertex_id)
+                .get_vertex(vertex_id)
                 .expect("vertex should exist in execution graph");
             let watermark_assign = vertex_meta.watermark_assign.clone();
             let vertex_operator_config = vertex_meta.operator_config.clone();
@@ -597,7 +596,7 @@ impl StreamTask {
                 assert!(
                     watermark_assign.is_none(),
                     "StreamTask {}: watermark_assign is not allowed in Batch execution mode",
-                    vertex_id.as_ref()
+                    vertex_id
                 );
             }
             let mut source_watermark_manager = if is_source {
@@ -623,7 +622,7 @@ impl StreamTask {
 
                 let preprocessed_stream = Self::create_preprocessed_input_stream(
                     input_stream,
-                    vertex_id.clone(),
+                    vertex_id,
                     vertex_operator_config.clone(),
                     watermark_assign.clone(),
                     upstream_vertices.clone(),
@@ -649,7 +648,7 @@ impl StreamTask {
                             );
                             Some(Message::CheckpointBarrier(
                                 crate::common::message::CheckpointBarrierMessage::new(
-                                    vertex_id.as_ref().to_string(),
+                                    vertex_id,
                                     checkpoint_id,
                                     None,
                                 ),
@@ -673,7 +672,7 @@ impl StreamTask {
                         let injected_wm = if is_source && matches!(message, Message::Regular(_) | Message::Keyed(_)) {
                             source_watermark_manager
                                 .as_mut()
-                                .and_then(|manager| manager.on_data_message(vertex_id.as_ref(), &message))
+                                .and_then(|manager| manager.on_data_message(vertex_id, &message))
                         } else {
                             None
                         };
@@ -698,8 +697,8 @@ impl StreamTask {
                                     .report_checkpoint(tonic::Request::new(
                                         crate::runtime::master_server::master_service::ReportCheckpointRequest {
                                             checkpoint_id,
-                                            vertex_id: vertex_id.as_ref().to_string(),
-                                            task_index: runtime_context.task_index(),
+                                            vertex_id: vertex_id.raw(),
+                                            task_index: runtime_context.task_index() as i32,
                                             blobs: blobs
                                                 .into_iter()
                                                 .map(|(name, bytes)| crate::runtime::master_server::master_service::StateBlob { name, bytes })
@@ -745,26 +744,26 @@ impl StreamTask {
                         }
                         
                         if MESSAGE_TRACE_ENABLED.load(Ordering::Relaxed) {
-                            message.append_trace(&vertex_id);
+                            message.append_trace(vertex_id);
                         }
 
                         // Set upstream vertex id for all messages before sending downstream
-                        message.set_upstream_vertex_id(vertex_id.as_ref().to_string());
-                        Self::record_metrics(vertex_id.clone(), &message, false, metrics_labels.as_ref());
+                        message.set_upstream_vertex_id(vertex_id);
+                        Self::record_metrics(vertex_id, &message, false, metrics_labels.as_ref());
 
                         // Send to collectors
                         Self::send_to_collectors_if_needed(
                             &mut collectors_per_target_operator,
                             message,
-                            vertex_id.clone(),
+                            vertex_id,
                             status.clone()
                         ).await;
 
                         if let Some(wm) = injected_wm {
                             let mut injected = Message::Watermark(wm);
-                            injected.set_upstream_vertex_id(vertex_id.as_ref().to_string());
+                            injected.set_upstream_vertex_id(vertex_id);
                             Self::record_metrics(
-                                vertex_id.clone(),
+                                vertex_id,
                                 &injected,
                                 false,
                                 metrics_labels.as_ref(),
@@ -772,7 +771,7 @@ impl StreamTask {
                             Self::send_to_collectors_if_needed(
                                 &mut collectors_per_target_operator,
                                 injected,
-                                vertex_id.clone(),
+                                vertex_id,
                                 status.clone(),
                             )
                             .await;
@@ -781,15 +780,15 @@ impl StreamTask {
                     OperatorPollResult::None => {
                         if is_source {
                             let wm = Message::Watermark(WatermarkMessage::new(
-                                vertex_id.as_ref().to_string(),
+                                vertex_id,
                                 MAX_WATERMARK_VALUE,
                                 None,
                             ));
-                            Self::record_metrics(vertex_id.clone(), &wm, false, metrics_labels.as_ref());
+                            Self::record_metrics(vertex_id, &wm, false, metrics_labels.as_ref());
                             Self::send_to_collectors_if_needed(
                                 &mut collectors_per_target_operator,
                                 wm,
-                                vertex_id.clone(),
+                                vertex_id,
                                 status.clone(),
                             )
                             .await;
@@ -798,7 +797,7 @@ impl StreamTask {
                         } else {
                             panic!(
                                 "StreamTask {}: upstream ended without terminal watermark",
-                                vertex_id.as_ref()
+                                vertex_id
                             );
                         }
                     }

--- a/src/runtime/tests/checkpoint_recovery_test.rs
+++ b/src/runtime/tests/checkpoint_recovery_test.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 
 use anyhow::Result;
 use datafusion::common::ScalarValue;
-use kameo::Reply;
 use crate::common::test_utils::gen_unique_grpc_port;
 use crate::runtime::master_server::master_service::master_service_client::MasterServiceClient;
 use crate::runtime::master_server::{MasterServer, TaskKey};

--- a/src/runtime/tests/checkpoint_recovery_test.rs
+++ b/src/runtime/tests/checkpoint_recovery_test.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use datafusion::common::ScalarValue;
+use kameo::Reply;
 use crate::common::test_utils::gen_unique_grpc_port;
 use crate::runtime::master_server::master_service::master_service_client::MasterServiceClient;
 use crate::runtime::master_server::{MasterServer, TaskKey};
@@ -20,6 +21,7 @@ use crate::runtime::operators::operator::operator_config_requires_checkpoint;
 // Watermark assigner placement is done by the planner (see LogicalGraph::to_execution_graph).
 
 use crate::runtime::tests::test_utils::{create_window_input_schema, wait_for_status, window_rows_from_messages};
+use crate::runtime::VertexId;
 use crate::runtime::watermark::{TimeHint, WatermarkAssignConfig};
 
 #[tokio::test]
@@ -96,7 +98,7 @@ async fn test_manual_checkpoint_and_restore() -> Result<()> {
     let lateness_ms: i64 = out_of_orderness_ms as i64;
     let vertex_ids_snapshot: Vec<_> = exec_graph1.get_vertices().keys().cloned().collect();
     for vid in vertex_ids_snapshot {
-        if let Some(v) = exec_graph1.get_vertex_mut(vid.as_ref()) {
+        if let Some(v) = exec_graph1.get_vertex_mut(vid) {
             if let OperatorConfig::WindowConfig(ref mut cfg) = v.operator_config {
                 cfg.spec.lateness = Some(lateness_ms);
             }
@@ -109,7 +111,7 @@ async fn test_manual_checkpoint_and_restore() -> Result<()> {
         .get_vertices()
         .values()
         .filter(|v| operator_config_requires_checkpoint(&v.operator_config))
-        .map(|v| TaskKey { vertex_id: v.vertex_id.as_ref().to_string(), task_index: v.task_index })
+        .map(|v| TaskKey { vertex_id: v.vertex_id })
         .collect::<Vec<_>>();
     master_server
         .set_checkpointable_tasks(expected_tasks.clone())
@@ -117,11 +119,11 @@ async fn test_manual_checkpoint_and_restore() -> Result<()> {
     master_server.start(&master_addr).await?;
 
     // Track all window vertices for state verification (parallelism > 1 => multiple task vertices)
-    let window_vertex_ids: Vec<String> = exec_graph1
+    let window_vertex_ids: Vec<VertexId> = exec_graph1
         .get_vertices()
         .values()
         .filter(|v| matches!(v.operator_config, OperatorConfig::WindowConfig(_)))
-        .map(|v| v.vertex_id.as_ref().to_string())
+        .map(|v| v.vertex_id)
         .collect();
 
     // Start worker #1
@@ -162,14 +164,14 @@ async fn test_manual_checkpoint_and_restore() -> Result<()> {
     }
 
     // Fetch checkpointed state for all checkpointable vertices from master for later comparison.
-    let mut checkpointed_window_key_counts: HashMap<String, usize> = HashMap::new();
+    let mut checkpointed_window_key_counts: HashMap<VertexId, usize> = HashMap::new();
     for task in &expected_tasks {
         let resp = master_client
             .get_task_checkpoint(tonic::Request::new(
                 crate::runtime::master_server::master_service::GetTaskCheckpointRequest {
                     checkpoint_id: 1,
-                    vertex_id: task.vertex_id.clone(),
-                    task_index: task.task_index,
+                    vertex_id: task.vertex_id.raw(),
+                    task_index: task.vertex_id.task_index() as i32,
                 },
             ))
             .await?
@@ -215,7 +217,7 @@ async fn test_manual_checkpoint_and_restore() -> Result<()> {
     let mut exec_graph2 = logical_graph.to_execution_graph();
     let vertex_ids_snapshot: Vec<_> = exec_graph2.get_vertices().keys().cloned().collect();
     for vid in vertex_ids_snapshot {
-        if let Some(v) = exec_graph2.get_vertex_mut(vid.as_ref()) {
+        if let Some(v) = exec_graph2.get_vertex_mut(vid) {
             if let OperatorConfig::WindowConfig(ref mut cfg) = v.operator_config {
                 cfg.spec.lateness = Some(lateness_ms);
             }
@@ -247,7 +249,7 @@ async fn test_manual_checkpoint_and_restore() -> Result<()> {
             .unwrap_or_else(|| panic!("missing checkpointed window key count for {}", window_vertex_id));
 
         let state_any = op_states
-            .get_operator_state(window_vertex_id)
+            .get_operator_state(*window_vertex_id)
             .unwrap_or_else(|| panic!("Expected window operator state to be registered for {}", window_vertex_id));
 
         let window_state = state_any

--- a/src/runtime/tests/distributed_execution_test.rs
+++ b/src/runtime/tests/distributed_execution_test.rs
@@ -11,6 +11,7 @@ use anyhow::Result;
 use tokio::runtime::Runtime;
 use arrow::array::StringArray;
 use async_trait::async_trait;
+use crate::common::{OperatorTypeCode, VertexId};
 
 #[derive(Debug, Clone)]
 struct KeyedToRegularMapFunction;
@@ -64,7 +65,7 @@ fn test_distributed_execution() -> Result<()> {
         
         // Add max watermark as the last message
         source_messages.push(Message::Watermark(WatermarkMessage::new(
-            "source".to_string(),
+            VertexId::new(OperatorTypeCode::Map, 1, 1),
             MAX_WATERMARK_VALUE,
             None,
         )));

--- a/src/runtime/tests/request_execution_mode_test.rs
+++ b/src/runtime/tests/request_execution_mode_test.rs
@@ -154,7 +154,7 @@ async fn wait_for_task_prefix_status(
         let mut all_match = true;
 
         for (vertex_id, task_status) in &st.task_statuses {
-            if vertex_id.starts_with(prefix) {
+            if vertex_id.to_string().starts_with(prefix) {
                 matched = true;
                 if *task_status != status {
                     all_match = false;
@@ -269,7 +269,7 @@ async fn test_request_execution_mode() {
     wait_for_request_server(&request_source_config.spec.bind_address, Duration::from_secs(5)).await;
     wait_for_task_prefix_status(
         &worker,
-        "Source(HttpRequest)_1",
+        "SourceHttpRequest.1",
         StreamTaskStatus::Running,
         Duration::from_secs(5),
     )

--- a/src/runtime/tests/stream_task_actor_test.rs
+++ b/src/runtime/tests/stream_task_actor_test.rs
@@ -54,7 +54,7 @@ fn test_stream_task_actor() -> Result<()> {
         // Non-source tasks only finish when they receive a terminal watermark from upstream.
         // With strict upstream tracking, the watermark must carry the true upstream vertex id.
         test_messages.push(Message::Watermark(WatermarkMessage::new(
-            input_vertex_id.as_ref().to_string(),
+            input_vertex_id,
             MAX_WATERMARK_VALUE,
             None,
         )));
@@ -63,10 +63,9 @@ fn test_stream_task_actor() -> Result<()> {
         let task = StreamTask::new(
             task_vertex_id.clone(),
             OperatorConfig::MapConfig(MapFunction::new_custom(IdentityMapFunction)),
-            configs.remove(task_vertex_id.as_ref()).unwrap(),
+            configs.remove(&task_vertex_id).unwrap(),
             RuntimeContext::new(
                 task_vertex_id.clone(),
-                0,
                 1,
                 None,
                 None,
@@ -80,8 +79,8 @@ fn test_stream_task_actor() -> Result<()> {
         let backend_ref = spawn(backend_actor);
 
         // Create external writer and reader actors
-        let input_actor = TestDataWriterActor::new(input_vertex_id.clone(), configs.remove(input_vertex_id.as_ref()).unwrap());
-        let output_actor = TestDataReaderActor::new(output_vertex_id.clone(), configs.remove(output_vertex_id.as_ref()).unwrap());
+        let input_actor = TestDataWriterActor::new(input_vertex_id.clone(), configs.remove(&input_vertex_id).unwrap());
+        let output_actor = TestDataReaderActor::new(output_vertex_id.clone(), configs.remove(&output_vertex_id).unwrap());
         let task_actor = StreamTaskActor::new(task);
 
         let input_ref = spawn(input_actor);
@@ -102,8 +101,8 @@ fn test_stream_task_actor() -> Result<()> {
             // let channel_id = gen_channel_id(&input_vertex_id, &task_vertex_id);
             // Channel ids are protocol strings.
             let channel = Channel::new_local(
-                input_vertex_id.as_ref().to_string(),
-                task_vertex_id.as_ref().to_string(),
+                input_vertex_id.clone(),
+                task_vertex_id.clone(),
             );
             input_ref.ask(crate::transport::test_utils::TestDataWriterMessage::WriteMessage {
                 channel,

--- a/src/runtime/tests/test_utils.rs
+++ b/src/runtime/tests/test_utils.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use arrow::array::{Float64Array, StringArray, TimestampMillisecondArray};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
-
+use crate::common::VertexId;
 use crate::runtime::observability::snapshot_types::StreamTaskStatus;
 use crate::runtime::worker::Worker;
 
@@ -32,18 +32,13 @@ pub async fn wait_for_status(worker: &Worker, status: StreamTaskStatus, timeout:
 #[derive(Debug, Clone)]
 pub struct WindowOutputRow {
     pub trace: Option<String>,
-    pub upstream_vertex_id: Option<String>,
-    pub upstream_task_index: Option<i32>,
+    pub upstream_vertex_id: Option<VertexId>,
     pub timestamp_ms: i64,
     pub partition_key: String,
     pub value: f64,
     pub sum: f64,
     pub cnt: i64,
     pub avg: f64,
-}
-
-pub fn parse_task_index_from_vertex_id(vertex_id: &str) -> Option<i32> {
-    vertex_id.rsplit('_').next()?.parse::<i32>().ok()
 }
 
 pub fn window_rows_from_messages(messages: Vec<crate::common::message::Message>) -> Vec<WindowOutputRow> {
@@ -54,8 +49,8 @@ pub fn window_rows_from_messages(messages: Vec<crate::common::message::Message>)
 
         let upstream_vertex_id = msg.upstream_vertex_id();
         let upstream_task_index = upstream_vertex_id
-            .as_deref()
-            .and_then(parse_task_index_from_vertex_id);
+            .unwrap()
+            .task_index();
 
         let batch = msg.record_batch();
         let ts = batch
@@ -93,7 +88,6 @@ pub fn window_rows_from_messages(messages: Vec<crate::common::message::Message>)
             out.push(WindowOutputRow {
                 trace: trace.clone(),
                 upstream_vertex_id: upstream_vertex_id.clone(),
-                upstream_task_index,
                 timestamp_ms: ts.value(i),
                 partition_key: key.value(i).to_string(),
                 value: val.value(i),

--- a/src/runtime/tests/watermark_streaming_e2e_test.rs
+++ b/src/runtime/tests/watermark_streaming_e2e_test.rs
@@ -123,7 +123,7 @@ pub(crate) async fn run_watermark_window_pipeline(
     // Set lateness directly on the execution graph for this test (PipelineContext/LogicalGraph stay unaware).
     let vertex_ids_snapshot: Vec<_> = exec_graph.get_vertices().keys().cloned().collect();
     for vid in vertex_ids_snapshot {
-        if let Some(v) = exec_graph.get_vertex_mut(vid.as_ref()) {
+        if let Some(v) = exec_graph.get_vertex_mut(vid) {
             if let OperatorConfig::WindowConfig(ref mut cfg) = v.operator_config {
                 cfg.spec.lateness = Some(lateness_ms);
             }

--- a/src/runtime/tests/window_operator_benchmark.rs
+++ b/src/runtime/tests/window_operator_benchmark.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::{ExecutionMode, ExecutionProfile, PipelineContext, PipelineSpecBuilder},
     api::compile_logical_graph,
+    common::{OperatorId, OperatorTypeCode},
     common::test_utils::{gen_unique_grpc_port, print_pipeline_state},
     runtime::{
         functions::source::datagen_source::{DatagenSourceConfig, FieldGenerator},
@@ -172,7 +173,7 @@ fn update_window_configs_in_graph(
     let window_nodes: Vec<NodeIndex> = graph
         .get_nodes()
         .filter(|node| matches!(node.operator_config, OperatorConfig::WindowConfig(_)))
-        .map(|node| graph.get_node_index(&node.operator_id).unwrap())
+        .map(|node| graph.get_node_index(node.operator_id).unwrap())
         .collect();
     
     for node_idx in window_nodes {
@@ -332,13 +333,13 @@ pub async fn run_window_benchmark(config: WindowBenchmarkConfig) -> Result<Bench
                             println!("[{}] Worker State", timestamp);
                             
                             // Find window operator IDs
-                            let window_operator_ids: Vec<String> = pipeline_state.worker_states
+                            let window_operator_ids: Vec<OperatorId> = pipeline_state.worker_states
                                 .values()
                                 .flat_map(|ws| {
                                     ws.worker_metrics.as_ref()
                                         .map(|wm| {
                                             wm.operator_metrics.keys()
-                                                .filter(|id| id.starts_with("Window_"))
+                                                .filter(|id| id.op_type() == OperatorTypeCode::Window)
                                                 .cloned()
                                                 .collect::<Vec<_>>()
                                         })

--- a/src/runtime/tests/window_request_operator_benchmark.rs
+++ b/src/runtime/tests/window_request_operator_benchmark.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use datafusion::common::ScalarValue;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
+use crate::common::{OperatorId, OperatorTypeCode};
 
 fn create_datagen_config(
     rate: Option<f32>,
@@ -229,7 +230,7 @@ pub async fn run_window_request_benchmark(
                     
                     print_pipeline_state(
                         &pipeline_state, 
-                        Some(&["Window_1".to_string()]), 
+                        Some(&[OperatorId::new(OperatorTypeCode::Window, 1)]),
                         true, 
                         false,
                         Some(&history),

--- a/src/runtime/tests/word_count_benchmark.rs
+++ b/src/runtime/tests/word_count_benchmark.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::{ExecutionProfile, PipelineContext, PipelineSpecBuilder},
     api::compile_logical_graph,
+    common::OperatorId,
     common::test_utils::{gen_unique_grpc_port, print_pipeline_state},
     runtime::{
         functions::source::word_count_source::BatchingMode,
@@ -114,8 +115,8 @@ async fn poll_pipeline_state_updates(
     benchmark_metrics: &mut BenchmarkMetrics,
     last_metrics: &mut Option<(u64, u64)>, // (messages, records)
     last_timestamp: &mut Instant,
-    source_operator_id: String,
-    sink_operator_id: String,
+    source_operator_id: OperatorId,
+    sink_operator_id: OperatorId,
 ) -> Option<PipelineSnapshot> {
     let current_time = Instant::now();
     let pipeline_state = match state_updates_receiver.recv().await {

--- a/src/runtime/tests/worker_test.rs
+++ b/src/runtime/tests/worker_test.rs
@@ -10,6 +10,8 @@ use anyhow::Result;
 use tokio::runtime::Runtime;
 use arrow::datatypes::{Schema, Field, DataType};
 use std::sync::Arc;
+use crate::common::OperatorTypeCode;
+use crate::runtime::VertexId;
 
 // TODO test early worker interruption/shutdown via setting state to finished from outside
 #[test]
@@ -24,7 +26,7 @@ fn test_worker_execution() -> Result<()> {
 
     let mut test_messages = expected_messages.clone();
     test_messages.push(Message::Watermark(WatermarkMessage::new(
-        "source".to_string(),
+        VertexId::new(OperatorTypeCode::Map, 1, 1),
         MAX_WATERMARK_VALUE,
         None,
     )));

--- a/src/runtime/watermark/manager.rs
+++ b/src/runtime/watermark/manager.rs
@@ -11,7 +11,7 @@ use crate::common::message::{Message, WatermarkMessage};
 use crate::runtime::operators::operator::OperatorConfig;
 
 use datafusion::physical_plan::expressions::Column;
-
+use crate::runtime::VertexId;
 use super::confg::{TimeHint, WatermarkAssignConfig};
 
 #[derive(Debug, Clone)]
@@ -34,7 +34,7 @@ struct UpstreamWatermarkProgress {
 pub struct WatermarkAssignerState {
     out_of_orderness_ms: u64,
     ts_column: TsColumnSpec,
-    per_upstream: HashMap<String, UpstreamWatermarkProgress>,
+    per_upstream: HashMap<VertexId, UpstreamWatermarkProgress>,
 }
 
 impl WatermarkAssignerState {
@@ -135,7 +135,7 @@ impl WatermarkAssignerState {
 
     pub fn on_data_message(
         &mut self,
-        upstream_vertex_id: &str,
+        upstream_vertex_id: VertexId,
         message: &Message,
     ) -> Option<WatermarkMessage> {
         let batch = message.record_batch();
@@ -146,7 +146,7 @@ impl WatermarkAssignerState {
 
         let progress = self
             .per_upstream
-            .entry(upstream_vertex_id.to_string())
+            .entry(upstream_vertex_id)
             .or_default();
 
         progress.max_event_time_seen_ms = progress.max_event_time_seen_ms.max(batch_max);
@@ -157,7 +157,7 @@ impl WatermarkAssignerState {
         if candidate > progress.last_emitted_wm_ms {
             progress.last_emitted_wm_ms = candidate;
             Some(WatermarkMessage::new(
-                upstream_vertex_id.to_string(),
+                upstream_vertex_id,
                 candidate,
                 None,
             ))
@@ -170,9 +170,9 @@ impl WatermarkAssignerState {
 #[derive(Debug)]
 pub struct WatermarkManager {
     idle_timeout_ms: Option<u64>,
-    upstream_vertices: Vec<String>,
-    last_seen_processing_time: HashMap<String, Instant>,
-    upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
+    upstream_vertices: Vec<VertexId>,
+    last_seen_processing_time: HashMap<VertexId, Instant>,
+    upstream_watermarks: Arc<Mutex<HashMap<VertexId, u64>>>,
     current_watermark: Arc<AtomicU64>,
     assigner: Option<WatermarkAssignerState>,
 }
@@ -181,15 +181,15 @@ impl WatermarkManager {
     pub fn new(
         watermark_assign: Option<WatermarkAssignConfig>,
         operator_config: Option<&OperatorConfig>,
-        upstream_vertices: Vec<String>,
-        upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
+        upstream_vertices: Vec<VertexId>,
+        upstream_watermarks: Arc<Mutex<HashMap<VertexId, u64>>>,
         current_watermark: Arc<AtomicU64>,
     ) -> Self {
         let idle_timeout_ms = watermark_assign.as_ref().and_then(|cfg| cfg.idle_timeout_ms);
         let assigner = watermark_assign.map(|cfg| WatermarkAssignerState::new(cfg, operator_config));
         let last_seen_processing_time = upstream_vertices
             .iter()
-            .map(|u| (u.clone(), Instant::now()))
+            .map(|u| (*u, Instant::now()))
             .collect();
         Self {
             idle_timeout_ms,
@@ -205,18 +205,18 @@ impl WatermarkManager {
         self.assigner.is_some()
     }
 
-    pub fn on_data_message(&mut self, upstream_vertex_id: &str, message: &Message) -> Option<WatermarkMessage> {
+    pub fn on_data_message(&mut self, upstream_vertex_id: VertexId, message: &Message) -> Option<WatermarkMessage> {
         self.last_seen_processing_time
-            .insert(upstream_vertex_id.to_string(), Instant::now());
+            .insert(upstream_vertex_id, Instant::now());
         self.assigner
             .as_mut()
             .and_then(|assigner| assigner.on_data_message(upstream_vertex_id, message))
     }
 
     pub async fn merge_watermark(&mut self, watermark: WatermarkMessage) -> Option<u64> {
-        if let Some(upstream_id) = watermark.metadata.upstream_vertex_id.as_ref() {
+        if let Some(upstream_id) = watermark.metadata.upstream_vertex_id {
             self.last_seen_processing_time
-                .insert(upstream_id.clone(), Instant::now());
+                .insert(upstream_id, Instant::now());
         }
         let active_upstreams = self.active_upstreams(Instant::now());
         advance_watermark_min(
@@ -228,7 +228,7 @@ impl WatermarkManager {
         .await
     }
 
-    fn active_upstreams(&self, now: Instant) -> Vec<String> {
+    fn active_upstreams(&self, now: Instant) -> Vec<VertexId> {
         if let Some(timeout_ms) = self.idle_timeout_ms {
             let timeout = Duration::from_millis(timeout_ms);
             self.upstream_vertices
@@ -239,7 +239,7 @@ impl WatermarkManager {
                         .map(|t| now.duration_since(*t) <= timeout)
                         .unwrap_or(false)
                 })
-                .cloned()
+                .copied()
                 .collect()
         } else {
             self.upstream_vertices.clone()
@@ -252,8 +252,8 @@ impl WatermarkManager {
 /// Returns `Some(new_watermark_value)` when the task watermark advanced, otherwise `None`.
 pub async fn advance_watermark_min(
     watermark: WatermarkMessage,
-    active_upstreams: &[String],
-    upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
+    active_upstreams: &[VertexId],
+    upstream_watermarks: Arc<Mutex<HashMap<VertexId, u64>>>,
     current_watermark: Arc<AtomicU64>,
 ) -> Option<u64> {
     // Sources (no incoming edges): just advance monotonically.
@@ -269,7 +269,6 @@ pub async fn advance_watermark_min(
     let upstream_id = watermark
         .metadata
         .upstream_vertex_id
-        .clone()
         .unwrap_or_else(|| panic!("Watermark must have upstream_vertex_id set: {:?}", watermark));
 
     let mut upstream_wms = upstream_watermarks.lock().await;
@@ -315,11 +314,16 @@ mod tests {
     use futures::stream;
     use futures::StreamExt;
 
-        use crate::runtime::observability::snapshot_types::StreamTaskStatus;
-        use crate::runtime::stream_task::{CheckpointAligner, StreamTask};
+    use crate::common::ids::{OperatorTypeCode, VertexId as VId};
+    use crate::runtime::observability::snapshot_types::StreamTaskStatus;
+    use crate::runtime::stream_task::{CheckpointAligner, StreamTask};
     use crate::transport::transport_client::DataReaderControl;
     use std::sync::atomic::AtomicU8;
     use std::time::Duration;
+
+    fn vid(instance: u8, parallel: u16) -> VId {
+        VId::new(OperatorTypeCode::Map, instance, parallel)
+    }
 
     #[test]
     fn assigner_tracks_per_upstream_independently() {
@@ -346,12 +350,14 @@ mod tests {
         };
         let mut assigner = WatermarkAssignerState::new(cfg, None);
 
-        let wm1 = assigner.on_data_message("upA", &msg).unwrap();
-        assert_eq!(wm1.metadata.upstream_vertex_id.as_deref(), Some("upA"));
+        let up_a = vid(1, 0);
+        let up_b = vid(2, 0);
+        let wm1 = assigner.on_data_message(up_a, &msg).unwrap();
+        assert_eq!(wm1.metadata.upstream_vertex_id, Some(up_a));
         assert_eq!(wm1.watermark_value, 100);
 
-        let wm2 = assigner.on_data_message("upB", &msg).unwrap();
-        assert_eq!(wm2.metadata.upstream_vertex_id.as_deref(), Some("upB"));
+        let wm2 = assigner.on_data_message(up_b, &msg).unwrap();
+        assert_eq!(wm2.metadata.upstream_vertex_id, Some(up_b));
         assert_eq!(wm2.watermark_value, 100);
     }
 
@@ -379,9 +385,11 @@ mod tests {
         )
         .unwrap();
 
+        let u0 = vid(1, 0);
+        let v0 = vid(10, 0);
         let input = Box::pin(stream::iter(vec![
-            Message::new(Some("u0".to_string()), b1, None, None),
-            Message::new(Some("u0".to_string()), b2, None, None),
+            Message::new(Some(u0), b1, None, None),
+            Message::new(Some(u0), b2, None, None),
         ]));
 
         let cfg = WatermarkAssignConfig::new(
@@ -393,16 +401,16 @@ mod tests {
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
-            Arc::<str>::from("v0"),
+            v0,
             OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
                 crate::common::test_utils::IdentityMapFunction,
             )),
             Some(cfg),
-            vec!["u0".to_string()],
+            vec![u0],
             Arc::new(Mutex::new(HashMap::new())),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU8::new(StreamTaskStatus::Running as u8)),
-            CheckpointAligner::new(&["u0".to_string()], DataReaderControl::empty_for_test()),
+            CheckpointAligner::new(&[u0], DataReaderControl::empty_for_test()),
             None,
         );
 
@@ -453,8 +461,11 @@ mod tests {
         )
         .unwrap();
 
-        let m0 = Message::new(Some("u0".to_string()), b_u0, None, None);
-        let m1 = Message::new(Some("u1".to_string()), b_u1, None, None);
+        let u0 = vid(1, 0);
+        let u1 = vid(2, 0);
+        let v0 = vid(10, 0);
+        let m0 = Message::new(Some(u0), b_u0, None, None);
+        let m1 = Message::new(Some(u1), b_u1, None, None);
 
         let input = Box::pin(stream::iter(vec![m0, m1]));
         let cfg = WatermarkAssignConfig::new(
@@ -466,17 +477,17 @@ mod tests {
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
-            Arc::<str>::from("v0"),
+            v0,
             OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
                 crate::common::test_utils::IdentityMapFunction,
             )),
             Some(cfg),
-            vec!["u0".to_string(), "u1".to_string()],
+            vec![u0, u1],
             Arc::new(Mutex::new(HashMap::new())),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU8::new(StreamTaskStatus::Running as u8)),
             CheckpointAligner::new(
-                &["u0".to_string(), "u1".to_string()],
+                &[u0, u1],
                 DataReaderControl::empty_for_test(),
             ),
             None,
@@ -514,9 +525,12 @@ mod tests {
         )
         .unwrap();
 
+        let u0 = vid(1, 0);
+        let u1 = vid(2, 0);
+        let v0 = vid(10, 0);
         let input = Box::pin(async_stream::stream! {
             tokio::time::sleep(Duration::from_millis(5)).await;
-            yield Message::new(Some("u0".to_string()), batch, None, None);
+            yield Message::new(Some(u0), batch, None, None);
         });
 
         let mut cfg = WatermarkAssignConfig::new(
@@ -529,17 +543,17 @@ mod tests {
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
-            Arc::<str>::from("v0"),
+            v0,
             OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
                 crate::common::test_utils::IdentityMapFunction,
             )),
             Some(cfg),
-            vec!["u0".to_string(), "u1".to_string()],
+            vec![u0, u1],
             Arc::new(Mutex::new(HashMap::new())),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU8::new(StreamTaskStatus::Running as u8)),
             CheckpointAligner::new(
-                &["u0".to_string(), "u1".to_string()],
+                &[u0, u1],
                 DataReaderControl::empty_for_test(),
             ),
             None,
@@ -570,9 +584,12 @@ mod tests {
         )
         .unwrap();
 
+        let u0 = vid(1, 0);
+        let u1 = vid(2, 0);
+        let v0 = vid(10, 0);
         let input = Box::pin(async_stream::stream! {
             tokio::time::sleep(Duration::from_millis(5)).await;
-            yield Message::new(Some("u0".to_string()), batch, None, None);
+            yield Message::new(Some(u0), batch, None, None);
         });
 
         let mut cfg = WatermarkAssignConfig::new(
@@ -585,17 +602,17 @@ mod tests {
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
-            Arc::<str>::from("v0"),
+            v0,
             OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
                 crate::common::test_utils::IdentityMapFunction,
             )),
             Some(cfg),
-            vec!["u0".to_string(), "u1".to_string()],
+            vec![u0, u1],
             Arc::new(Mutex::new(HashMap::new())),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU8::new(StreamTaskStatus::Running as u8)),
             CheckpointAligner::new(
-                &["u0".to_string(), "u1".to_string()],
+                &[u0, u1],
                 DataReaderControl::empty_for_test(),
             ),
             None,

--- a/src/runtime/worker.rs
+++ b/src/runtime/worker.rs
@@ -221,7 +221,7 @@ impl Worker {
             .into_iter()
             .map(|(k, v)| (k, v))
             .collect();
-        let worker_metrics = WorkerAggregateMetrics::new(worker_id, execution_ids, task_metrics_str, &graph);
+        let worker_metrics = WorkerAggregateMetrics::new(worker_id, execution_ids, task_metrics_str);
         worker_metrics.record();
         emit_poll_derived_gauges(&worker_metrics);
 

--- a/src/runtime/worker.rs
+++ b/src/runtime/worker.rs
@@ -209,7 +209,7 @@ impl Worker {
                 task_statuses.insert(vertex_id.clone(), state.status.clone());
                 task_metrics.insert(vertex_id.clone(), state.metrics.clone());
 
-                if let Some(op_state) = operator_states.get_operator_state(vertex_id.as_ref()) {
+                if let Some(op_state) = operator_states.get_operator_state(vertex_id.clone()) {
                     if let Some(m) = op_state.task_operator_metrics() {
                         task_operator_metrics.insert(vertex_id.clone(), m);
                     }
@@ -217,9 +217,9 @@ impl Worker {
             }
         }
 
-        let task_metrics_str: HashMap<String, TaskMetrics> = task_metrics
+        let task_metrics_str: HashMap<VertexId, TaskMetrics> = task_metrics
             .into_iter()
-            .map(|(k, v)| (k.as_ref().to_string(), v))
+            .map(|(k, v)| (k, v))
             .collect();
         let worker_metrics = WorkerAggregateMetrics::new(worker_id, execution_ids, task_metrics_str, &graph);
         worker_metrics.record();
@@ -308,7 +308,7 @@ impl Worker {
         for vertex_id in &vertex_ids {
             let vertex = self
                 .graph
-                .get_vertex(vertex_id.as_ref())
+                .get_vertex(*vertex_id)
                 .expect("Vertex should exist");
             let task_runtime = self.task_runtimes.get(vertex_id).expect("Task runtime should exist");
 
@@ -331,8 +331,7 @@ impl Worker {
             // Create runtime context for the vertex
             let mut runtime_context = RuntimeContext::new(
                 vertex_id.clone(),
-                vertex.task_index,
-                vertex.parallelism,
+                vertex.parallelism as u16,
                 {
                     let mut cfg = HashMap::<String, Value>::new();
                     if let Some(master_addr) = &self.master_addr {
@@ -506,7 +505,7 @@ impl Worker {
 
     async fn send_signal_to_task_actors(&mut self, signal: StreamTaskMessage) {
         println!("[WORKER] Sending {:?} signal to all task actors", signal);
-        
+
         for (vertex_id, runtime) in &self.task_runtimes {
             let vertex_id = vertex_id.clone();
             let task_ref = self.task_actors.get(&vertex_id).unwrap().clone();
@@ -599,14 +598,14 @@ impl Worker {
     pub async fn trigger_checkpoint(&mut self, checkpoint_id: u64) {
         println!("[WORKER] Triggering checkpoint {} on source tasks", checkpoint_id);
         for (vertex_id, runtime) in &self.task_runtimes {
-            let vertex_id = vertex_id.clone();
-            let vertex_type = self.graph.get_vertex_type(vertex_id.as_ref());
+            let vertex_id = *vertex_id;
+            let vertex_type = self.graph.get_vertex_type(vertex_id);
             if vertex_type != OperatorType::Source && vertex_type != OperatorType::ChainedSourceSink {
                 continue;
             }
 
             // Only trigger sources that actually participate in checkpointing.
-            if let Some(v) = self.graph.get_vertices().get(vertex_id.as_ref()) {
+            if let Some(v) = self.graph.get_vertices().get(&vertex_id) {
                 if !operator_config_requires_checkpoint(&v.operator_config) {
                     continue;
                 }

--- a/src/sql_testing/sql_tests.rs
+++ b/src/sql_testing/sql_tests.rs
@@ -12,6 +12,7 @@ use arrow::{
     record_batch::RecordBatch
 };
 use std::sync::Arc;
+use crate::common::{OperatorTypeCode, VertexId};
 
 /// Test case definition for SQL queries
 #[derive(Debug)]
@@ -486,7 +487,7 @@ async fn run_sql_test_case(test_case: &SqlTestCase) -> Result<()> {
         .collect();
     
     test_messages.push(Message::Watermark(WatermarkMessage::new(
-        "source".to_string(),
+        VertexId::new(OperatorTypeCode::Map, 1, 1),
         MAX_WATERMARK_VALUE,
         None,
     )));

--- a/src/storage/compactor/compactor.rs
+++ b/src/storage/compactor/compactor.rs
@@ -1055,6 +1055,7 @@ mod tests {
     use arrow::array::StringArray;
     use arrow::array::TimestampMillisecondArray;
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use crate::common::{OperatorTypeCode, VertexId};
     use crate::runtime::operators::window::BucketIndex;
     use crate::runtime::operators::window::TimeGranularity;
     use crate::storage::batch_store::InMemBatchStore;
@@ -1116,7 +1117,7 @@ mod tests {
 
         let arc = Arc::new(RwLock::new(ws));
         compactor
-            .compact_bucket(&key, &arc, Arc::<str>::from("t"), bucket_ts, 0)
+            .compact_bucket(&key, &arc, VertexId::new(OperatorTypeCode::Map, 1, 1), bucket_ts, 0)
             .await;
 
         assert!(in_mem.get(old_id1).is_none());
@@ -1161,7 +1162,7 @@ mod tests {
             .dump_bucket(
                 &key,
                 &arc,
-                Arc::<str>::from("t"),
+                VertexId::new(OperatorTypeCode::Map, 1, 1),
                 bucket_ts,
                 0,
                 DumpMode::KeepHot,

--- a/src/storage/sorted_range_view_loader.rs
+++ b/src/storage/sorted_range_view_loader.rs
@@ -103,6 +103,14 @@ pub fn plan_load_from_index(bucket_index: &BucketIndex, plans: &[RangesLoadPlan]
                         DataBounds::All => {}
                     }
 
+                    // Dedup: same run may be referenced from both base (hot_base or persisted)
+                    // and hot_deltas during compactor tier transitions. Skip if we've already
+                    // accounted for it in this bucket — otherwise the loaded SortedRangeView
+                    // would contain duplicate segments and violate disjoint/ordered invariants.
+                    if !seen_runs.insert((bucket.timestamp, meta.run)) {
+                        continue;
+                    }
+
                     match meta.run {
                         BatchRef::Stored(id) => {
                             batch_ids_to_load.insert(id);
@@ -349,7 +357,7 @@ mod tests {
     use arrow::array::{Float64Array, StringArray, TimestampMillisecondArray, UInt64Array};
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use arrow::record_batch::RecordBatch;
-
+    use crate::common::{OperatorTypeCode, VertexId};
     use crate::runtime::operators::window::TimeGranularity;
     use crate::runtime::operators::window::aggregates::{BucketRange, test_utils};
     use crate::storage::batch_store::{BatchStore, BatchId, InMemBatchStore};
@@ -501,7 +509,7 @@ mod tests {
 
         let store = Arc::new(InMemBatchStore::new(8, TimeGranularity::Seconds(1), 16)) as Arc<dyn BatchStore>;
         store
-            .put_batch_with_id(Arc::<str>::from("t"), batch_id, stored_batch.clone(), &key)
+            .put_batch_with_id(VertexId::new(OperatorTypeCode::Map, 1, 1), batch_id, stored_batch.clone(), &key)
             .await;
 
         let mut idx = BucketIndex::new(TimeGranularity::Seconds(1));
@@ -538,7 +546,7 @@ mod tests {
             pins,
             work_budget.clone(),
             &in_mem,
-            Arc::<str>::from("t"),
+            VertexId::new(OperatorTypeCode::Map, 1, 1),
             &key,
             0,
             2,
@@ -575,10 +583,10 @@ mod tests {
         let store_dyn: Arc<dyn BatchStore> = store.clone();
 
         store_dyn
-            .put_batch_with_id(Arc::<str>::from("t"), id_known, make_batch(0, 0), &key)
+            .put_batch_with_id(VertexId::new(OperatorTypeCode::Map, 1, 1), id_known, make_batch(0, 0), &key)
             .await;
         store_dyn
-            .put_batch_with_id(Arc::<str>::from("t"), id_missing, make_batch(1, 1), &key)
+            .put_batch_with_id(VertexId::new(OperatorTypeCode::Map, 1, 1), id_missing, make_batch(1, 1), &key)
             .await;
 
         let mut idx = BucketIndex::new(TimeGranularity::Seconds(1));
@@ -626,7 +634,7 @@ mod tests {
             pins,
             work_budget.clone(),
             &in_mem,
-            Arc::<str>::from("t"),
+            VertexId::new(OperatorTypeCode::Map, 1, 1),
             &key,
             0,
             2,

--- a/src/transport/batcher.rs
+++ b/src/transport/batcher.rs
@@ -446,10 +446,15 @@ mod tests {
     use super::*;
     use arrow::array::{Int64Array, StringArray};
     use arrow::datatypes::{Schema, Field, DataType};
-    use rand::{random, Rng};
+    use rand::Rng;
     use std::sync::Arc;
     use std::time::Instant;
     use crate::common::{Key, MAX_WATERMARK_VALUE};
+    use crate::common::ids::{OperatorTypeCode, VertexId};
+
+    fn test_vid(parallel: u16) -> VertexId {
+        VertexId::new(OperatorTypeCode::Map, 1, parallel)
+    }
 
     fn create_test_record_batch(rows: usize) -> arrow::record_batch::RecordBatch {
         let schema = Arc::new(Schema::new(vec![
@@ -472,7 +477,7 @@ mod tests {
     fn create_test_message(rows: usize, timestamp: u64) -> Message {
         let record_batch = create_test_record_batch(rows);
         Message::new(
-            Some("test_vertex".to_string()),
+            Some(VertexId::new(OperatorTypeCode::Map, 1, 0)),
             record_batch,
             Some(timestamp),
             None
@@ -495,7 +500,7 @@ mod tests {
         
         let key_obj = Key::new(key_batch).unwrap();
         Message::new_keyed(
-            Some("test_vertex".to_string()),
+            Some(VertexId::new(OperatorTypeCode::Map, 1, 0)),
             record_batch,
             key_obj,
             Some(timestamp),
@@ -580,7 +585,7 @@ mod tests {
         
         // Add watermark message
         let watermark = Message::Watermark(crate::common::message::WatermarkMessage::new(
-            "test".to_string(), 100, Some(100)
+            VertexId::new(OperatorTypeCode::Map, 1, 0), 100, Some(100)
         ));
         
         batcher.write_message(&"test_channel".to_string(), watermark).await.unwrap();
@@ -820,17 +825,17 @@ mod tests {
         assert!(rx_mixed.try_recv().is_err(), "Mixed channel should not have auto-flushed");
         
         let watermark_regular = Message::Watermark(crate::common::message::WatermarkMessage::new(
-            "watermark_regular".to_string(), 1000, Some(1000)
+            VertexId::new(OperatorTypeCode::Map, 1, 1), 1000, Some(1000)
         ));
         batcher.write_message(&"regular_channel".to_string(), watermark_regular).await.unwrap();
-        
+
         let watermark_keyed = Message::Watermark(crate::common::message::WatermarkMessage::new(
-            "watermark_keyed".to_string(), 2000, Some(2000)
+            VertexId::new(OperatorTypeCode::Map, 1, 2), 2000, Some(2000)
         ));
         batcher.write_message(&"keyed_channel".to_string(), watermark_keyed).await.unwrap();
-        
+
         let watermark_mixed = Message::Watermark(crate::common::message::WatermarkMessage::new(
-            "watermark_mixed".to_string(), 3000, Some(3000)
+            VertexId::new(OperatorTypeCode::Map, 1, 3), 3000, Some(3000)
         ));
         batcher.write_message(&"mixed_channel".to_string(), watermark_mixed).await.unwrap();
         
@@ -1065,7 +1070,7 @@ mod tests {
                         // Generate watermark every 10th message
                         if message_id % 10 == 0 {
                             let watermark = Message::Watermark(crate::common::message::WatermarkMessage::new(
-                                format!("watermark_{}", message_id),
+                                VertexId::new(OperatorTypeCode::Map, 1, (message_id as u16).wrapping_add(1)),
                                 message_id,
                                 Some(message_id)
                             ));
@@ -1091,7 +1096,7 @@ mod tests {
                 // send max watermark to each channel to notify of finish
                 for channel_id in &channels {
                     let watermark = Message::Watermark(crate::common::message::WatermarkMessage::new(
-                        format!("watermark_{}", message_id),
+                        VertexId::new(OperatorTypeCode::Map, 1, (message_id as u16).wrapping_add(1)),
                         MAX_WATERMARK_VALUE,
                         Some(message_id)
                     ));

--- a/src/transport/channel.rs
+++ b/src/transport/channel.rs
@@ -1,6 +1,8 @@
 use std::cmp::PartialEq;
 use std::hash::{Hash, Hasher};
 
+use crate::common::ids::{ChannelId, VertexId};
+
 impl PartialEq for Channel {
     fn eq(&self, other: &Self) -> bool {
         self.get_channel_id() == other.get_channel_id()
@@ -18,15 +20,15 @@ impl Hash for Channel {
 #[derive(Clone, Debug)]
 pub enum Channel {
     Local {
-        channel_id: String,
-        source_vertex_id: String,
-        target_vertex_id: String,
+        channel_id: ChannelId,
+        source_vertex_id: VertexId,
+        target_vertex_id: VertexId,
         queue_size_records: u32,
     },
     Remote {
-        channel_id: String,
-        source_vertex_id: String,
-        target_vertex_id: String,
+        channel_id: ChannelId,
+        source_vertex_id: VertexId,
+        target_vertex_id: VertexId,
         source_node_ip: String,
         source_node_id: String,
         target_node_ip: String,
@@ -37,18 +39,18 @@ pub enum Channel {
 }
 
 impl Channel {
-    pub fn new_local(source_vertex_id: String, target_vertex_id: String) -> Self {
+    pub fn new_local(source_vertex_id: VertexId, target_vertex_id: VertexId) -> Self {
         Self::new_local_with_queue(source_vertex_id, target_vertex_id, crate::transport::transport_spec::TransportSpec::DEFAULT_QUEUE_RECORDS)
     }
 
-    pub fn new_local_with_queue(source_vertex_id: String, target_vertex_id: String, queue_size_records: u32) -> Self {
-        let channel_id = gen_channel_id(source_vertex_id.clone(), target_vertex_id.clone());
+    pub fn new_local_with_queue(source_vertex_id: VertexId, target_vertex_id: VertexId, queue_size_records: u32) -> Self {
+        let channel_id = ChannelId::new(source_vertex_id, target_vertex_id);
         Channel::Local { channel_id, source_vertex_id, target_vertex_id, queue_size_records }
     }
 
     pub fn new_remote(
-        source_vertex_id: String,
-        target_vertex_id: String,
+        source_vertex_id: VertexId,
+        target_vertex_id: VertexId,
         source_node_ip: String,
         source_node_id: String,
         target_node_ip: String,
@@ -68,8 +70,8 @@ impl Channel {
     }
 
     pub fn new_remote_with_queue(
-        source_vertex_id: String,
-        target_vertex_id: String,
+        source_vertex_id: VertexId,
+        target_vertex_id: VertexId,
         source_node_ip: String,
         source_node_id: String,
         target_node_ip: String,
@@ -77,7 +79,7 @@ impl Channel {
         target_port: i32,
         queue_size_records: u32,
     ) -> Self {
-        let channel_id = gen_channel_id(source_vertex_id.clone(), target_vertex_id.clone());
+        let channel_id = ChannelId::new(source_vertex_id, target_vertex_id);
         Channel::Remote {
             channel_id,
             source_vertex_id,
@@ -93,41 +95,29 @@ impl Channel {
 }
 
 impl Channel {
-    pub fn get_channel_id(&self) -> String {
-        match &self {
-            Channel::Local { channel_id, ..} => {
-                channel_id.clone()
-            },
-            Channel::Remote { channel_id, ..} => {
-                channel_id.clone()  
-            }
+    pub fn get_channel_id(&self) -> ChannelId {
+        match self {
+            Channel::Local { channel_id, ..} => *channel_id,
+            Channel::Remote { channel_id, ..} => *channel_id,
         }
     }
 
-    pub fn get_source_vertex_id(&self) -> String {
-        match &self {
-            Channel::Local { source_vertex_id, ..} => {
-                source_vertex_id.clone()
-            },
-            Channel::Remote { source_vertex_id, ..} => {
-                source_vertex_id.clone()
-            }
+    pub fn get_source_vertex_id(&self) -> VertexId {
+        match self {
+            Channel::Local { source_vertex_id, ..} => *source_vertex_id,
+            Channel::Remote { source_vertex_id, ..} => *source_vertex_id,
         }
     }
 
-    pub fn get_target_vertex_id(&self) -> String {
-        match &self {
-            Channel::Local { target_vertex_id, ..} => {
-                target_vertex_id.clone()
-            },
-            Channel::Remote { target_vertex_id, ..} => {
-                target_vertex_id.clone()
-            }
+    pub fn get_target_vertex_id(&self) -> VertexId {
+        match self {
+            Channel::Local { target_vertex_id, ..} => *target_vertex_id,
+            Channel::Remote { target_vertex_id, ..} => *target_vertex_id,
         }
     }
 
     pub fn get_queue_size_records(&self) -> u32 {
-        match &self {
+        match self {
             Channel::Local { queue_size_records, .. } => *queue_size_records,
             Channel::Remote { queue_size_records, .. } => *queue_size_records,
         }
@@ -150,8 +140,4 @@ pub fn to_local_and_remote(channels: &Vec<Channel>) -> (Vec<Channel>, Vec<Channe
     }
 
     (local, remote)
-} 
-
-fn gen_channel_id(source_vertex_id: String, target_vertex_id: String) -> String {
-    format!("{}_to_{}", source_vertex_id, target_vertex_id)
 }

--- a/src/transport/grpc/grpc_streaming_service.rs
+++ b/src/transport/grpc/grpc_streaming_service.rs
@@ -1,6 +1,7 @@
 use tonic::{Request, Response, Status};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
+use crate::common::ids::ChannelId;
 use crate::common::message::Message;
 
 pub mod message_stream {
@@ -17,11 +18,11 @@ use crate::transport::grpc::grpc_streaming_service::message_stream::message_stre
 #[derive(Default)]
 pub struct MessageStreamServiceImpl {
     // Channel to send received messages to the application
-    tx: Option<mpsc::Sender<(Message, String)>>,
+    tx: Option<mpsc::Sender<(Message, ChannelId)>>,
 }
 
 impl MessageStreamServiceImpl {
-    pub fn new(tx: mpsc::Sender<(Message, String)>) -> Self {
+    pub fn new(tx: mpsc::Sender<(Message, ChannelId)>) -> Self {
         Self {
             tx: Some(tx),
         }
@@ -40,11 +41,11 @@ impl MessageStreamService for MessageStreamServiceImpl {
         // Process incoming messages
         while let Some(message) = stream.message().await? {
             let message_data = message.message_data;
-            let channel_id = message.channel_id;
-            
+            let channel_id = ChannelId::from_raw(message.channel_id);
+
             // Deserialize the message
             let deserialized_message = Message::from_bytes(&message_data);
-            
+
             // Send to application via channel
             if let Err(e) = tx.send((deserialized_message, channel_id)).await {
                 eprintln!("[SERVER] Failed to send message to application: {}", e);
@@ -67,8 +68,8 @@ impl MessageStreamClient {
     }
 
     pub async fn connect_with_retry(
-        addr: String, 
-        max_retries: u32, 
+        addr: String,
+        max_retries: u32,
         delay: Duration
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut last_error = None;
@@ -82,7 +83,7 @@ impl MessageStreamClient {
                 Err(e) => {
                     last_error = Some(e);
                     if attempt < max_retries {
-                        println!("[GRPC_CLIENT] Connection attempt {} failed for {}: {}. Retrying in {:?}...", 
+                        println!("[GRPC_CLIENT] Connection attempt {} failed for {}: {}. Retrying in {:?}...",
                                 attempt + 1, addr, last_error.as_ref().unwrap(), delay);
                         sleep(delay).await;
                     }
@@ -90,13 +91,13 @@ impl MessageStreamClient {
             }
         }
 
-        Err(format!("Failed to connect to {} after {} attempts. Last error: {}", 
+        Err(format!("Failed to connect to {} after {} attempts. Last error: {}",
                    addr, max_retries + 1, last_error.unwrap()).into())
     }
 
     pub async fn stream_messages(
         &mut self,
-        rx: mpsc::Receiver<(Message, String)>,
+        rx: mpsc::Receiver<(Message, ChannelId)>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let stream = tokio_stream::StreamExt::map(
             tokio_stream::wrappers::ReceiverStream::new(rx),
@@ -104,15 +105,15 @@ impl MessageStreamClient {
                 // Serialize the message
                 let message_data = message.to_bytes();
                 GrpcMessage {
-                    message_data,
-                    channel_id,
+                    message_data: message_data,
+                    channel_id: channel_id.raw(),
                 }
             }
         );
 
         let request = Request::new(stream);
         let _response = self.client.stream_messages(request).await?;
-        
+
         Ok(())
     }
 }

--- a/src/transport/grpc/grpc_streaming_service_test.rs
+++ b/src/transport/grpc/grpc_streaming_service_test.rs
@@ -1,3 +1,4 @@
+use crate::common::ids::{ChannelId, OperatorTypeCode, VertexId};
 use crate::common::message::Message;
 use crate::common::key::Key;
 use crate::transport::grpc::grpc_streaming_service::{
@@ -11,10 +12,18 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use std::collections::HashMap;
 
+fn test_vertex_id(seed: u8) -> VertexId {
+    VertexId::new(OperatorTypeCode::Map, seed, 0)
+}
+
+fn test_channel_id(seed: u8) -> ChannelId {
+    ChannelId::new(test_vertex_id(seed * 2), test_vertex_id(seed * 2 + 1))
+}
+
 /// Start the gRPC server with custom shutdown signal
 pub async fn start_server(
     addr: String,
-    tx: mpsc::Sender<(Message, String)>,
+    tx: mpsc::Sender<(Message, ChannelId)>,
     shutdown: tokio::sync::oneshot::Receiver<()>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("[SERVER] Starting gRPC server on {}", addr);
@@ -40,7 +49,7 @@ pub async fn start_server(
 /// Start the gRPC client
 pub async fn start_client(
     server_addr: String,
-    rx: mpsc::Receiver<(Message, String)>,
+    rx: mpsc::Receiver<(Message, ChannelId)>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("[CLIENT] Starting gRPC client");
     let mut client = MessageStreamClient::connect(server_addr).await?;
@@ -54,7 +63,7 @@ pub async fn stream_grpc_many_clients_one_server() {
     let server_addr = "127.0.0.1:50053";
     
     // Create channels for server communication
-    let (server_tx, mut server_rx) = mpsc::channel::<(Message, String)>(100);
+    let (server_tx, mut server_rx) = mpsc::channel::<(Message, ChannelId)>(100);
     
     // Create shutdown channel
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
@@ -74,10 +83,10 @@ pub async fn stream_grpc_many_clients_one_server() {
     
     // Create multiple clients with different channel IDs
     let client_configs = vec![
-        ("client1".to_string(), "channel1".to_string(), 10),
-        ("client2".to_string(), "channel2".to_string(), 10),
-        ("client3".to_string(), "channel3".to_string(), 10),
-        ("client4".to_string(), "channel4".to_string(), 10),
+        ("client1".to_string(), test_channel_id(1), 10),
+        ("client2".to_string(), test_channel_id(2), 10),
+        ("client3".to_string(), test_channel_id(3), 10),
+        ("client4".to_string(), test_channel_id(4), 10),
     ];
     
     let mut client_handles = Vec::new();
@@ -89,7 +98,7 @@ pub async fn stream_grpc_many_clients_one_server() {
         println!("[TEST] Starting client: {} on channel: {} with {} messages", 
                 client_name, channel_id, message_count);
         
-        let (client_tx, client_rx) = mpsc::channel::<(Message, String)>(100);
+        let (client_tx, client_rx) = mpsc::channel::<(Message, ChannelId)>(100);
         
         // Start client task
         let client_handle = tokio::spawn(async move {
@@ -108,9 +117,10 @@ pub async fn stream_grpc_many_clients_one_server() {
     for (client_name, channel_id, message_count, client_tx) in client_senders {
         let send_task = tokio::spawn(async move {
             let mut client_sent_messages = Vec::new();
-            
+            let upstream_vertex_id = channel_id.source();
+
             for i in 0..message_count {
-                let message = create_test_message_for_client(&client_name, i);
+                let message = create_test_message_for_client(&client_name, upstream_vertex_id, i);
                 
                 // Store sent message for verification
                 client_sent_messages.push((i, message.clone()));
@@ -270,7 +280,7 @@ fn get_message_type(message: &Message) -> MessageType {
     }
 }
 
-fn create_test_message_for_client(client_name: &str, index: usize) -> Message {
+fn create_test_message_for_client(client_name: &str, upstream_vertex_id: VertexId, index: usize) -> Message {
     // Create schema
     let schema = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int64, false),
@@ -294,7 +304,7 @@ fn create_test_message_for_client(client_name: &str, index: usize) -> Message {
             ).unwrap();
             
             Message::new(
-                Some(format!("upstream_{}", client_name)),
+                Some(upstream_vertex_id),
                 record_batch,
                 Some(1234567890 + index as u64),
                 None
@@ -324,7 +334,7 @@ fn create_test_message_for_client(client_name: &str, index: usize) -> Message {
             ).unwrap();
             
             Message::new_keyed(
-                Some(format!("upstream_{}", client_name)),
+                Some(upstream_vertex_id),
                 data_batch,
                 key,
                 Some(1234567890 + index as u64),
@@ -335,7 +345,7 @@ fn create_test_message_for_client(client_name: &str, index: usize) -> Message {
             // Watermark message
             Message::Watermark(
                 crate::common::message::WatermarkMessage::new(
-                    format!("source_{}", client_name),
+                    upstream_vertex_id,
                     9876543210 + index as u64,
                     Some(1234567890 + index as u64)
                 )

--- a/src/transport/grpc_transport_backend.rs
+++ b/src/transport/grpc_transport_backend.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time;
+use crate::common::ids::ChannelId;
 use crate::common::message::Message;
 use crate::runtime::execution_graph::ExecutionGraph;
 use crate::runtime::VertexId;
@@ -26,11 +27,11 @@ pub struct GrpcTransportBackend {
     reader_task: Option<tokio::task::JoinHandle<()>>,
     writer_task: Option<tokio::task::JoinHandle<()>>,
 
-    reader_senders: Option<HashMap<String, BatchSender>>,
-    writer_receivers: Option<HashMap<String, BatchReceiver>>,
+    reader_senders: Option<HashMap<ChannelId, BatchSender>>,
+    writer_receivers: Option<HashMap<ChannelId, BatchReceiver>>,
 
     nodes: Option<Vec<(String, String, i32)>>,
-    channel_to_node: Option<HashMap<String, String>>,
+    channel_to_node: Option<HashMap<ChannelId, String>>,
     port: Option<i32>,
 
     shutdown_tx: Option<oneshot::Sender<()>>,
@@ -86,16 +87,16 @@ impl GrpcTransportBackend {
         return p.unwrap()
     }
 
-    fn get_remote_nodes_from_out_channels(&self, out_channels: &[Channel]) -> (Vec<(String, String, i32)>, HashMap<String, String>) {
+    fn get_remote_nodes_from_out_channels(&self, out_channels: &[Channel]) -> (Vec<(String, String, i32)>, HashMap<ChannelId, String>) {
         if out_channels.len() == 0 {
             panic!("No channels provided");
         }
         let mut nodes = HashMap::new();
         let mut channel_to_node = HashMap::new();
-        
+
         for channel in out_channels {
             if let Channel::Remote { target_node_ip, target_node_id, target_port, .. } = channel {
-                let channel_id = channel.get_channel_id().clone();
+                let channel_id = channel.get_channel_id();
                 channel_to_node.insert(channel_id, target_node_id.clone());
                 
                 let ip_and_port = nodes.get(target_node_id);
@@ -195,9 +196,9 @@ impl TransportBackend for GrpcTransportBackend {
         if writer_receivers.len() != 0 {
 
             // Start clients for each peer node
-            let channel_to_node: HashMap<String, String> = self.channel_to_node.take().expect("Nodes should be found");
+            let channel_to_node: HashMap<ChannelId, String> = self.channel_to_node.take().expect("Nodes should be found");
             let nodes = self.nodes.take().expect("Nodes should be found");
-            let mut client_txs: HashMap<String, mpsc::Sender<(Message, String)>> = HashMap::new();
+            let mut client_txs: HashMap<String, mpsc::Sender<(Message, ChannelId)>> = HashMap::new();
             
             // println!("[GRPC_BACKEND] Setting up clients for nodes: {:?}", nodes);
             // println!("[GRPC_BACKEND] Channel to node mapping: {:?}", channel_to_node);
@@ -221,26 +222,24 @@ impl TransportBackend for GrpcTransportBackend {
             // routes data from writer channels to clients based on peer node<->channel mapping
             let writer_task = tokio::spawn(async move {
                 let mut receiver_futures = Vec::new();
-                
+
                 // Create futures for all writer receivers
                 for (channel_id, mut receiver) in writer_receivers {
-                    let channel_id_clone = channel_id.clone();
+                    let channel_id_clone = channel_id;
                     let client_txs_clone = client_txs.clone();
                     let channel_to_node_clone = channel_to_node.clone();
-                    
+
                     let r = running.clone();
                     let future = async move {
-                        
+
                         // THIS WILL CAUSE BACKPRESSURE FOR ALL CHANNELS IF ONE CHANNEL IS BLOCKED
                         while r.load(std::sync::atomic::Ordering::Relaxed) {
                             match time::timeout(Duration::from_millis(100), receiver.recv()).await {
                                 Ok(Some(message)) => {
                                     let node_id = channel_to_node_clone.get(&channel_id_clone).unwrap();
-                                    // println!("[GRPC_BACKEND] Looking up client for node_id: {} (channel: {})", node_id, channel_id_clone);
-                                    // println!("[GRPC_BACKEND] Available client_txs keys: {:?}", client_txs_clone.keys().collect::<Vec<_>>());
                                     let client_tx = client_txs_clone.get(node_id).unwrap();
                                     while r.load(std::sync::atomic::Ordering::Relaxed) {
-                                        match time::timeout(Duration::from_millis(100), client_tx.send((message.clone(), channel_id_clone.clone()))).await {
+                                        match time::timeout(Duration::from_millis(100), client_tx.send((message.clone(), channel_id_clone))).await {
                                             Ok(Ok(())) => {
                                                 break;
                                             }, 
@@ -313,7 +312,7 @@ impl TransportBackend for GrpcTransportBackend {
         let mut all_output_edges = Vec::new();
         
         for vertex_id in &vertex_ids {
-            let (input_edges, output_edges) = execution_graph.get_edges_for_vertex(vertex_id.as_ref()).unwrap();
+            let (input_edges, output_edges) = execution_graph.get_edges_for_vertex(*vertex_id).unwrap();
             all_input_edges.extend(input_edges);
             all_output_edges.extend(output_edges);
         }
@@ -331,47 +330,47 @@ impl TransportBackend for GrpcTransportBackend {
             self.nodes = Some(remote_nodes);
         }
 
-        let mut reader_receivers = HashMap::new();
-        let mut reader_senders = HashMap::new();
-        
+        let mut reader_receivers: HashMap<ChannelId, BatchReceiver> = HashMap::new();
+        let mut reader_senders: HashMap<ChannelId, BatchSender> = HashMap::new();
+
         for edge in &all_input_edges {
             let channel = edge.get_channel();
             let channel_id = channel.get_channel_id();
             let (tx, rx) = batch_bounded_channel(channel.get_queue_size_records());
-            reader_senders.insert(channel_id.clone(), tx);
-            reader_receivers.insert(channel_id.clone(), rx);
+            reader_senders.insert(channel_id, tx);
+            reader_receivers.insert(channel_id, rx);
         }
 
-        let mut writer_receivers = HashMap::new();
-        let mut writer_senders = HashMap::new();
+        let mut writer_receivers: HashMap<ChannelId, BatchReceiver> = HashMap::new();
+        let mut writer_senders: HashMap<ChannelId, BatchSender> = HashMap::new();
 
         for edge in &all_output_edges {
             let channel = edge.get_channel();
             let channel_id = channel.get_channel_id();
             let (tx, rx) = batch_bounded_channel(channel.get_queue_size_records());
-            writer_senders.insert(channel_id.clone(), tx);
-            writer_receivers.insert(channel_id.clone(), rx);
+            writer_senders.insert(channel_id, tx);
+            writer_receivers.insert(channel_id, rx);
         }
 
         let mut transport_client_configs: HashMap<VertexId, TransportClientConfig> = HashMap::new();
-        
+
         for vertex_id in vertex_ids {
             let config = transport_client_configs
-                .entry(vertex_id.clone())
-                .or_insert(TransportClientConfig::new(vertex_id.clone()));
-            
-            let (input_edges, output_edges) = execution_graph.get_edges_for_vertex(vertex_id.as_ref()).unwrap();
-            
+                .entry(vertex_id)
+                .or_insert(TransportClientConfig::new(vertex_id));
+
+            let (input_edges, output_edges) = execution_graph.get_edges_for_vertex(vertex_id).unwrap();
+
             for edge in input_edges {
                 let channel = edge.get_channel();
                 let channel_id = channel.get_channel_id();
-                config.add_reader_receiver(channel_id.clone(), reader_receivers.remove(&channel_id).unwrap());
+                config.add_reader_receiver(channel_id, reader_receivers.remove(&channel_id).unwrap());
             }
 
             for edge in output_edges {
                 let channel = edge.get_channel();
                 let channel_id = channel.get_channel_id();
-                config.add_writer_sender(channel_id.clone(), writer_senders.get(&channel_id).unwrap().clone());
+                config.add_writer_sender(channel_id, writer_senders.get(&channel_id).unwrap().clone());
             }
         }
 

--- a/src/transport/in_memory_transport_backend.rs
+++ b/src/transport/in_memory_transport_backend.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use crate::common::ids::ChannelId;
 use crate::runtime::execution_graph::ExecutionGraph;
 use crate::runtime::VertexId;
 use crate::transport::batch_channel::{batch_bounded_channel, BatchReceiver, BatchSender};
@@ -9,8 +10,8 @@ use async_trait::async_trait;
 use super::transport_client::TransportClientConfig;
 
 pub struct InMemoryTransportBackend {
-    senders: HashMap<String, BatchSender>, // keep references so channels are not closed
-    receivers: HashMap<String, BatchReceiver>,
+    senders: HashMap<ChannelId, BatchSender>, // keep references so channels are not closed
+    receivers: HashMap<ChannelId, BatchReceiver>,
 }
 
 impl InMemoryTransportBackend {
@@ -25,25 +26,25 @@ impl InMemoryTransportBackend {
         &mut self,
         transport_client_configs: &mut HashMap<VertexId, TransportClientConfig>,
         vertex_id: VertexId,
-        channel: Channel, 
+        channel: Channel,
         is_in: bool
     ) {
         // Only handle local channels
         let channel_id = match &channel {
-            Channel::Local { channel_id, ..} => channel_id.clone(),
+            Channel::Local { channel_id, ..} => *channel_id,
             _ => panic!("Only local channels are supported"),
         };
 
         // Create a new channel if it doesn't exist
         if !self.senders.contains_key(&channel_id) {
             let (tx, rx) = batch_bounded_channel(channel.get_queue_size_records());
-            self.senders.insert(channel_id.clone(), tx);
-            self.receivers.insert(channel_id.clone(), rx);
+            self.senders.insert(channel_id, tx);
+            self.receivers.insert(channel_id, rx);
         }
 
         let config = transport_client_configs
-            .entry(vertex_id.clone())
-            .or_insert(TransportClientConfig::new(vertex_id.clone()));
+            .entry(vertex_id)
+            .or_insert(TransportClientConfig::new(vertex_id));
 
         if is_in {
             // For readers, we need to move the receiver since it can't be cloned
@@ -73,14 +74,14 @@ impl TransportBackend for InMemoryTransportBackend {
         vertex_ids: Vec<VertexId>,
     ) -> HashMap<VertexId, TransportClientConfig> {
         let mut transport_client_configs: HashMap<VertexId, TransportClientConfig> = HashMap::new();
-        
+
         for vertex_id in vertex_ids {
-            let (input_edges, output_edges) = execution_graph.get_edges_for_vertex(vertex_id.as_ref()).unwrap();
+            let (input_edges, output_edges) = execution_graph.get_edges_for_vertex(vertex_id).unwrap();
             for edge in input_edges {
                 let channel = edge.get_channel();
                 self.register_local_channel(
                     &mut transport_client_configs,
-                    vertex_id.clone(),
+                    vertex_id,
                     channel,
                     true,
                 );
@@ -90,7 +91,7 @@ impl TransportBackend for InMemoryTransportBackend {
                 let channel = edge.get_channel();
                 self.register_local_channel(
                     &mut transport_client_configs,
-                    vertex_id.clone(),
+                    vertex_id,
                     channel,
                     false,
                 );
@@ -98,4 +99,4 @@ impl TransportBackend for InMemoryTransportBackend {
         }
         return transport_client_configs;
     }
-} 
+}

--- a/src/transport/tests/grpc_transport_backend_test.rs
+++ b/src/transport/tests/grpc_transport_backend_test.rs
@@ -1,10 +1,8 @@
-use crate::runtime::execution_graph::{gen_edge_id, ExecutionEdge, ExecutionGraph, ExecutionVertex};
+use crate::common::ids::{ChannelId, OperatorTypeCode, VertexId};
+use crate::runtime::execution_graph::{ExecutionEdge, ExecutionGraph, ExecutionVertex};
 use crate::runtime::operators::operator::OperatorConfig;
 use crate::runtime::partition::PartitionType;
-use crate::runtime::functions::{
-    map::MapFunction,
-    map::MapFunctionTrait,
-};
+use crate::runtime::functions::map::MapFunction;
 use crate::transport::transport_backend_actor::{TransportBackendActor, TransportBackendActorMessage};
 use crate::transport::channel::Channel;
 use crate::common::message::Message;
@@ -14,8 +12,17 @@ use crate::transport::{GrpcTransportBackend, TransportBackend};
 use arrow::array::StringArray;
 use kameo::spawn;
 use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::time::{sleep, Duration};
+
+fn make_writer_vid(node_idx: usize, writer_idx: usize, num_writers_per_node: usize) -> VertexId {
+    let parallel = (node_idx * num_writers_per_node + writer_idx) as u16;
+    VertexId::new(OperatorTypeCode::Map, 1, parallel)
+}
+
+fn make_reader_vid(node_idx: usize, reader_idx: usize, num_readers_per_node: usize) -> VertexId {
+    let parallel = (node_idx * num_readers_per_node + reader_idx) as u16;
+    VertexId::new(OperatorTypeCode::Map, 2, parallel)
+}
 
 #[tokio::test]
 async fn test_grpc_transport_backend() {
@@ -25,52 +32,42 @@ async fn test_grpc_transport_backend() {
     let num_writers_per_node = 3;
     let num_readers_per_node = 3;
     let messages_per_writer = 5;
-    
+
     // Create vertex IDs for each node
-    let mut writer_vertex_ids = Vec::new();
-    let mut reader_vertex_ids = Vec::new();
+    let mut writer_vertex_ids: Vec<VertexId> = Vec::new();
+    let mut reader_vertex_ids: Vec<VertexId> = Vec::new();
 
     for node_idx in 0..num_writer_nodes {
         for writer_idx in 0..num_writers_per_node {
-            writer_vertex_ids.push(format!("writer_node_{}_writer_{}", node_idx, writer_idx));
+            writer_vertex_ids.push(make_writer_vid(node_idx, writer_idx, num_writers_per_node));
         }
     }
 
     for node_idx in 0..num_reader_nodes {
         for reader_idx in 0..num_readers_per_node {
-            reader_vertex_ids.push(format!("reader_node_{}_reader_{}", node_idx, reader_idx));
+            reader_vertex_ids.push(make_reader_vid(node_idx, reader_idx, num_readers_per_node));
         }
     }
 
     // Create a single execution graph for the entire system
     let mut graph = ExecutionGraph::new();
-    
+
     // Add all writer vertices
-    for node_idx in 0..num_writer_nodes {
-        for writer_idx in 0..num_writers_per_node {
-            let vertex_id = format!("writer_node_{}_writer_{}", node_idx, writer_idx);
-            graph.add_vertex(ExecutionVertex::new(
-                vertex_id.clone(),
-                "writer_operator".to_string(),
-                OperatorConfig::MapConfig(MapFunction::new_custom(IdentityMapFunction)),
-                1,
-                0
-            ));
-        }
+    for writer_vertex_id in &writer_vertex_ids {
+        graph.add_vertex(ExecutionVertex::new(
+            *writer_vertex_id,
+            OperatorConfig::MapConfig(MapFunction::new_custom(IdentityMapFunction)),
+            1
+        ));
     }
 
     // Add all reader vertices
-    for node_idx in 0..num_reader_nodes {
-        for reader_idx in 0..num_readers_per_node {
-            let vertex_id = format!("reader_node_{}_reader_{}", node_idx, reader_idx);
-            graph.add_vertex(ExecutionVertex::new(
-                vertex_id.clone(),
-                "reader_operator".to_string(),
-                OperatorConfig::MapConfig(MapFunction::new_custom(IdentityMapFunction)),
-                1,
-                0
-            ));
-        }
+    for reader_vertex_id in &reader_vertex_ids {
+        graph.add_vertex(ExecutionVertex::new(
+            *reader_vertex_id,
+            OperatorConfig::MapConfig(MapFunction::new_custom(IdentityMapFunction)),
+            1
+        ));
     }
 
     // Create remote channels between all writers and all readers
@@ -80,26 +77,25 @@ async fn test_grpc_transport_backend() {
             // Calculate target node ID
             let target_node_id = reader_idx / num_readers_per_node;
             let source_node_id = writer_idx / num_writers_per_node;
-            
+
             // Use port based on target node ID to ensure same node gets same port
             let target_port = 50051 + target_node_id as i32;
-            
+
             let edge = ExecutionEdge::new(
-                writer_vertex_id.clone(),
-                reader_vertex_id.clone(),
-                reader_vertex_id.clone(),
+                *writer_vertex_id,
+                *reader_vertex_id,
                 PartitionType::Forward,
                 Some(Channel::new_remote(
-                    writer_vertex_id.clone(),
-                    reader_vertex_id.clone(),
+                    *writer_vertex_id,
+                    *reader_vertex_id,
                     "127.0.0.1".to_string(),
                     format!("writer_node_{}", source_node_id),
                     "127.0.0.1".to_string(),
                     format!("reader_node_{}", target_node_id),
-                    target_port
-                ))
+                    target_port,
+                )),
             );
-            
+
             graph.add_edge(edge);
         }
     }
@@ -111,11 +107,10 @@ async fn test_grpc_transport_backend() {
     // Create writer node backends
     for node_idx in 0..num_writer_nodes {
         let mut backend: Box<dyn TransportBackend> = Box::new(GrpcTransportBackend::new());
-        let vertex_ids = (0..num_writers_per_node)
-            .map(|writer_idx| format!("writer_node_{}_writer_{}", node_idx, writer_idx))
-            .map(|s| Arc::<str>::from(s))
-            .collect::<Vec<_>>();
-        
+        let vertex_ids: Vec<VertexId> = (0..num_writers_per_node)
+            .map(|writer_idx| make_writer_vid(node_idx, writer_idx, num_writers_per_node))
+            .collect();
+
         let configs = backend.init_channels(&graph, vertex_ids);
         writer_backends.push((backend, configs));
     }
@@ -123,11 +118,10 @@ async fn test_grpc_transport_backend() {
     // Create reader node backends
     for node_idx in 0..num_reader_nodes {
         let mut backend: Box<dyn TransportBackend> = Box::new(GrpcTransportBackend::new());
-        let vertex_ids = (0..num_readers_per_node)
-            .map(|reader_idx| format!("reader_node_{}_reader_{}", node_idx, reader_idx))
-            .map(|s| Arc::<str>::from(s))
-            .collect::<Vec<_>>();
-        
+        let vertex_ids: Vec<VertexId> = (0..num_readers_per_node)
+            .map(|reader_idx| make_reader_vid(node_idx, reader_idx, num_readers_per_node))
+            .collect();
+
         let configs = backend.init_channels(&graph, vertex_ids);
         reader_backends.push((backend, configs));
     }
@@ -142,10 +136,10 @@ async fn test_grpc_transport_backend() {
         let backend_actor = TransportBackendActor::new(backend);
         let backend_ref = spawn(backend_actor);
         writer_backend_refs.push(backend_ref);
-        
+
         // Create writer actors for this backend
         for (vertex_id, config) in configs {
-            let writer_actor = TestDataWriterActor::new(vertex_id.clone(), config);
+            let writer_actor = TestDataWriterActor::new(vertex_id, config);
             let writer_ref = spawn(writer_actor);
             writer_refs.insert(vertex_id, writer_ref.clone());
         }
@@ -155,10 +149,10 @@ async fn test_grpc_transport_backend() {
         let backend_actor = TransportBackendActor::new(backend);
         let backend_ref = spawn(backend_actor);
         reader_backend_refs.push(backend_ref);
-        
+
         // Create reader actors for this backend
         for (vertex_id, config) in configs {
-            let reader_actor = TestDataReaderActor::new(vertex_id.clone(), config);
+            let reader_actor = TestDataReaderActor::new(vertex_id, config);
             let reader_ref = spawn(reader_actor);
             reader_refs.insert(vertex_id, reader_ref.clone());
         }
@@ -178,21 +172,21 @@ async fn test_grpc_transport_backend() {
     // Create test data and send from each writer to each reader
     for writer_idx in 0..writer_vertex_ids.len() {
         // Start writer
-        let writer_vertex_id = &writer_vertex_ids[writer_idx];
-        let writer_ref = writer_refs.get(writer_vertex_id.as_str()).unwrap();
+        let writer_vertex_id = writer_vertex_ids[writer_idx];
+        let writer_ref = writer_refs.get(&writer_vertex_id).unwrap();
         writer_ref.ask(crate::transport::test_utils::TestDataWriterMessage::Start).await.unwrap();
-        
+
         for message_idx in 0..messages_per_writer {
             let message = Message::new(
-                Some(format!("writer_{}_stream", writer_idx)),
+                Some(writer_vertex_id),
                 create_test_string_batch(vec![format!("writer_{}_batch_{}", writer_idx, message_idx)]),
                 Some(100),
-                None
+                None,
             );
 
             for reader_idx in 0..reader_vertex_ids.len() {
-                let edge_id = gen_edge_id(&writer_vertex_id, &reader_vertex_ids[reader_idx]);
-                let channel = graph.get_edge(&edge_id).unwrap().get_channel();
+                let edge_id = ChannelId::new(writer_vertex_id, reader_vertex_ids[reader_idx]);
+                let channel = graph.get_edge(edge_id).unwrap().get_channel();
                 writer_ref.ask(crate::transport::test_utils::TestDataWriterMessage::WriteMessage {
                     channel,
                     message: message.clone(),
@@ -209,10 +203,10 @@ async fn test_grpc_transport_backend() {
 
     // Verify data received by each reader
     for reader_idx in 0..reader_vertex_ids.len() {
-        let reader_vertex_id = &reader_vertex_ids[reader_idx];
-        let reader_ref = reader_refs.get(reader_vertex_id.as_str()).unwrap();
+        let reader_vertex_id = reader_vertex_ids[reader_idx];
+        let reader_ref = reader_refs.get(&reader_vertex_id).unwrap();
         let mut received_messages = Vec::new();
-        
+
         // Read all expected batches
         for _ in 0..(writer_vertex_ids.len() * messages_per_writer) {
             let result = reader_ref.ask(crate::transport::test_utils::TestDataReaderMessage::ReadMessage).await.unwrap();
@@ -222,7 +216,7 @@ async fn test_grpc_transport_backend() {
         }
 
         // Verify we got all expected batches
-        assert_eq!(received_messages.len(), writer_vertex_ids.len() * messages_per_writer, 
+        assert_eq!(received_messages.len(), writer_vertex_ids.len() * messages_per_writer,
             "Reader {} did not receive all expected batches", reader_idx);
 
         // Create a map to track received batches by writer and batch number
@@ -234,13 +228,13 @@ async fn test_grpc_transport_backend() {
                 .downcast_ref::<StringArray>()
                 .unwrap()
                 .value(0);
-            
+
             // Parse writer_idx and batch_num from the value
             let parts: Vec<&str> = value.split("_batch_").collect();
             let writer_part = parts[0].strip_prefix("writer_").unwrap();
             let writer_idx = writer_part.parse::<usize>().unwrap();
             let message_idx = parts[1].parse::<usize>().unwrap();
-            
+
             received_map.insert((writer_idx, message_idx), value.to_string());
         }
 
@@ -264,6 +258,6 @@ async fn test_grpc_transport_backend() {
     for backend_ref in &reader_backend_refs {
         backend_ref.ask(TransportBackendActorMessage::Close).await.unwrap();
     }
-    
+
     println!("gRPC transport backend test completed successfully!");
-} 
+}

--- a/src/transport/tests/in_memory_transport_backend_test.rs
+++ b/src/transport/tests/in_memory_transport_backend_test.rs
@@ -1,10 +1,8 @@
-use crate::runtime::execution_graph::{gen_edge_id, ExecutionEdge, ExecutionGraph, ExecutionVertex};
+use crate::common::ids::{ChannelId, OperatorTypeCode, VertexId};
+use crate::runtime::execution_graph::{ExecutionEdge, ExecutionGraph, ExecutionVertex};
 use crate::runtime::operators::operator::OperatorConfig;
 use crate::runtime::partition::PartitionType;
-use crate::runtime::functions::{
-    map::MapFunction,
-    map::MapFunctionTrait,
-};
+use crate::runtime::functions::map::MapFunction;
 use crate::transport::transport_backend_actor::{TransportBackendActor, TransportBackendActorMessage};
 use crate::transport::channel::Channel;
 use crate::common::message::Message;
@@ -14,7 +12,14 @@ use crate::transport::{InMemoryTransportBackend, TransportBackend};
 use arrow::array::StringArray;
 use kameo::spawn;
 use std::collections::HashMap;
-use std::sync::Arc;
+
+fn make_writer_vid(i: usize) -> VertexId {
+    VertexId::new(OperatorTypeCode::Map, 1, i as u16)
+}
+
+fn make_reader_vid(i: usize) -> VertexId {
+    VertexId::new(OperatorTypeCode::Map, 2, i as u16)
+}
 
 // TODO test ordered delivery
 #[tokio::test]
@@ -27,50 +32,45 @@ async fn test_actor_transport() {
     let num_readers = 10;
     let messages_per_writer = 10;
 
-    let writer_vertex_ids = (0..num_writers).map(|i| format!("writer{}", i)).collect::<Vec<_>>();
-    let reader_vertex_ids = (0..num_readers).map(|i| format!("reader{}", i)).collect::<Vec<_>>();
+    let writer_vertex_ids: Vec<VertexId> = (0..num_writers).map(make_writer_vid).collect();
+    let reader_vertex_ids: Vec<VertexId> = (0..num_readers).map(make_reader_vid).collect();
 
     let mut graph = ExecutionGraph::new();
     for i in 0..num_writers {
         graph.add_vertex(ExecutionVertex::new(
-            writer_vertex_ids[i].clone(),
-            "writer_operator".to_string(),
+            writer_vertex_ids[i],
             OperatorConfig::MapConfig(MapFunction::new_custom(IdentityMapFunction)),
-            1,
-            0
+            1
         ));
     }
     for i in 0..num_readers {
         graph.add_vertex(ExecutionVertex::new(
-            reader_vertex_ids[i].clone(),
-            "reader_operator".to_string(),
+            reader_vertex_ids[i],
             OperatorConfig::MapConfig(MapFunction::new_custom(IdentityMapFunction)),
-            1,
-            0
+            1
         ));
     }
 
     for i in 0..num_writers {
         for j in 0..num_readers {
             let edge = ExecutionEdge::new(
-                writer_vertex_ids[i].clone(),
-                reader_vertex_ids[j].clone(),
-                reader_vertex_ids[j].clone(),
+                writer_vertex_ids[i],
+                reader_vertex_ids[j],
                 PartitionType::Forward,
-                Some(Channel::new_local(writer_vertex_ids[i].clone(), reader_vertex_ids[j].clone()))
+                Some(Channel::new_local(writer_vertex_ids[i], reader_vertex_ids[j])),
             );
             graph.add_edge(edge);
         }
     }
 
     let mut backend: Box<dyn TransportBackend> = Box::new(InMemoryTransportBackend::new());
-    let all_vertex_ids = writer_vertex_ids
+    let all_vertex_ids: Vec<VertexId> = writer_vertex_ids
         .iter()
         .chain(reader_vertex_ids.iter())
-        .map(|s| Arc::<str>::from(s.as_str()))
-        .collect::<Vec<_>>();
+        .copied()
+        .collect();
     let mut configs = backend.init_channels(&graph, all_vertex_ids);
-    
+
 
     // Create transport backend actor
     let backend_actor = TransportBackendActor::new(backend);
@@ -80,8 +80,8 @@ async fn test_actor_transport() {
     let mut writer_refs = Vec::new();
     for vertex_id in &writer_vertex_ids {
         let writer_actor = TestDataWriterActor::new(
-            Arc::<str>::from(vertex_id.as_str()),
-            configs.remove(vertex_id.as_str()).unwrap(),
+            *vertex_id,
+            configs.remove(vertex_id).unwrap(),
         );
         let writer_ref = spawn(writer_actor);
         writer_refs.push(writer_ref.clone());
@@ -91,8 +91,8 @@ async fn test_actor_transport() {
     let mut reader_refs = Vec::new();
     for vertex_id in &reader_vertex_ids {
         let reader_actor = TestDataReaderActor::new(
-            Arc::<str>::from(vertex_id.as_str()),
-            configs.remove(vertex_id.as_str()).unwrap(),
+            *vertex_id,
+            configs.remove(vertex_id).unwrap(),
         );
         let reader_ref = spawn(reader_actor);
         reader_refs.push(reader_ref.clone());
@@ -106,18 +106,18 @@ async fn test_actor_transport() {
         // Start writer
         let writer_ref = &writer_refs[writer_idx];
         writer_ref.ask(crate::transport::test_utils::TestDataWriterMessage::Start).await.unwrap();
-        
+
         // Send message to each reader
         for message_idx in 0..messages_per_writer {
             let message = Message::new(
-                Some(format!("writer{}_stream", writer_idx)),
+                Some(writer_vertex_ids[writer_idx]),
                 create_test_string_batch(vec![format!("writer{}_batch{}", writer_idx, message_idx)]),
                 Some(100),
                 None
             );
             for reader_idx in 0..num_readers {
-                let edge_id = gen_edge_id(&writer_vertex_ids[writer_idx].clone(), &reader_vertex_ids[reader_idx].clone());
-                let channel = graph.get_edge(&edge_id).unwrap().get_channel();
+                let edge_id = ChannelId::new(writer_vertex_ids[writer_idx], reader_vertex_ids[reader_idx]);
+                let channel = graph.get_edge(edge_id).unwrap().get_channel();
                 writer_ref.ask(crate::transport::test_utils::TestDataWriterMessage::WriteMessage {
                     channel,
                     message: message.clone(),
@@ -133,7 +133,7 @@ async fn test_actor_transport() {
     // Verify data received by each reader
     for reader_idx in 0..num_readers {
         let mut received_messages = Vec::new();
-        
+
         // Read all expected batches
         for _ in 0..(num_writers * messages_per_writer) {
             let result = reader_refs[reader_idx].ask(crate::transport::test_utils::TestDataReaderMessage::ReadMessage).await.unwrap();
@@ -143,7 +143,7 @@ async fn test_actor_transport() {
         }
 
         // Verify we got all expected batches
-        assert_eq!(received_messages.len(), num_writers * messages_per_writer, 
+        assert_eq!(received_messages.len(), num_writers * messages_per_writer,
             "Reader {} did not receive all expected batches", reader_idx);
 
         // Create a map to track received batches by writer and batch number
@@ -155,13 +155,13 @@ async fn test_actor_transport() {
                 .downcast_ref::<StringArray>()
                 .unwrap()
                 .value(0);
-            
+
             // Parse writer_idx and batch_num from the value
             let parts: Vec<&str> = value.split("_batch").collect();
             let writer_part = parts[0].strip_prefix("writer").unwrap();
             let writer_idx = writer_part.parse::<usize>().unwrap();
             let message_idx = parts[1].parse::<usize>().unwrap();
-            
+
             received_map.insert((writer_idx, message_idx), value.to_string());
         }
 
@@ -178,4 +178,4 @@ async fn test_actor_transport() {
 
     // Close the backend
     backend_ref.ask(TransportBackendActorMessage::Close).await.unwrap();
-} 
+}

--- a/src/transport/transport_client.rs
+++ b/src/transport/transport_client.rs
@@ -8,6 +8,7 @@ use tokio::sync::Notify;
 use futures::stream;
 use crate::transport::batcher::BatcherConfig;
 use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use crate::common::ChannelId;
 use crate::runtime::VertexId;
 
 // pub type MessageStream = Pin<Box<dyn Stream<Item = Message> + Send>>;
@@ -15,8 +16,8 @@ use crate::runtime::VertexId;
 #[derive(Debug)]
 pub struct TransportClientConfig {
     pub vertex_id: VertexId,
-    pub reader_receivers: Option<HashMap<String, BatchReceiver>>,
-    pub writer_senders: Option<HashMap<String, BatchSender>>,
+    pub reader_receivers: Option<HashMap<ChannelId, BatchReceiver>>,
+    pub writer_senders: Option<HashMap<ChannelId, BatchSender>>,
     pub metrics_labels: Option<MetricsLabels>,
 }
 
@@ -30,14 +31,14 @@ impl TransportClientConfig {
         }
     }
 
-    pub fn add_reader_receiver(&mut self, channel_id: String, receiver: BatchReceiver) {
+    pub fn add_reader_receiver(&mut self, channel_id: ChannelId, receiver: BatchReceiver) {
         if self.reader_receivers.is_none() {
             self.reader_receivers = Some(HashMap::new());
         }
         self.reader_receivers.as_mut().unwrap().insert(channel_id, receiver);
     }
 
-    pub fn add_writer_sender(&mut self, channel_id: String, sender: BatchSender) {
+    pub fn add_writer_sender(&mut self, channel_id: ChannelId, sender: BatchSender) {
         if self.writer_senders.is_none() {
             self.writer_senders = Some(HashMap::new());
         }
@@ -52,7 +53,7 @@ impl TransportClientConfig {
 #[derive(Debug)]
 pub struct DataReader {
     _vertex_id: VertexId,
-    receivers: HashMap<String, BatchReceiver>,
+    receivers: HashMap<ChannelId, BatchReceiver>,
 }
 
 #[derive(Debug)]
@@ -82,18 +83,18 @@ impl UpstreamGate {
 #[derive(Debug, Clone)]
 pub struct DataReaderControl {
     // upstream_vertex_id -> gate shared by all channels from that upstream
-    gates: HashMap<String, Arc<UpstreamGate>>,
+    gates: HashMap<VertexId, Arc<UpstreamGate>>,
 }
 
 impl DataReaderControl {
-    pub fn block_upstream(&self, upstream_vertex_id: &str) {
-        if let Some(gate) = self.gates.get(upstream_vertex_id) {
+    pub fn block_upstream(&self, upstream_vertex_id: VertexId) {
+        if let Some(gate) = self.gates.get(&upstream_vertex_id) {
             gate.block();
         }
     }
 
-    pub fn unblock_upstream(&self, upstream_vertex_id: &str) {
-        if let Some(gate) = self.gates.get(upstream_vertex_id) {
+    pub fn unblock_upstream(&self, upstream_vertex_id: VertexId) {
+        if let Some(gate) = self.gates.get(&upstream_vertex_id) {
             gate.unblock();
         }
     }
@@ -111,7 +112,7 @@ impl DataReaderControl {
 }
 
 impl DataReader {
-    pub fn new(vertex_id: VertexId, receivers: HashMap<String, BatchReceiver>) -> Self {
+    pub fn new(vertex_id: VertexId, receivers: HashMap<ChannelId, BatchReceiver>) -> Self {
         Self {
             _vertex_id: vertex_id,
             receivers,
@@ -132,12 +133,12 @@ impl DataReader {
                 })) as MessageStream
             })
             .collect();
-        
+
         Box::pin(stream::select_all(receiver_streams))
     }
 
     pub fn message_stream_with_control(self) -> (MessageStream, DataReaderControl) {
-        let mut gates: HashMap<String, Arc<UpstreamGate>> = HashMap::new();
+        let mut gates: HashMap<VertexId, Arc<UpstreamGate>> = HashMap::new();
 
         // Convert each BatchReceiver into a gated stream and then select_all.
         // No background tasks: gating happens inside the stream.
@@ -145,11 +146,7 @@ impl DataReader {
             .into_iter()
             .map(|(channel_id, receiver)| {
                 // channel id is "{source}_to_{target}"
-                let upstream_vertex_id = channel_id
-                    .split("_to_")
-                    .next()
-                    .unwrap_or("")
-                    .to_string();
+                let upstream_vertex_id = channel_id.target();
 
                 let gate = gates
                     .entry(upstream_vertex_id)
@@ -178,7 +175,7 @@ impl DataReader {
 #[derive(Debug, Clone)]
 pub struct DataWriter {
     pub vertex_id: VertexId,
-    pub senders: HashMap<String, BatchSender>,
+    pub senders: HashMap<ChannelId, BatchSender>,
     metrics_labels: Option<MetricsLabels>,
     // batcher: Batcher,
     default_timeout: Duration,
@@ -187,10 +184,10 @@ pub struct DataWriter {
 }
 
 impl DataWriter {
-    pub fn new(vertex_id: VertexId, senders: HashMap<String, BatchSender>, metrics_labels: Option<MetricsLabels>) -> Self {
+    pub fn new(vertex_id: VertexId, senders: HashMap<ChannelId, BatchSender>, metrics_labels: Option<MetricsLabels>) -> Self {
         let batching_config = BatcherConfig::default();
         // let batcher = Batcher::new(batching_config.clone(), senders.clone());
-        
+
         Self {
             vertex_id,
             senders,
@@ -238,12 +235,14 @@ impl DataWriter {
                 let queue_size = sender.size();
                 let queue_remaining = sender.capacity();
                 let target_vertex_id = channel.get_target_vertex_id();
+                let vertex_label = self.vertex_id.to_string();
+                let target_vertex_label = target_vertex_id.to_string();
 
                 if let Some(labels) = &self.metrics_labels {
                     gauge!(
                         METRIC_STREAM_TASK_TX_QUEUE_SIZE,
-                        LABEL_VERTEX_ID => self.vertex_id.clone(),
-                        LABEL_TARGET_VERTEX_ID => target_vertex_id.clone(),
+                        LABEL_VERTEX_ID => vertex_label.clone(),
+                        LABEL_TARGET_VERTEX_ID => target_vertex_label.clone(),
                         LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                         LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                         LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -251,8 +250,8 @@ impl DataWriter {
                     ).set(queue_size);
                     gauge!(
                         METRIC_STREAM_TASK_TX_QUEUE_REM,
-                        LABEL_VERTEX_ID => self.vertex_id.clone(),
-                        LABEL_TARGET_VERTEX_ID => target_vertex_id.clone(),
+                        LABEL_VERTEX_ID => vertex_label.clone(),
+                        LABEL_TARGET_VERTEX_ID => target_vertex_label.clone(),
                         LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                         LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                         LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
@@ -261,18 +260,18 @@ impl DataWriter {
                     let backpressure = 1.0 - (queue_remaining as f64 + 1.0) / (queue_size as f64 + 1.0);
                     gauge!(
                         METRIC_STREAM_TASK_BACKPRESSURE_RATIO,
-                        LABEL_VERTEX_ID => self.vertex_id.clone(),
-                        LABEL_TARGET_VERTEX_ID => target_vertex_id.clone(),
+                        LABEL_VERTEX_ID => vertex_label,
+                        LABEL_TARGET_VERTEX_ID => target_vertex_label,
                         LABEL_PIPELINE_SPEC_ID => labels.pipeline_spec_id.clone(),
                         LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                         LABEL_ATTEMPT_ID => labels.attempt_id.to_string(),
                         LABEL_WORKER_ID => labels.worker_id.clone()
                     ).set(backpressure);
                 } else {
-                    gauge!(METRIC_STREAM_TASK_TX_QUEUE_SIZE, LABEL_VERTEX_ID => self.vertex_id.clone(), LABEL_TARGET_VERTEX_ID => target_vertex_id.clone()).set(queue_size);
-                    gauge!(METRIC_STREAM_TASK_TX_QUEUE_REM, LABEL_VERTEX_ID => self.vertex_id.clone(), LABEL_TARGET_VERTEX_ID => target_vertex_id.clone()).set(queue_remaining);
+                    gauge!(METRIC_STREAM_TASK_TX_QUEUE_SIZE, LABEL_VERTEX_ID => vertex_label.clone(), LABEL_TARGET_VERTEX_ID => target_vertex_label.clone()).set(queue_size);
+                    gauge!(METRIC_STREAM_TASK_TX_QUEUE_REM, LABEL_VERTEX_ID => vertex_label.clone(), LABEL_TARGET_VERTEX_ID => target_vertex_label.clone()).set(queue_remaining);
                     let backpressure = 1.0 - (queue_remaining as f64 + 1.0) / (queue_size as f64 + 1.0);
-                    gauge!(METRIC_STREAM_TASK_BACKPRESSURE_RATIO, LABEL_VERTEX_ID => self.vertex_id.clone(), LABEL_TARGET_VERTEX_ID => target_vertex_id.clone()).set(backpressure);
+                    gauge!(METRIC_STREAM_TASK_BACKPRESSURE_RATIO, LABEL_VERTEX_ID => vertex_label, LABEL_TARGET_VERTEX_ID => target_vertex_label).set(backpressure);
                 }
                 match time::timeout(timeout_duration, sender.send(message.clone())).await {
                     Ok(Ok(())) => {
@@ -291,12 +290,12 @@ impl DataWriter {
                 panic!("DataWriter {:?} channel {} not found", self.vertex_id, channel_id);
             }
         }
-    
+
         (false, start_time.elapsed().as_millis() as u32)
     }
 
-    pub fn get_queue_size_and_capacity(&self, channel_id: &str) -> Option<(u32, u32)> {
-        self.senders.get(channel_id).map(|sender| (sender.size(), sender.capacity()))
+    pub fn get_queue_size_and_capacity(&self, channel_id: ChannelId) -> Option<(u32, u32)> {
+        self.senders.get(&channel_id).map(|sender| (sender.size(), sender.capacity()))
     }
 }
 
@@ -328,7 +327,7 @@ impl TransportClient {
         }
     }
 
-    pub fn vertex_id(&self) -> &str {
-        self.vertex_id.as_ref()
+    pub fn vertex_id(&self) -> VertexId {
+        self.vertex_id.clone()
     }
 }


### PR DESCRIPTION
The point of the PR is:
1. Replace string-based identifiers with typed numeric IDs on the hot path.
2. Give each ID-like concept its own struct/enum so the type system enforces correctness.
3. Reduce allocations and improve cache efficiency.

OperatorTypeCode — a #[repr(u8)] enum that assigns a stable numeric code to each concrete operator variant. Restricts the system to at most 255 distinct operator types. Codes must only be appended (never renumbered) so existing checkpoints and serialized IDs stay interpretable.
OperatorId — a u16 identifier for a logical operator node within the execution graph. Layout: [op_type: u8 | instance: u8], where the upper 8 bits hold the OperatorTypeCode and the lower 8 bits hold the instance index of that operator type within the graph. All parallel partitions of the same operator share one OperatorId.
VertexId — a u32 identifier for a single execution vertex (one parallel partition of an operator). Layout: [op_type: u8 | instance: u8 | task_index: u16], where the upper 16 bits form the OperatorId and the lower 16 bits identify the parallel partition within that operator.
ChannelId — a u64 globally unique identifier for a directed channel between two vertices. Layout: [source: VertexId | target: VertexId], upper 32 bits for the source and lower 32 bits for the target.
Also added: Display/Debug formatters, accessor methods, and unit tests covering round-trips, layout packing, and display output.

Also added formatters, helper methods and tests.