### PR TITLE
Scylla window store design: versioned cut history with checkpoint publication

### DIFF
--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -154,15 +154,16 @@ for the attempt:
 
 ```text
 StateNamespace  = (pipeline, owner operator)
+max_parallelism = job-wide, bound on the client
 KeyGroupRange   = groups for this task_index at (p, max_p)
 WriterId        = this task execution
 AttemptToken    = job-level execution attempt
 ```
 
-`stream_due` / `checkpoint` / `restore` use that bound range. They do not take
-`owned` or `namespace` — the client is the task's store. Per-key calls derive
-`key_group` from the business key and must land in the bound range (routing
-bug otherwise).
+The client derives `key_group` from `Key.hash` and bound `max_p`. It never
+trusts a caller-supplied group. `stream_due` / `checkpoint` / `restore` use
+the bound range and do not take `owned` or `namespace`. Per-key calls must
+land in the bound range (routing bug otherwise).
 
 WRO reuses the WO owner namespace. It addresses rows by `PartitionKey`
 (namespace + business key). Request routing still sends a lookup to the WRO
@@ -239,7 +240,9 @@ pub trait WindowRequestStore: Send + Sync + Debug {
 
 - Missing partitions and empty runs return empty/default results.
 - Raw rows are restricted to the requested runs, deduplicated, and globally
-  ordered by `Cursor`. Their Arrow schema includes `__seq_no: UInt64`.
+  ordered by `Cursor`. Their Arrow schema includes `__seq_no: UInt64`. The
+  Scylla backend stores **one CQL row per event**, clustered by time; it does
+  not pack events into a serialized batch blob.
 - Tiles are unique by `(granularity, tile_start)` and restricted to requested
   runs. Missing tiles mean empty intervals.
 - `commit_events` atomically publishes raw rows, replacement tiles, key state,
@@ -270,6 +273,13 @@ state and triggers for that range. The shared backend implements
 `OperatorStore::maintain` and prunes eagerly under the same retention contract
 as Scylla (control flow identical; lag ~0), reading the range from
 `OperatorTaskState` rather than a task-suffixed namespace blob.
+
+**Land the engine contract and InMem before any Scylla backend.** Today
+`StateNamespace` still includes `task_index`, and restore/maintain key on that
+blob. Operator-scoped namespace plus range isolation must ship on the traits
+and InMem first (two tasks, one worker: restore/maintain of task 0 must not
+clobber task 1). Otherwise the same type has two meanings and shared-worker
+restore wipes sibling keys. Scylla implements that already-landed contract.
 
 ## Runtime flows
 
@@ -404,6 +414,28 @@ watermark remain in the operator's `WindowStateSnapshot` envelope.
 
 ### Tables
 
+`attempt` is **not** in any data partition key. It is clustering (or a
+column) so recovery overlay is a visibility filter on one `LOCAL_QUORUM`
+read, not a second partition hop. Restore still does not copy rows.
+`maintain` drops unreachable generations so the filter stays one or two
+attempt clauses.
+
+**GC default: skinny index + per-key data PK. Do not cluster `business_key`
+under `(namespace, key_group, bucket)`.** `load_raw` is per-key; a key group
+is unbounded, so that clustering would make one partition (compaction,
+repair, hot token) hold every key in the group+bucket. Keep `business_key`
+in the data partition key so each key+bucket stays small.
+
+That data layout cannot list “this key group” or `bucket_start < data_floor`,
+so `commit_events` also writes a payload-free index
+`(namespace, key_group, bucket_start) → business_key`. `maintain` walks
+event-time `bucket_start` values below `data_floor` (configured bucket width;
+empty index partitions are skipped), pages each partition, and deletes the
+per-key data partitions. If the key count per group+bucket grows large, shard
+the index (`index_shard = hash(business_key) % N`) so each index partition
+stays bounded. TWCS/TTL on write-time cannot replace this: event-time buckets
+≠ write time, and replay rewrites old buckets.
+
 ```sql
 CREATE TABLE window_head (
     namespace blob,
@@ -428,32 +460,43 @@ CREATE TABLE window_recovery_bases (
     PRIMARY KEY ((namespace, recovery_attempt), range_start)
 );
 
+-- Skinny GC index only: no payloads. v1: one partition per group+bucket.
+-- If that partition grows too wide, add index_shard to the partition key
+-- (hash(business_key) % N) and page all shards in maintain.
+CREATE TABLE window_kg_buckets (
+    namespace blob,
+    key_group int,
+    bucket_start bigint,
+    business_key blob,
+    PRIMARY KEY ((namespace, key_group, bucket_start), business_key)
+);
+
 CREATE TABLE window_raw (
     namespace blob,
     key_group int,
     business_key blob,
-    attempt blob,
     bucket_start bigint,
     event_ts bigint,
     seq_no bigint,
+    attempt blob,
     epoch bigint,
     payload blob,
     PRIMARY KEY (
-        (namespace, key_group, business_key, attempt, bucket_start),
-        event_ts, seq_no, epoch
+        (namespace, key_group, business_key, bucket_start),
+        event_ts, seq_no, attempt, epoch
     )
 ) WITH CLUSTERING ORDER BY (
-    event_ts ASC, seq_no ASC, epoch DESC
+    event_ts ASC, seq_no ASC, attempt ASC, epoch DESC
 );
 
 CREATE TABLE window_tiles (
     namespace blob,
     key_group int,
     business_key blob,
-    attempt blob,
     granularity_ms bigint,
     bucket_start bigint,
     tile_start bigint,
+    attempt blob,
     epoch bigint,
     payload blob,
     PRIMARY KEY (
@@ -461,13 +504,12 @@ CREATE TABLE window_tiles (
             namespace,
             key_group,
             business_key,
-            attempt,
             granularity_ms,
             bucket_start
         ),
-        tile_start, epoch
+        tile_start, attempt, epoch
     )
-) WITH CLUSTERING ORDER BY (tile_start ASC, epoch DESC);
+) WITH CLUSTERING ORDER BY (tile_start ASC, attempt ASC, epoch DESC);
 
 CREATE TABLE window_key_states (
     namespace blob,
@@ -477,81 +519,85 @@ CREATE TABLE window_key_states (
     epoch bigint,
     key_state blob,
     PRIMARY KEY (
-        (namespace, key_group, business_key, attempt),
-        epoch
+        (namespace, key_group, business_key),
+        attempt, epoch
     )
-) WITH CLUSTERING ORDER BY (epoch DESC);
+) WITH CLUSTERING ORDER BY (attempt ASC, epoch DESC);
 
 CREATE TABLE window_triggers (
     namespace blob,
-    attempt blob,
     bucket_start bigint,
     kg_shard int,
-    key_group int,
     fire_ts bigint,
     fire_seq bigint,
     business_key blob,
     trigger_kind tinyint,
     window_id bigint,
+    key_group int,
+    attempt blob,
     epoch bigint,
     PRIMARY KEY (
-        (namespace, attempt, bucket_start, kg_shard),
-        key_group,
+        (namespace, bucket_start, kg_shard),
         fire_ts,
         fire_seq,
         business_key,
         trigger_kind,
         window_id,
+        attempt,
         epoch
     )
 ) WITH CLUSTERING ORDER BY (
-    key_group ASC,
     fire_ts ASC,
     fire_seq ASC,
     business_key ASC,
     trigger_kind ASC,
     window_id ASC,
+    attempt ASC,
     epoch DESC
 );
 ```
 
 - `window_head`: per-key writer fence plus writer and WRO-visible version
   pointers; the LWT publication boundary. `owner_writer` is `WriterId`.
-  `writer_*` / `serving_*` are job-level `StateVersion`. `key_group` is in the
-  partition key so point gets (WO already has the hash) stay single-partition
-  and a key group cannot collapse into one unbounded Scylla partition.
+  `writer_*` / `serving_*` are job-level `StateVersion`. Point get by
+  `(namespace, key_group, business_key)`.
 - `window_recovery_bases`: immutable rows mapping a new job `recovery_attempt`
   to restored checkpoint cutoffs at **key-group range** granularity. Lookup for
   a key: find the row with `range_start <= key_group < range_end`. This lets a
   new execution inherit unchanged state without copying raw rows, tiles, or
   `KeyState`, and lets a later rescale inherit different cutoffs from different
   source tasks.
-- `window_raw`: cursor-ordered event rows, physically split into time buckets
-  and versioned by job attempt and epoch.
-- `window_tiles`: versioned aggregate tiles, partitioned by time bucket and
-  granularity.
-- `window_key_states`: versioned `KeyState` history used by current WO reads and
-  checkpoint recovery.
-- `window_triggers`: immutable due work ordered by event time. Time buckets and
-  `kg_shard` bound each Scylla partition. Shard with the **same range formula
-  as routing**, not `hash(business_key) % N`:
+- `window_kg_buckets`: skinny GC index, not a source of truth for reads.
+  `commit_events` upserts `business_key` under
+  `(namespace, key_group, bucket_start)` — no payload columns. `maintain`
+  pages each owned group’s buckets below `data_floor` (by event-time bucket
+  id, not a cross-bucket clustering scan) and deletes the matching **per-key**
+  raw/tile partitions, then the index rows. Shard the index partition key if
+  one group+bucket has too many keys.
+- `window_raw`: **one CQL row per event**, clustered by event time. `payload`
+  is that event only (Arrow-IPC including `__seq_no`). Do not pack a batch
+  into one blob — that breaks time clustering, overlay, and per-event GC.
+- `window_tiles`: versioned aggregate tiles, partitioned by key, granularity,
+  and time bucket. Overlay filters `attempt` / `epoch` in the same partition.
+- `window_key_states`: versioned `KeyState` in one partition per key. Overlay
+  is a clustering filter, not another hop.
+- `window_triggers`: immutable due work. Locality is
+  `(namespace, bucket_start, kg_shard)`. Cluster by `fire_ts` first so
+  `stream_due` can slice `(after, through]` without `ALLOW FILTERING`.
+  `key_group` is a regular column; the client drops rows outside the bound
+  range (`kg_shard` already limits how many groups share a partition).
+  Shard with the **same range formula as routing**, not
+  `hash(business_key) % N`:
 
   ```text
   kg_shard = key_group * SHARD_COUNT / max_parallelism
   ```
 
-  A task's contiguous groups map to a small number of shards, so `stream_due`
-  queries those shards and restricts clustering to the client's bound range.
-  `SHARD_COUNT` is a
-  store constant (e.g. 32 or 64), not `p` (changes on rescale) and not
-  `max_parallelism` (too fine: `p=4`, `max_p=32768` would otherwise mean 8192
-  queries per time bucket). `SHARD_COUNT` and `max_parallelism` are immutable
-  for the namespace. Hash-mod sharding would scatter one task across every
-  shard and is not used. Row triggers use a sentinel `window_id`; scheduled
-  windows retain their actual `WindowId`. Job-level `attempt` stays in the
-  trigger PK as the MVCC branch (recovery overlay), not as a task id.
-
-Raw payloads are Arrow-IPC `RecordBatch` values including `__seq_no`.
+  `SHARD_COUNT` is a store constant (e.g. 32 or 64), not `p` (changes on
+  rescale) and not `max_parallelism` (too fine: `p=4`, `max_p=32768` would
+  otherwise mean 8192 queries per time bucket). `SHARD_COUNT` and
+  `max_parallelism` are immutable for the namespace. Row triggers use a
+  sentinel `window_id`; scheduled windows retain their actual `WindowId`.
 
 ### Head semantics
 
@@ -577,52 +623,72 @@ For one key:
 
 1. Load writer `KeyState`.
 2. Allocate writer epoch `E`.
-3. Write changed raw rows, tiles, `KeyState`, and triggers under
-   `(job attempt, E)` with the derived `key_group`.
-4. LWT-update the head, requiring the current `owner_writer` and previous
+3. Derive `key_group` from the key hash and the client's `max_p`.
+4. Write changed raw rows, tiles, `KeyState`, triggers, and `window_kg_buckets`
+   under `(job attempt, E)`.
+5. LWT-update the head, requiring the current `owner_writer` and previous
    writer version.
-5. During normal operation, set both writer and serving versions to
+6. During normal operation, set both writer and serving versions to
    `(job attempt, E)`. During recovery, advance only writer until catch-up.
-6. Update or invalidate affected WO cache entries.
+7. Update or invalidate affected WO cache entries.
 
-The head update is the visibility boundary. Data written before a failed head
-update is orphaned. A new epoch starts only after the previous publication
-outcome is known. On success, advance the epoch; on failure, safely retry the
-same publication or abort the attempt. An ownership CAS failure stops the WO as
-fenced. Trigger rows from an unpublished attempt/epoch are orphaned with its
-other data and are not returned by `stream_due`.
+Each `(key, bucket)` (and each tile partition) is one Scylla partition.
+`commit_events` issues one **UNLOGGED BATCH** per such partition — one
+mutation per event/tile row, one RTT per partition, not one RTT per event.
+Do not use logged BATCH. Do not batch across partitions (no cross-partition
+atomicity, coordinator penalty). Tiles, triggers, and other buckets are
+separate requests. The head LWT is the visibility boundary after those
+writes complete.
 
-`store_key_state` follows the same protocol but writes no raw, tile, or trigger
-versions.
+Data written before a failed head update is orphaned. A new epoch starts only
+after the previous publication outcome is known. On success, advance the
+epoch; on failure, safely retry the same publication or abort the attempt.
+An ownership CAS failure stops the WO as fenced. Trigger rows from an
+unpublished attempt/epoch are orphaned with its other data and are not
+returned by `stream_due`.
+
+`store_key_state` follows the same protocol but writes no raw, tile, trigger,
+or bucket-index rows.
 
 ### WO reads
 
 WO reads the writer snapshot. A fresh execution attempt reads only its own
 versions. A recovery attempt overlays its versions over the immutable
-checkpoint base from `window_recovery_bases`: read the newest value from the
-recovery attempt first, then fall back to the base version for that key's
-range (`epoch <= base_epoch`) for data not replaced by recovery writes.
+checkpoint base from `window_recovery_bases`. Because `attempt` is clustering,
+that overlay is one `LOCAL_QUORUM` read per data partition: keep the newest
+row that matches the recovery attempt, else the base attempt with
+`epoch <= base_epoch`. No extra partition hop, and restore still does not
+copy rows.
 
 Logical runs are mapped to time buckets, loaded, merged, and filtered back to
 the exact requested ranges. Raw rows are deduplicated by `Cursor`; current
 tiles replace matching base tiles.
 
 `stream_due` maps its stable watermark range to trigger buckets and the
-`kg_shard`s that overlap the client's bound range, overlays the recovery
-attempt over each inherited base range, and filters trigger versions through
-each key's writer head. It batch-loads writer `KeyState`, groups triggers into
-`DueWindowWork`, and owns page sizing and continuation state for the lifetime
-of the stream.
+`kg_shard`s that overlap the client's bound range. Each query is
+
+```text
+WHERE namespace = ? AND bucket_start = ? AND kg_shard = ?
+  AND fire_ts > ? AND fire_ts <= ?
+```
+
+then the client drops `key_group` outside the bound range and applies the
+same attempt/epoch visibility filter as raw overlay. It batch-loads writer
+`KeyState`, groups triggers into `DueWindowWork`, and owns page sizing and
+continuation state for the lifetime of the stream.
 
 ### WRO reads
 
 WRO:
 
-1. Reads and retains the key's serving version for the request.
+1. Reads and retains the key's serving version for the request (the pin
+   `maintain` must honor).
 2. Builds exact raw/tile plans.
-3. Loads serving-attempt buckets. If that attempt has a recovery-base row
-   covering this `key_group`, loads unchanged data from its base checkpoint as
-   well. This may repeat when checkpoints span several recovery attempts.
+3. Loads serving-attempt data from the same partitions, filtering clustering
+   `attempt` / `epoch`. If that attempt has a recovery-base covering this
+   `key_group`, the base generation is visible in those same partitions.
+   Chain only as many recovery-base generations as `maintain` has not yet
+   dropped (target: 1–2 clauses).
 4. Selects visible versions, then merges, orders, deduplicates, and rebuilds.
 
 WRO does not read writer state, use Foyer, contact the master, or consume
@@ -736,29 +802,38 @@ Not on the master; not inside WO `poll_next`. The window impl reads cutoff and
 owned range from `OperatorTaskState`.
 
 **Window `maintain` body:**
-- drop consumed triggers (`fire_at.ts ≤ W`) in shards overlapping the task's
-  key-group range (from `OperatorTaskState`);
-- prune raw rows with `ts < data_floor` and tiles fully below the floor
-  (Scylla: time-bucket drop / TWCS / TTL aligned with `data_floor`; per-key
-  partitions are not listed by scan);
-- Scylla additionally: MVCC cleanup of versions unreachable from writer heads,
-  serving heads, recovery bases, and retained checkpoints; orphan/zombie
-  cleanup for failed writes.
+- drop consumed triggers (`fire_at.ts ≤ W`) with a `fire_ts` clustering
+  range delete on shards overlapping the task's key-group range;
+- from `window_kg_buckets`, for each owned group and each event-time
+  `bucket_start` fully below `data_floor`, page `business_key`s (and index
+  shards if enabled); delete each per-key raw/tile partition; drop the
+  index rows. Do not rely on TWCS/TTL for this (write-time ≠ event-time;
+  replay rewrites old buckets);
+- drop unreachable MVCC generations (`attempt` / `epoch` not reachable
+  from writer heads, serving heads, recovery bases, or retained
+  checkpoints; orphan/zombie writes). After this, overlay filters stay
+  one or two attempt clauses.
+
+**In-flight WRO:** `load_window_data` pins the key's serving version at
+start. `maintain` must not drop that version while the request can still
+read it. v1: never delete the current serving pointer; delay dropping a
+just-superseded serving version by at least the maximum WRO request
+budget (grace). No pin table.
 
 TTL/TWCS may expire physical SSTables only when consistent with logical
-`data_floor`. InMem applies the same logical rules immediately inside
-`maintain`, iterating in-memory partitions whose namespace matches and whose
-`key_group` is in the task state's range.
+`data_floor` **and** the serving-pin grace. InMem applies the same logical
+rules immediately inside `maintain`, iterating in-memory partitions whose
+namespace matches and whose `key_group` is in the task state's range.
 
 ## Future next steps
 
+**Prerequisite:** operator-scoped `StateNamespace`, per-task store client
+(`max_p`, key-group range), and InMem restore/maintain isolation (two tasks
+on one worker, no clobber). Then Scylla.
+
 Worker maintenance **orchestration** (`OperatorStore::maintain`, cleaner loop,
 `StateSpec.maintenance_*`) is decided in the runtime; Scylla's `maintain`
-implementation remains TODO.
-
-Engine `StateNamespace`, per-task store client bound to the assigned
-`KeyGroupRange`, InMem filter-by-range, and the Scylla schemas above should
-land together. v1 `RestorePlanner` may keep identity mapping.
+implementation remains TODO. v1 `RestorePlanner` may keep identity mapping.
 
 ### Namespaced cache quota
 

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -1,0 +1,496 @@
+# Window store with Scylla design
+
+`WindowOperatorStore` serves the sole WO owner of a key.
+`WindowRequestStore` serves coherent WRO point lookups. Physical layout, MVCC,
+serialization, and caching stay inside the backend.
+
+The current data contract is append-only. CDC and late-event correction will
+require explicit mutation semantics rather than implicit delete markers - this is future work
+
+## Contract types
+
+These are the logical models; backend serialization may differ.
+
+```rust
+pub struct StateNamespace {
+    pub bytes: Vec<u8>,
+}
+pub struct PartitionKey {
+    pub namespace: Vec<u8>,
+    pub business_key: Vec<u8>,
+}
+pub struct Cursor {
+    pub ts: i64,
+    pub seq_no: u64,
+}
+pub struct RawRun {
+    pub from: Cursor,
+    pub to: Cursor,
+}
+pub struct TileRun {
+    pub granularity: TimeGranularity,
+    pub start_ts: i64,
+    pub end_ts_exclusive: i64,
+}
+pub enum TimeGranularity {
+    Seconds(u32),
+    Minutes(u32),
+    Hours(u32),
+    Days(u32),
+    Months(u32),
+}
+pub type WindowId = usize;
+pub type AccumulatorState = Vec<ScalarValue>;
+pub struct KeyState {
+    pub max_seen: Option<Cursor>,
+    pub processed_pos: Option<Cursor>,
+    pub accumulators: BTreeMap<WindowId, AccumulatorState>,
+    pub first_ingested: Option<Cursor>,
+    pub next_seq: u64,
+    pub retention_floor: Option<Cursor>,
+}
+pub struct TileState {
+    pub accumulator_state: Option<AccumulatorState>,
+}
+pub struct WindowTiles {
+    pub windows: BTreeMap<WindowId, TileState>,
+}
+pub type TileMap =
+    BTreeMap<(TimeGranularity, i64 /* tile_start */), WindowTiles>;
+pub struct WindowData {
+    raw_batches: Vec<RecordBatch>,
+    tile_map: TileMap,
+}
+```
+
+- `PartitionKey` must remain collision-safe; hashes alone are insufficient.
+  In practice, persist the serialized business-key bytes directly, as in the
+  schemas below. Scylla hashes the complete partition key for distribution.
+- `Cursor` is raw event identity and total order within a partition.
+- `RawRun` and `TileRun` are half-open. Calls contain merged logical runs, and
+  backends must return exactly their union.
+- `max_seen` is the greatest ingested cursor; `processed_pos` is the evaluated
+  frontier; `first_ingested` is the cold-start bound; `next_seq` allocates
+  per-key sequence IDs.
+- `retention_floor` is the first cursor still required by logical retention.
+- Tiles for all windows share `(granularity, tile_start)`, so persisted tile and
+  accumulator state retain `WindowId`.
+- `WindowData` is one materialized WRO snapshot. Evaluation filters its rows by
+  cursor; batches need not be mapped back to individual runs.
+
+## Store traits
+
+```rust
+#[async_trait]
+pub trait WindowOperatorStore: Send + Sync + Debug {
+    async fn load_meta(&self, partition: &PartitionKey) -> Result<KeyState>;
+    async fn load_raw(
+        &self,
+        partition: &PartitionKey,
+        runs: &[RawRun],
+    ) -> Result<Vec<RecordBatch>>;
+    async fn load_tiles(
+        &self,
+        partition: &PartitionKey,
+        runs: &[TileRun],
+    ) -> Result<TileMap>;
+    async fn commit_events(
+        &self,
+        partition: &PartitionKey,
+        ts_column_index: usize,
+        events: &RecordBatch,
+        tiles: &TileMap,
+        meta: &KeyState,
+    ) -> Result<()>;
+    async fn store_meta(&self, partition: &PartitionKey, meta: &KeyState)
+        -> Result<()>;
+    async fn flush(&self) -> Result<()> {
+        Ok(())
+    }
+    async fn checkpoint(
+        &self,
+        namespace: &StateNamespace,
+    ) -> Result<WindowCheckpointMeta>;
+    async fn restore(
+        &self,
+        namespace: &StateNamespace,
+        meta: &WindowRestoreMeta,
+    ) -> Result<()>;
+}
+#[async_trait]
+pub trait WindowRequestStore: Send + Sync + Debug {
+    async fn load_window_data(
+        &self,
+        partition: &PartitionKey,
+        raw_runs: &[RawRun],
+        tile_runs: &[TileRun],
+    ) -> Result<WindowData>;
+}
+```
+
+### Required behavior
+
+- Missing partitions and empty runs return empty/default results.
+- Raw rows are restricted to the requested runs, deduplicated, and globally
+  ordered by `Cursor`. Their Arrow schema includes `__seq_no: UInt64`.
+- Tiles are unique by `(granularity, tile_start)` and restricted to requested
+  runs. Missing tiles mean empty intervals.
+- `commit_events` atomically publishes raw rows, replacement tiles, and meta.
+  `ts_column_index` plus `__seq_no` identifies each raw cursor. Retries are
+  idempotent.
+- `store_meta` publishes only progress and retention state.
+- `checkpoint` resolves pending writes, flushes them, and returns the backend
+  version at the aligned barrier. It does not serialize window payloads.
+- `restore` starts store access from the supplied checkpoint base. For Scylla,
+  the current fenced attempt inherits reads from that immutable version.
+- The namespace argument scopes checkpoint and restore when one store instance
+  is shared by multiple window operators.
+- WO reads observe their latest publication. One fenced WO owns a partition, so
+  its historical raw and tile reads need not share a snapshot and can run
+  concurrently.
+- WRO: Each `load_window_data` is one coherent published snapshot across all
+  physical buckets and pages.
+- Methods must not broaden ranges or return partial results.
+
+`InMemWindowStore` is the reference backend. One lock provides the WRO snapshot
+boundary; asynchronous physical retention is not emulated.
+
+## Runtime flows
+
+WO ingest:
+
+1. Load meta, drop rows at or behind `processed_pos`, and assign sequence IDs.
+2. Load and update affected tiles.
+3. Atomically `commit_events(..., events, tiles, meta)`.
+
+WO advance:
+
+1. Load meta and derive the unprocessed cursor range.
+2. Load that raw range to discover the exact emit cursors.
+3. Build per-cursor plans. Sliding aggregates plan leave bands; rebuild
+   aggregates plan raw edges plus interior tiles.
+4. Merge the plans, then load historical raw edges and tiles concurrently.
+   Small ranges remain all-raw. Large slide leave bands may also use tiles.
+5. Evaluate using those same plans. New rows are always raw; rebuild interiors
+   do not overfetch raw rows.
+6. Publish updated progress, accumulators, and `retention_floor` with
+   `store_meta`.
+
+Tile-based slide retraction is limited to aggregates whose states can be
+subtracted safely (`SUM`, `COUNT`, and `AVG`). Other sliding aggregates retract
+raw leave-band rows. Rebuilds may use mergeable tile states for any aggregate.
+
+WRO lookup:
+
+1. Both plain and retractable aggregates use rebuild plans, since WRO has no
+   prior accumulator.
+2. Build and merge exact raw-edge and tile plans for all points and windows.
+3. Call `load_window_data` once for one coherent snapshot.
+4. Evaluate per-window request arguments and rebuild every answer.
+
+WRO is read-only
+
+## Scylla backend
+
+Scylla does not provide one snapshot spanning multiple partitions, CQL queries,
+or result pages. A logical window read may cross several physical ranges, so
+concurrent writes could otherwise make those pieces represent different
+moments. We us application-level MVCC to pin every piece to one published version and
+provide a coherent logical snapshot. We also use time buckets to keep physical partitions
+and individual range reads bounded instead of storing a key's entire history
+in one ever-growing partition.
+
+The initial backend assumes append-only input and stable task parallelism.
+(rescaling is future work)
+
+### Versions and checkpoints
+
+```rust
+pub struct StateVersion {
+    pub attempt: AttemptToken,
+    pub epoch: u64,
+}
+
+pub struct WindowCheckpointMeta {
+    pub version: StateVersion,
+}
+
+pub struct WindowRestoreMeta {
+    pub base_version: StateVersion,
+}
+```
+
+`AttemptToken` must uniquely identify a WO task execution across master
+restarts, for example pipeline incarnation + execution_attempt_id + task identity.
+It is both the writer fence and the recovery branch ID.
+
+Epoch is one task-wide counter within an attempt. Every publication, regardless
+of key, gets the next epoch. A new attempt may restart at zero because
+`(attempt, epoch)` remains unique. Scylla stores the two fields separately.
+The process-local in-memory backend keeps cloned snapshots indexed by a local
+version; those versions are valid only while that store instance survives.
+Namespace remains in the operator's checkpoint envelope.
+
+### Tables
+
+```sql
+CREATE TABLE window_head (
+    namespace blob,
+    business_key blob,
+    owner_attempt blob,
+    writer_attempt blob,
+    writer_epoch bigint,
+    serving_attempt blob,
+    serving_epoch bigint,
+    PRIMARY KEY ((namespace, business_key))
+);
+
+CREATE TABLE window_recovery_bases (
+    namespace blob,
+    recovery_attempt blob,
+    base_attempt blob,
+    base_epoch bigint,
+    PRIMARY KEY ((namespace, recovery_attempt))
+);
+
+CREATE TABLE window_raw (
+    namespace blob,
+    business_key blob,
+    attempt blob,
+    bucket_start bigint,
+    event_ts bigint,
+    seq_no bigint,
+    epoch bigint,
+    payload blob,
+    PRIMARY KEY (
+        (namespace, business_key, attempt, bucket_start),
+        event_ts, seq_no, epoch
+    )
+) WITH CLUSTERING ORDER BY (
+    event_ts ASC, seq_no ASC, epoch DESC
+);
+
+CREATE TABLE window_tiles (
+    namespace blob,
+    business_key blob,
+    attempt blob,
+    granularity_ms bigint,
+    bucket_start bigint,
+    tile_start bigint,
+    epoch bigint,
+    payload blob,
+    PRIMARY KEY (
+        (
+            namespace,
+            business_key,
+            attempt,
+            granularity_ms,
+            bucket_start
+        ),
+        tile_start, epoch
+    )
+) WITH CLUSTERING ORDER BY (tile_start ASC, epoch DESC);
+
+CREATE TABLE window_key_states (
+    namespace blob,
+    business_key blob,
+    attempt blob,
+    epoch bigint,
+    key_state blob,
+    PRIMARY KEY (
+        (namespace, business_key, attempt),
+        epoch
+    )
+) WITH CLUSTERING ORDER BY (epoch DESC);
+```
+
+- `window_head`: per-key ownership fence plus writer and WRO-visible version
+  pointers; the LWT publication boundary.
+- `window_recovery_bases`: one immutable row per recovery attempt. It maps the
+  new `recovery_attempt` to the restored checkpoint version
+  `(base_attempt, base_epoch)`. This lets the new attempt inherit unchanged
+  state without copying every raw row, tile, and `KeyState`.
+- `window_raw`: cursor-ordered event rows, physically split into time buckets
+  and versioned by attempt and epoch.
+- `window_tiles`: versioned aggregate tiles, partitioned by time bucket and
+  granularity.
+- `window_key_states`: versioned `KeyState` history used by current WO reads and
+  checkpoint recovery.
+
+Raw payloads are Arrow-IPC one-row `RecordBatch` values including `__seq_no`..
+
+### Head semantics
+
+- `owner_attempt` is the WO allowed to publish this key.
+- `writer_(attempt, epoch)` is the private WO snapshot.
+- `serving_(attempt, epoch)` is the complete snapshot visible to WRO.
+- Writer and serving versions are equal normally and may differ during
+  recovery.
+
+When a new WO instance (initial or recovery) first writes a key, it
+LWT/CAS-claims `owner_attempt`. Every later head update checks both owner and
+expected writer version.
+
+Claiming means conditionally setting `owner_attempt`: insert it for a new head,
+or replace the expected previous owner. Only one competing WO can succeed.
+Fencing happens when a zombie tries to update a head now owned by the new WO:
+the conditional update fails, so the zombie's data is not published.
+
+### Publication
+
+For one key:
+
+1. Load writer `KeyState`.
+2. Allocate task epoch `E`.
+3. Write changed raw rows, tiles, and `KeyState` under `(attempt, E)`.
+4. LWT-update the head, requiring the current owner and previous writer version.
+5. During normal operation, set both writer and serving versions to
+   `(attempt, E)`. During recovery, advance only writer until catch-up.
+6. Update or invalidate affected WO cache entries.
+
+The head update is the visibility boundary. Data written before a failed head
+update is orphaned. A new epoch starts only after the previous publication
+outcome is known. On success, advance the epoch; on failure, safely retry the
+same publication or abort the attempt. An ownership CAS failure stops the WO as
+fenced.
+
+`store_meta` follows the same protocol but writes no raw or tile versions.
+
+### WO reads
+
+WO reads the writer snapshot. A fresh attempt reads only its own versions. A
+recovery attempt overlays its versions over the immutable checkpoint base from
+`window_recovery_bases`: read the newest value from the recovery attempt first,
+then fall back to the base version for data not replaced by recovery writes.
+
+Logical runs are mapped to time buckets, loaded, merged, and filtered back to
+the exact requested ranges. Raw rows are deduplicated by `Cursor`; current
+tiles replace matching base tiles.
+
+### WRO reads
+
+WRO:
+
+1. Reads and retains the key's serving version for the request.
+2. Builds exact raw/tile plans.
+3. Loads serving-attempt buckets. If that attempt has a recovery-base row,
+   loads unchanged data from its base checkpoint as well. This may repeat when
+   checkpoints span several recovery attempts.
+4. Selects visible versions, then merges, orders, deduplicates, and rebuilds.
+
+WRO does not read writer state, use Foyer, contact the master, or consume
+checkpoint metadata. If WO is unavailable, WRO continues serving the unchanged
+complete serving snapshot.
+
+### Checkpoint
+
+At an aligned barrier:
+
+1. Drain all buffered keys to a defined checkpoint frontier.
+2. Resolve all in-flight publication outcomes and flush the backend.
+3. Capture `(current attempt, current task epoch)`.
+4. Return `WindowCheckpointMeta`; master persists it with task/checkpoint
+   identity.
+5. Continue processing at later epochs.
+
+The checkpoint contains no keys or state payloads. For any key, checkpoint
+state is its newest version from the checkpoint attempt with epoch at or below
+the cutoff. Creating a checkpoint does not insert a recovery-base row; that row
+is created only when a new attempt restores this checkpoint.
+
+The operator stores namespace plus `WindowCheckpointMeta` and passes the
+corresponding `WindowRestoreMeta` back to the store on restore. It still does
+not drain `buffered_keys`; checkpoint integration must implement that frontier.
+
+### Recovery
+
+1. Master starts the replacement with `WindowRestoreMeta`.
+2. Create a new attempt, insert
+   `window_recovery_bases(new attempt -> restored checkpoint version)`, and
+   start epoch at zero. The row must exist before the attempt publishes data.
+3. Source restores its checkpoint offset and replays post-checkpoint input.
+4. On first access to a key, retain its old serving version, claim ownership,
+   and restore writer `KeyState` from the checkpoint base.
+5. Replay into the new attempt and advance only writer state.
+6. Once append-only replay catches the old serving state, atomically switch
+   serving to writer.
+7. Continue normal publication with writer and serving together.
+
+During recovery, writer and serving versions differ. Replay advances writer
+while WRO keeps using the old serving snapshot. While they differ, compare the
+writer `KeyState` with the retained serving state. Once `next_seq`, `max_seen`,
+and `processed_pos` reach the serving frontier, atomically promote writer to
+serving. Keys not touched after recovery may continue serving their old
+snapshot.
+
+### WO cache
+
+Foyer is WO-only:
+
+```text
+meta:
+    PartitionKey -> (writer version, KeyState)
+data:
+    (PartitionKey, family, bucket) -> materialized writer-view data
+```
+
+`family` is raw data or tiles at a specific granularity.
+
+The cache is cleared before each execution attempt. On a miss, run the normal
+WO bucket read and cache its materialized result. Successful writes replace or
+invalidate affected buckets.
+
+`writer_version` remains in the meta value because the next CAS needs it, but
+it is not part of the cache key.
+
+It needs point get, put, invalidation, and optionally batched gets. Logical
+scans are assembled from bucket point reads. WRO bypasses cache.
+
+### State Prune/Cleanup
+
+Retain versions reachable from writer heads, serving heads, recovery bases, and
+retained completed checkpoints. We should have a separet maintenance task (per worker?) that independently performs:
+
+- logical retention below `retention_floor`;
+- MVCC cleanup of unreachable versions;
+- orphan cleanup for failed or zombie writes;
+
+TTL/TWCS may perform physical expiry when consistent with logical retention.
+
+## Future next steps
+
+### Namespaced cache quota
+
+Assign each state consumer its own memory and local-disk quota. This prevents
+one operator or namespace from consuming the shared cache and gives concurrent
+consumers a predictable fair share of local resources.
+
+### Mem pressure / backpressure
+
+Track both local cache pressure (mem+disk) and logical remote-state usage. If eviction or
+spill cannot keep a consumer within its cache quota, or its retained remote
+state reaches a configured logical limit, backpressure its upstream tasks.
+Remote state must not act as a bottomless overflow sink; these limits make
+state growth visible to normal flow control.
+
+### CDC and late events
+
+The current flow is append-only. An event is accepted while its cursor is
+ahead of `processed_pos`; an event at or behind that frontier is dropped.
+`lateness` only extends retention and does not provide a late-update grace
+period or revise already emitted results.
+
+Future late-event and CDC support must identify logical rows independently of
+their arrival cursor and represent inserts, updates, and deletes explicitly.
+WO would retain enough raw history, invalidate or rebuild affected tiles and
+windows, and publish corrections through the same atomic version boundary.
+The backend would add row identity, revision/operation metadata, and
+versioned tombstones while cleanup would preserve data needed by the allowed
+lateness interval. WRO would continue reading one coherent serving version;
+only the materialization and merge rules would change.
+
+### Rescaling
+
+When we introduce key groups, rescaling is simiply re-mapping key-group <->task in-between checkpoints. `WindowRestoreMeta` becomes a key-group-to-base-version
+mapping and window_recovery_bases gain key-group granularity. The core head, raw,
+tile, `KeyState`, WO, and WRO contracts remain unchanged.

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -9,20 +9,37 @@ see the [window operator README](README.md). This document focuses on store
 contracts and the proposed Scylla backend.
 
 The current data contract is append-only. CDC and late-event correction will
-require explicit mutation semantics rather than implicit delete markers - this is future work
+require explicit mutation semantics rather than implicit delete markers — this
+is future work.
 
 ## Contract types
 
-These are the logical models; backend serialization may differ.
+These are the logical models; backend serialization may differ. They are an
+**engine contract** (WO, WRO, InMem, Scylla). Physical layout may add columns
+such as `key_group`; it must not change what `StateNamespace` means.
 
 ```rust
+/// Operator state space. Shared by every WO task and by WRO.
+/// Bytes encode (pipeline, owner operator) only — not task_index.
 pub struct StateNamespace {
     pub bytes: Vec<u8>,
 }
+
+/// Collision-safe logical identity. Backends derive `key_group` from the
+/// business-key hash and job `max_parallelism`; they do not hash-mod `p`.
 pub struct PartitionKey {
     pub namespace: Vec<u8>,
     pub business_key: Vec<u8>,
 }
+
+/// Contiguous Flink-style assignment: `subtask = key_group * p / max_p`.
+/// `start` inclusive, `end` exclusive. `max_parallelism` is immutable for a
+/// pipeline incarnation.
+pub struct KeyGroupRange {
+    pub start: usize,
+    pub end: usize,
+}
+
 pub struct Cursor {
     pub ts: i64,
     pub seq_no: u64,
@@ -37,6 +54,7 @@ pub struct TileRun {
     pub end_ts_exclusive: i64,
 }
 pub enum TimeGranularity {
+    Milliseconds(u32),
     Seconds(u32),
     Minutes(u32),
     Hours(u32),
@@ -86,17 +104,34 @@ pub struct WindowStateSnapshot {
 }
 ```
 
+Routing (already landed):
+
+```text
+key_group = hash % max_parallelism
+subtask   = key_group * p / max_parallelism
+```
+
+Each WO/WRO task owns a contiguous `KeyGroupRange`. `max_parallelism` is
+job-wide and must not change for a pipeline incarnation.
+
+- `StateNamespace` is the operator state space, not a task. Task isolation is
+  the owned key-group range, bound on the per-task store client at open (see
+  below). Changing only Scylla to strip `task_index` while InMem still keys on
+  `for_operator_task(..., task_index)` would give the same type two meanings;
+  both backends follow this contract.
 - `PartitionKey` must remain collision-safe; hashes alone are insufficient.
-  In practice, persist the serialized business-key bytes directly, as in the
-  schemas below. Scylla hashes the complete partition key for distribution.
+  Persist the serialized business-key bytes. Derive `key_group` from `Key.hash`
+  (first 8 bytes of `Key::to_bytes`) and `max_parallelism`. Scylla hashes the
+  complete partition key for distribution.
 - `Cursor` is raw event identity and total order within a partition.
 - `RawRun` and `TileRun` are half-open. Calls contain merged logical runs, and
   backends must return exactly their union.
 - `next_seq` allocates per-key sequence IDs. Optional `evaluation` keeps the
   last fired trigger together with retractable accumulator state. State-only WO
   does not keep evaluation state.
-- `watermark_frontier` is the task-level late-data boundary. Logical retention
-  is derived from it, the largest window, and configured lateness.
+- `watermark_frontier` is the **task-level** late-data boundary (each task
+  advances its own watermark over the keys it owns). Logical retention is
+  derived from it, the largest window, and configured lateness.
 - `WindowTrigger` is durable event-time work. Current RANGE windows create one
   `RowEmit` trigger per accepted row; `WindowEnd` is reserved for scheduled
   windows.
@@ -107,20 +142,44 @@ pub struct WindowStateSnapshot {
 
 ## Worker state topology
 
-Physical stores are worker-scoped and shared by `OperatorKind` (one backend
-instance per kind). Logical isolation is `StateNamespace` (pipeline + owner
-operator + task). WRO reuses the WO owner namespace.
+Two layers:
 
-`OperatorStore` is the generic maintenance port (same `Arc` as the window
-backend). The worker cleaner runs one tick:
+```text
+physical backend     worker + OperatorKind (one InMem map / Scylla session)
+WindowOperatorStore  per-task client wrapping that backend
+```
+
+The client is created at WO `open` from the task's assignment and is stable
+for the attempt:
+
+```text
+StateNamespace  = (pipeline, owner operator)
+KeyGroupRange   = groups for this task_index at (p, max_p)
+WriterId        = this task execution
+AttemptToken    = job-level execution attempt
+```
+
+`stream_due` / `checkpoint` / `restore` use that bound range. They do not take
+`owned` or `namespace` — the client is the task's store. Per-key calls derive
+`key_group` from the business key and must land in the bound range (routing
+bug otherwise).
+
+WRO reuses the WO owner namespace. It addresses rows by `PartitionKey`
+(namespace + business key). Request routing still sends a lookup to the WRO
+task that owns that key (locality); the namespace no longer encodes
+`task_index`.
+
+`OperatorStore` is the generic maintenance port on the **shared** physical
+backend (registry: one store per kind). The worker cleaner runs one tick:
 
 1. for each registered kind in parallel,
 2. `try_join_all` over that kind's task states,
 3. `store.maintain(ns, task_state)`.
 
 Window eligibility is read from `OperatorTaskState` (watermark →
-`retention_cutoff`); there is no separate cut/meta publish on the data-plane
-trait. Pipeline `StateSpec.maintenance_*` (default on) enables the cleaner.
+`retention_cutoff`, plus the same key-group range the WO client was bound to).
+There is no separate cut/meta publish on the data-plane trait. Pipeline
+`StateSpec.maintenance_*` (default on) enables the cleaner.
 
 See the [window operator README](README.md) for the runtime retention contract
 and how InMem implements `maintain` today. Scylla's `maintain` body is still
@@ -153,7 +212,6 @@ pub trait WindowOperatorStore: Send + Sync + Debug {
     ) -> Result<()>;
     fn stream_due<'a>(
         &'a self,
-        namespace: &'a StateNamespace,
         after: Option<Cursor>,
         through: Cursor,
     ) -> BoxStream<'a, Result<Vec<DueWindowWork>>>;
@@ -163,15 +221,8 @@ pub trait WindowOperatorStore: Send + Sync + Debug {
         state: &KeyState,
     ) -> Result<()>;
     /// Complete pending writes before capturing the returned snapshot.
-    async fn checkpoint(
-        &self,
-        namespace: &StateNamespace,
-    ) -> Result<WindowBackendSnapshot>;
-    async fn restore(
-        &self,
-        namespace: &StateNamespace,
-        snapshot: &WindowBackendSnapshot,
-    ) -> Result<()>;
+    async fn checkpoint(&self) -> Result<WindowBackendSnapshot>;
+    async fn restore(&self, snapshot: &WindowBackendSnapshot) -> Result<()>;
 }
 #[async_trait]
 pub trait WindowRequestStore: Send + Sync + Debug {
@@ -193,16 +244,18 @@ pub trait WindowRequestStore: Send + Sync + Debug {
   runs. Missing tiles mean empty intervals.
 - `commit_events` atomically publishes raw rows, replacement tiles, key state,
   and triggers. `ts_column_index` plus `__seq_no` identifies each raw cursor.
-  Retries are idempotent.
+  Retries are idempotent. The backend derives `key_group` from the partition's
+  business key; it does not trust a caller-supplied group.
 - `stream_due` owns backend pagination for one stable watermark range and
-  returns bounded trigger groups with their corresponding key state.
+  returns bounded trigger groups with their corresponding key state. It only
+  returns work for the client's bound key-group range.
 - `store_key_state` publishes only sequence/evaluation state.
 - `checkpoint` completes pending writes and returns a backend-specific
-  snapshot. Scylla returns only the aligned backend version.
-- `restore` starts store access from the supplied checkpoint base. For Scylla,
-  the current fenced attempt inherits reads from that immutable version.
-- The namespace argument scopes checkpoint and restore when one store instance
-  is shared by multiple window operators.
+  snapshot of the client's bound range only. Scylla returns this writer's
+  `StateVersion`; InMem serializes partitions in that range.
+- `restore` starts store access from the supplied checkpoint base and must
+  not clobber keys outside the bound range (the physical InMem/Scylla backend
+  is shared by all tasks of the kind).
 - WO reads observe their latest publication. One fenced WO owns a partition, so
   its historical raw and tile reads need not share a snapshot and can run
   concurrently.
@@ -210,10 +263,13 @@ pub trait WindowRequestStore: Send + Sync + Debug {
   physical buckets and pages.
 - Methods must not broaden ranges or return partial results.
 
-`InMemWindowStore` is the reference backend. One lock provides the WRO snapshot
-boundary, and its checkpoint embeds serialized partition state and triggers.
-It implements `OperatorStore::maintain` and prunes eagerly under the same
-retention contract as Scylla (control flow identical; lag ~0).
+`InMemWindowStore` is the reference physical backend. One lock provides the
+WRO snapshot boundary. Each WO task holds a client over that shared map,
+bound to namespace + key-group range; checkpoint embeds serialized partition
+state and triggers for that range. The shared backend implements
+`OperatorStore::maintain` and prunes eagerly under the same retention contract
+as Scylla (control flow identical; lag ~0), reading the range from
+`OperatorTaskState` rather than a task-suffixed namespace blob.
 
 ## Runtime flows
 
@@ -229,7 +285,8 @@ WO ingest:
 WO advance:
 
 1. Stream backend-sized trigger pages for
-   `(watermark_frontier, incoming_watermark]`.
+   `(watermark_frontier, incoming_watermark]` (client already scoped to this
+   task's key groups).
 2. Group each page by key and use every trigger cursor as an exact emit point.
 3. Build per-cursor plans. Sliding aggregates plan leave bands; rebuild
    aggregates plan raw edges plus interior tiles.
@@ -255,70 +312,125 @@ WRO lookup:
 3. Call `load_window_data` once for one coherent snapshot.
 4. Evaluate per-window request arguments and rebuild every answer.
 
-WRO is read-only
+WRO is read-only.
 
 ## Scylla backend
 
 Scylla does not provide one snapshot spanning multiple partitions, CQL queries,
 or result pages. A logical window read may cross several physical ranges, so
 concurrent writes could otherwise make those pieces represent different
-moments. We us application-level MVCC to pin every piece to one published version and
-provide a coherent logical snapshot. We also use time buckets to keep physical partitions
-and individual range reads bounded instead of storing a key's entire history
-in one ever-growing partition.
+moments. We use application-level MVCC to pin every piece to one published
+version and provide a coherent logical snapshot. We also use time buckets to
+keep physical partitions and individual range reads bounded instead of storing
+a key's entire history in one ever-growing partition.
 
-The initial backend assumes append-only input and stable task parallelism.
-(rescaling is future work)
+v1 restore still assumes **same task assignment** (`RestorePlanner` identity
+map). The physical model is key-group-native from the start so later rescaling
+is a remap of ranges between checkpoints, not a data rewrite. `task_index`
+does not appear in PRIMARY KEYs.
 
 ### Versions and checkpoints
 
 ```rust
+/// Job-level recovery branch. Not a task id.
+/// Example: pipeline incarnation + execution_attempt_id.
+pub struct AttemptToken(Vec<u8>);
+
+/// Unique WO task execution. Head fence only, not part of data PKs.
+/// Example: AttemptToken + vertex/task identity.
+pub struct WriterId(Vec<u8>);
+
 pub struct StateVersion {
     pub attempt: AttemptToken,
     pub epoch: u64,
 }
 
+/// Restore/remap only. Not stored in the checkpoint blob.
+/// Planner output, then rows in `window_recovery_bases`.
+pub struct VersionedRange {
+    pub range: KeyGroupRange,
+    pub version: StateVersion,
+}
+
 pub enum WindowBackendSnapshot {
-    InMemory { snapshot: Vec<u8> }, // in mem uses whole snapshot
-    Versioned { version: StateVersion }, // this is for scylla
+    InMemory { snapshot: Vec<u8> },
+    /// This writer's cutoff. Range is not stored: it is the client's bound
+    /// assignment, and on the master the payload is already keyed by task.
+    Versioned { version: StateVersion },
 }
 ```
 
-`AttemptToken` must uniquely identify a WO task execution across master
-restarts, for example pipeline incarnation + execution_attempt_id + task identity.
-It is both the writer fence and the recovery branch ID.
+There is **one epoch**: a per-writer monotonic publish id. Each successful
+`commit_events` / `store_key_state` does `E += 1` and stamps that `E` on the
+write. It is not a per-key or per-key-group clock.
 
-Epoch is one task-wide counter within an attempt. Every publication, regardless
-of key, gets the next epoch. A new attempt may restart at zero because
-`(attempt, epoch)` remains unique. Scylla stores the two fields separately.
-Scylla uses `WindowBackendSnapshot::Versioned`; the in-memory backend uses
-`InMemory` with a serialized namespace snapshot. Namespace and the last fully
-processed watermark remain in the operator's `WindowStateSnapshot` envelope.
+| Place | Role |
+| --- | --- |
+| Writer allocator | produces `E` |
+| Data rows | MVCC: this cell belongs to publish `E` |
+| Head `writer_(attempt, epoch)` | this key's latest publish |
+| Head `serving_(attempt, epoch)` | WRO pin; same number line, equal to writer except during recovery |
+| Checkpoint cutoff | include versions with `epoch <= E` for keys in this range |
+
+Head `writer_epoch=5` on key A and `7` on key B means A and B were last
+published at those points on the **same** writer counter. Checkpoint `E=7`
+means “every owned key, newest row with `epoch <= 7`.”
+
+`AttemptToken` in table keys and in `StateVersion` is job-level. All WO tasks
+of one execution share it and write different key groups. Numeric epochs may
+repeat across writers (`E=3` on task 0 and task 1); that is fine because they
+are different keys. A cutoff is applied only to the groups that writer owned —
+the master already stores one checkpoint payload per task, so the blob does
+not need to repeat the range.
+
+`WriterId` is stored only on the head (`owner_writer`). It is the lock holder
+for zombie fencing, not a data address.
+
+A new execution attempt may restart writers at epoch zero because
+`(attempt, epoch)` is unique. Scylla stores the two fields separately.
+
+`VersionedRange` is not a checkpoint record. Checkpoint persists one
+`StateVersion` for this writer. The owned `KeyGroupRange` is already known
+from the client's assignment (and, on the master, from `TaskKey` + graph
+`p` / `max_p`). After a future rescale, `RestorePlanner` intersects old task
+ranges with the new assignment and produces a `Vec<VersionedRange>` as the
+**restore instruction**. `restore()` writes those slices into
+`window_recovery_bases`. v1 same-assignment is the trivial case: one slice =
+bound range + the checkpoint's `StateVersion`.
+
+Scylla uses `WindowBackendSnapshot::Versioned`. InMem uses `InMemory` with a
+serialized snapshot of the owned range. Namespace and the last fully processed
+watermark remain in the operator's `WindowStateSnapshot` envelope.
 
 ### Tables
 
 ```sql
 CREATE TABLE window_head (
     namespace blob,
+    key_group int,
     business_key blob,
-    owner_attempt blob,
+    owner_writer blob,
     writer_attempt blob,
     writer_epoch bigint,
     serving_attempt blob,
     serving_epoch bigint,
-    PRIMARY KEY ((namespace, business_key))
+    PRIMARY KEY ((namespace, key_group, business_key))
 );
 
+-- One row per inherited range (usually one at same assignment).
 CREATE TABLE window_recovery_bases (
     namespace blob,
     recovery_attempt blob,
+    range_start int,
+    range_end int,
     base_attempt blob,
     base_epoch bigint,
-    PRIMARY KEY ((namespace, recovery_attempt))
+    PRIMARY KEY ((namespace, recovery_attempt), range_start)
 );
 
 CREATE TABLE window_raw (
     namespace blob,
+    key_group int,
     business_key blob,
     attempt blob,
     bucket_start bigint,
@@ -327,7 +439,7 @@ CREATE TABLE window_raw (
     epoch bigint,
     payload blob,
     PRIMARY KEY (
-        (namespace, business_key, attempt, bucket_start),
+        (namespace, key_group, business_key, attempt, bucket_start),
         event_ts, seq_no, epoch
     )
 ) WITH CLUSTERING ORDER BY (
@@ -336,6 +448,7 @@ CREATE TABLE window_raw (
 
 CREATE TABLE window_tiles (
     namespace blob,
+    key_group int,
     business_key blob,
     attempt blob,
     granularity_ms bigint,
@@ -346,6 +459,7 @@ CREATE TABLE window_tiles (
     PRIMARY KEY (
         (
             namespace,
+            key_group,
             business_key,
             attempt,
             granularity_ms,
@@ -357,12 +471,13 @@ CREATE TABLE window_tiles (
 
 CREATE TABLE window_key_states (
     namespace blob,
+    key_group int,
     business_key blob,
     attempt blob,
     epoch bigint,
     key_state blob,
     PRIMARY KEY (
-        (namespace, business_key, attempt),
+        (namespace, key_group, business_key, attempt),
         epoch
     )
 ) WITH CLUSTERING ORDER BY (epoch DESC);
@@ -371,7 +486,8 @@ CREATE TABLE window_triggers (
     namespace blob,
     attempt blob,
     bucket_start bigint,
-    trigger_shard int,
+    kg_shard int,
+    key_group int,
     fire_ts bigint,
     fire_seq bigint,
     business_key blob,
@@ -379,7 +495,8 @@ CREATE TABLE window_triggers (
     window_id bigint,
     epoch bigint,
     PRIMARY KEY (
-        (namespace, attempt, bucket_start, trigger_shard),
+        (namespace, attempt, bucket_start, kg_shard),
+        key_group,
         fire_ts,
         fire_seq,
         business_key,
@@ -388,6 +505,7 @@ CREATE TABLE window_triggers (
         epoch
     )
 ) WITH CLUSTERING ORDER BY (
+    key_group ASC,
     fire_ts ASC,
     fire_seq ASC,
     business_key ASC,
@@ -397,43 +515,58 @@ CREATE TABLE window_triggers (
 );
 ```
 
-- `window_head`: per-key ownership fence plus writer and WRO-visible version
-  pointers; the LWT publication boundary.
-- `window_recovery_bases`: one immutable row per recovery attempt. It maps the
-  new `recovery_attempt` to the restored checkpoint version
-  `(base_attempt, base_epoch)`. This lets the new attempt inherit unchanged
-  state without copying every raw row, tile, and `KeyState`.
+- `window_head`: per-key writer fence plus writer and WRO-visible version
+  pointers; the LWT publication boundary. `owner_writer` is `WriterId`.
+  `writer_*` / `serving_*` are job-level `StateVersion`. `key_group` is in the
+  partition key so point gets (WO already has the hash) stay single-partition
+  and a key group cannot collapse into one unbounded Scylla partition.
+- `window_recovery_bases`: immutable rows mapping a new job `recovery_attempt`
+  to restored checkpoint cutoffs at **key-group range** granularity. Lookup for
+  a key: find the row with `range_start <= key_group < range_end`. This lets a
+  new execution inherit unchanged state without copying raw rows, tiles, or
+  `KeyState`, and lets a later rescale inherit different cutoffs from different
+  source tasks.
 - `window_raw`: cursor-ordered event rows, physically split into time buckets
-  and versioned by attempt and epoch.
+  and versioned by job attempt and epoch.
 - `window_tiles`: versioned aggregate tiles, partitioned by time bucket and
   granularity.
 - `window_key_states`: versioned `KeyState` history used by current WO reads and
   checkpoint recovery.
 - `window_triggers`: immutable due work ordered by event time. Time buckets and
-  `trigger_shard` bound each Scylla partition:
-  `stable_hash(business_key) % trigger_shard_count`. Without it, every trigger
-  in one namespace, attempt, and time bucket would share one hot, potentially
-  oversized partition. `stream_due` queries all shards for each relevant time
-  bucket and merges their results by trigger cursor. The shard is only a
-  physical storage concern, not a window, task, or rescaling key group; its
-  count must remain stable for the namespace. Row triggers use a sentinel
-  `window_id`; scheduled windows retain their actual `WindowId`.
+  `kg_shard` bound each Scylla partition. Shard with the **same range formula
+  as routing**, not `hash(business_key) % N`:
 
-Raw payloads are Arrow-IPC one-row `RecordBatch` values including `__seq_no`..
+  ```text
+  kg_shard = key_group * SHARD_COUNT / max_parallelism
+  ```
+
+  A task's contiguous groups map to a small number of shards, so `stream_due`
+  queries those shards and restricts clustering to the client's bound range.
+  `SHARD_COUNT` is a
+  store constant (e.g. 32 or 64), not `p` (changes on rescale) and not
+  `max_parallelism` (too fine: `p=4`, `max_p=32768` would otherwise mean 8192
+  queries per time bucket). `SHARD_COUNT` and `max_parallelism` are immutable
+  for the namespace. Hash-mod sharding would scatter one task across every
+  shard and is not used. Row triggers use a sentinel `window_id`; scheduled
+  windows retain their actual `WindowId`. Job-level `attempt` stays in the
+  trigger PK as the MVCC branch (recovery overlay), not as a task id.
+
+Raw payloads are Arrow-IPC `RecordBatch` values including `__seq_no`.
 
 ### Head semantics
 
-- `owner_attempt` is the WO allowed to publish this key.
-- `writer_(attempt, epoch)` is the private WO snapshot.
+- `owner_writer` is the WO task execution allowed to publish this key.
+- `writer_(attempt, epoch)` is the private WO snapshot (job attempt + writer
+  epoch).
 - `serving_(attempt, epoch)` is the complete snapshot visible to WRO.
 - Writer and serving versions are equal normally and may differ during
   recovery.
 
 When a new WO instance (initial or recovery) first writes a key, it
-LWT/CAS-claims `owner_attempt`. Every later head update checks both owner and
+LWT/CAS-claims `owner_writer`. Every later head update checks both owner and
 expected writer version.
 
-Claiming means conditionally setting `owner_attempt`: insert it for a new head,
+Claiming means conditionally setting `owner_writer`: insert it for a new head,
 or replace the expected previous owner. Only one competing WO can succeed.
 Fencing happens when a zombie tries to update a head now owned by the new WO:
 the conditional update fails, so the zombie's data is not published.
@@ -443,11 +576,13 @@ the conditional update fails, so the zombie's data is not published.
 For one key:
 
 1. Load writer `KeyState`.
-2. Allocate task epoch `E`.
-3. Write changed raw rows, tiles, `KeyState`, and triggers under `(attempt, E)`.
-4. LWT-update the head, requiring the current owner and previous writer version.
+2. Allocate writer epoch `E`.
+3. Write changed raw rows, tiles, `KeyState`, and triggers under
+   `(job attempt, E)` with the derived `key_group`.
+4. LWT-update the head, requiring the current `owner_writer` and previous
+   writer version.
 5. During normal operation, set both writer and serving versions to
-   `(attempt, E)`. During recovery, advance only writer until catch-up.
+   `(job attempt, E)`. During recovery, advance only writer until catch-up.
 6. Update or invalidate affected WO cache entries.
 
 The head update is the visibility boundary. Data written before a failed head
@@ -462,20 +597,22 @@ versions.
 
 ### WO reads
 
-WO reads the writer snapshot. A fresh attempt reads only its own versions. A
-recovery attempt overlays its versions over the immutable checkpoint base from
-`window_recovery_bases`: read the newest value from the recovery attempt first,
-then fall back to the base version for data not replaced by recovery writes.
+WO reads the writer snapshot. A fresh execution attempt reads only its own
+versions. A recovery attempt overlays its versions over the immutable
+checkpoint base from `window_recovery_bases`: read the newest value from the
+recovery attempt first, then fall back to the base version for that key's
+range (`epoch <= base_epoch`) for data not replaced by recovery writes.
 
 Logical runs are mapped to time buckets, loaded, merged, and filtered back to
 the exact requested ranges. Raw rows are deduplicated by `Cursor`; current
 tiles replace matching base tiles.
 
-`stream_due` maps its stable watermark range to trigger buckets and shards,
-overlays the recovery attempt over its checkpoint base, and filters trigger
-versions through each key's writer head. It batch-loads writer `KeyState`,
-groups triggers into `DueWindowWork`, and owns page sizing and continuation
-state for the lifetime of the stream.
+`stream_due` maps its stable watermark range to trigger buckets and the
+`kg_shard`s that overlap the client's bound range, overlays the recovery
+attempt over each inherited base range, and filters trigger versions through
+each key's writer head. It batch-loads writer `KeyState`, groups triggers into
+`DueWindowWork`, and owns page sizing and continuation state for the lifetime
+of the stream.
 
 ### WRO reads
 
@@ -483,47 +620,56 @@ WRO:
 
 1. Reads and retains the key's serving version for the request.
 2. Builds exact raw/tile plans.
-3. Loads serving-attempt buckets. If that attempt has a recovery-base row,
-   loads unchanged data from its base checkpoint as well. This may repeat when
-   checkpoints span several recovery attempts.
+3. Loads serving-attempt buckets. If that attempt has a recovery-base row
+   covering this `key_group`, loads unchanged data from its base checkpoint as
+   well. This may repeat when checkpoints span several recovery attempts.
 4. Selects visible versions, then merges, orders, deduplicates, and rebuilds.
 
 WRO does not read writer state, use Foyer, contact the master, or consume
 checkpoint metadata. If WO is unavailable, WRO continues serving the unchanged
-complete serving snapshot.
+complete serving snapshot. Any WRO task can read any key in the operator
+namespace; keyed routing is locality, not identity.
 
 ### Checkpoint
 
 At an aligned barrier:
 
 1. Resolve all in-flight publication outcomes and complete pending writes.
-2. Capture `(current attempt, current task epoch)`.
-3. Return `WindowBackendSnapshot::Versioned`; the operator persists it in its
-   checkpoint envelope.
+2. Capture `(current job attempt, current writer epoch)`.
+3. Return `WindowBackendSnapshot::Versioned { version }`. The operator
+   persists it in its checkpoint envelope. The range is the client's bound
+   assignment and is not copied into the blob.
 4. Continue processing at later epochs.
 
-The checkpoint contains no keys or state payloads. For any key, checkpoint
-state is its newest version from the checkpoint attempt with epoch at or below
-the cutoff. Creating a checkpoint does not insert a recovery-base row; that row
-is created only when a new attempt restores this checkpoint.
+The checkpoint contains no keys, no key-group list, and no state payloads.
+For any key this writer owned, checkpoint state is its newest version from
+that attempt with `epoch <=` the cutoff. Creating a checkpoint does not insert
+a recovery-base row; those rows are created only when a new attempt restores.
 
 The operator stores namespace, its last fully processed watermark, and
 `WindowBackendSnapshot` in `WindowStateSnapshot`. Durable triggers already
 represent work above that watermark, so checkpointing neither drains nor
 serializes an operator-local pending-key set. For unchanged task assignment,
-restore passes the same versioned snapshot back to the store.
+restore passes the same `StateVersion` back; the client applies it to its
+bound range. `RestorePlanner` remapping (producing `Vec<VersionedRange>`) is
+future work.
 
 ### Recovery
 
-1. The replacement worker has the restored version in
-   `WindowBackendSnapshot::Versioned`.
-2. During operator restore, the worker's Scylla store creates the new attempt,
-   inserts `window_recovery_bases(new attempt -> restored checkpoint version)`,
-   and starts its epoch at zero. The row must exist before the attempt
-   publishes data. The master only plans and sends the restore snapshot.
+1. v1: the replacement worker has `WindowBackendSnapshot::Versioned { version }`
+   and the same assignment, so one `VersionedRange` = bound range + that
+   version. After rescale: `RestorePlanner` sends the intersected
+   `Vec<VersionedRange>` (still not a checkpoint format; it is restore input).
+2. During operator restore, the worker's Scylla store uses the new **job**
+   attempt, inserts `window_recovery_bases` rows
+   `(new attempt, range) -> (base_attempt, base_epoch)` for each restore
+   slice, and starts this writer's epoch at zero. The rows must exist before
+   the attempt publishes data. The master only plans and sends the restore
+   payload.
 3. Source restores its checkpoint offset and replays post-checkpoint input.
-4. On first access to a key, retain its old serving version, claim ownership,
-   and restore writer `KeyState` from the checkpoint base.
+4. On first access to a key, retain its old serving version, claim
+   `owner_writer`, and restore writer `KeyState` from the checkpoint base for
+   that key's range.
 5. Resume watermark work by streaming checkpoint-visible triggers above the
    restored watermark while replay advances only writer state.
 6. Once append-only replay catches the old serving state, atomically switch
@@ -547,7 +693,7 @@ meta:
 data:
     (PartitionKey, family, bucket) -> materialized writer-view data
 triggers:
-    (namespace, attempt, bucket, shard) -> immutable due entries
+    (namespace, attempt, bucket, kg_shard) -> immutable due entries
 ```
 
 `family` is raw data or tiles at a specific granularity.
@@ -578,32 +724,41 @@ each publish; still quorum everywhere. Explore it only if LWT latency hurts.
 
 ### State prune / cleanup
 
-**Eligibility (per task / namespace):** after watermark advance to `W`,
+**Eligibility (per task):** after watermark advance to `W`,
 `data_floor = W − max_window_length − lateness` (lateness default `0`).
 `max_window_length` is required because raw/tiles are shared across all window
 expressions on the op — shorter windows over-retain; longer ones must not
-under-retain.
+under-retain. Prune is limited to the task's owned key-group range.
 
 **Executor (per worker):** `StateRegistry::run_maintenance_once` — parallel
 loop per `OperatorKind`, then per-task `OperatorStore::maintain(ns, state)`.
-Not on the master; not inside WO `poll_next`.
+Not on the master; not inside WO `poll_next`. The window impl reads cutoff and
+owned range from `OperatorTaskState`.
 
 **Window `maintain` body:**
-- drop consumed triggers (`fire_at.ts ≤ W`);
-- prune raw rows with `ts < data_floor` and tiles fully below the floor;
+- drop consumed triggers (`fire_at.ts ≤ W`) in shards overlapping the task's
+  key-group range (from `OperatorTaskState`);
+- prune raw rows with `ts < data_floor` and tiles fully below the floor
+  (Scylla: time-bucket drop / TWCS / TTL aligned with `data_floor`; per-key
+  partitions are not listed by scan);
 - Scylla additionally: MVCC cleanup of versions unreachable from writer heads,
   serving heads, recovery bases, and retained checkpoints; orphan/zombie
   cleanup for failed writes.
 
 TTL/TWCS may expire physical SSTables only when consistent with logical
 `data_floor`. InMem applies the same logical rules immediately inside
-`maintain`.
+`maintain`, iterating in-memory partitions whose namespace matches and whose
+`key_group` is in the task state's range.
 
 ## Future next steps
 
 Worker maintenance **orchestration** (`OperatorStore::maintain`, cleaner loop,
 `StateSpec.maintenance_*`) is decided in the runtime; Scylla's `maintain`
 implementation remains TODO.
+
+Engine `StateNamespace`, per-task store client bound to the assigned
+`KeyGroupRange`, InMem filter-by-range, and the Scylla schemas above should
+land together. v1 `RestorePlanner` may keep identity mapping.
 
 ### Namespaced cache quota
 
@@ -639,8 +794,43 @@ only the materialization and merge rules would change.
 
 ### Rescaling
 
-When we introduce key groups, rescaling is simiply re-mapping key-group <->task
-in-between checkpoints. The versioned backend snapshot becomes a
-key-group-to-base-version mapping and `window_recovery_bases` gain key-group
-granularity. The core head, raw, tile, `KeyState`, WO, and WRO contracts remain
-unchanged.
+Rescaling remaps `key_group ↔ task` between checkpoints. Data rows stay put:
+PKs are task-agnostic. `max_parallelism` is fixed for the pipeline incarnation;
+only `p` changes. At any one `p`, `subtask = key_group * p / max_p` **partitions**
+`[0, max_p)` into disjoint contiguous ranges — two live tasks never own the
+same key group, so they never “own an intersection” of each other.
+
+What *does* intersect is **new range ∩ old range** in the planner, when `p`
+changes. Each old task’s checkpoint blob is only a `StateVersion`. The old
+range is recomputed from that task’s index and the checkpoint graph’s
+`(p, max_p)`. `RestorePlanner` intersects the new assignment with every old
+task range and emits a `Vec<VersionedRange>` restore instruction — disjoint
+slices that cover exactly the new task’s groups, each with its source cutoff.
+`restore()` writes those into `window_recovery_bases`. The checkpoint blob
+never stores a range.
+
+Example, `max_p = 128`, rescale `p=3 → p=2`:
+
+```text
+old p=3:  task 0 [0, 43)   task 1 [43, 86)   task 2 [86, 128)
+new p=2:  task 0 [0, 64)   task 1 [64, 128)
+```
+
+```text
+new task 0 ← [0, 43) @ old0 version  +  [43, 64) @ old1 version
+new task 1 ← [64, 86) @ old1 version  +  [86, 128) @ old2 version
+```
+
+Old task 1 is **split** across both new tasks; new task 0 **merges** a suffix
+of old 0 with a prefix of old 1. Each inherited slice keeps its source
+`(attempt, epoch)` because the two old writers had independent epoch clocks.
+The restore instruction is that list of slices — not overlapping ranges for
+the same groups, and not something that was persisted at checkpoint time.
+
+Power-of-two rescale (`2 → 4`, `4 → 2`) is the aligned special case: a new
+range is exactly one old range or a concatenation of whole old ranges, never a
+partial split of an old range.
+
+`RestorePlanner` still needs this intersection; that planner change is separate
+from this store contract. Head fences are re-claimed by the new `WriterId` on
+first write.

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -41,13 +41,27 @@ pub enum TimeGranularity {
 }
 pub type WindowId = usize;
 pub type AccumulatorState = Vec<ScalarValue>;
-pub struct KeyState {
-    pub max_seen: Option<Cursor>,
-    pub processed_pos: Option<Cursor>,
+pub struct KeyEvaluationState {
+    pub through: Cursor,
     pub accumulators: BTreeMap<WindowId, AccumulatorState>,
-    pub first_ingested: Option<Cursor>,
+}
+pub struct KeyState {
     pub next_seq: u64,
-    pub retention_floor: Option<Cursor>,
+    pub evaluation: Option<KeyEvaluationState>,
+}
+pub enum WindowTriggerKind {
+    RowEmit,
+    WindowEnd { window_id: WindowId },
+}
+pub struct WindowTrigger {
+    pub fire_at: Cursor,
+    pub partition: PartitionKey,
+    pub kind: WindowTriggerKind,
+}
+pub struct DueWindowWork {
+    pub partition: PartitionKey,
+    pub key_state: KeyState,
+    pub triggers: Vec<WindowTrigger>,
 }
 pub struct TileState {
     pub accumulator_state: Option<AccumulatorState>,
@@ -61,6 +75,11 @@ pub struct WindowData {
     raw_batches: Vec<RecordBatch>,
     tile_map: TileMap,
 }
+pub struct WindowStateSnapshot {
+    pub namespace: Vec<u8>,
+    pub watermark_frontier: Option<i64>,
+    pub backend: WindowBackendSnapshot,
+}
 ```
 
 - `PartitionKey` must remain collision-safe; hashes alone are insufficient.
@@ -69,10 +88,14 @@ pub struct WindowData {
 - `Cursor` is raw event identity and total order within a partition.
 - `RawRun` and `TileRun` are half-open. Calls contain merged logical runs, and
   backends must return exactly their union.
-- `max_seen` is the greatest ingested cursor; `processed_pos` is the evaluated
-  frontier; `first_ingested` is the cold-start bound; `next_seq` allocates
-  per-key sequence IDs.
-- `retention_floor` is the first cursor still required by logical retention.
+- `next_seq` allocates per-key sequence IDs. Optional `evaluation` keeps the
+  last fired trigger together with retractable accumulator state. State-only WO
+  does not keep evaluation state.
+- `watermark_frontier` is the task-level late-data boundary. Logical retention
+  is derived from it, the largest window, and configured lateness.
+- `WindowTrigger` is durable event-time work. Current RANGE windows create one
+  `RowEmit` trigger per accepted row; `WindowEnd` is reserved for scheduled
+  windows.
 - Tiles for all windows share `(granularity, tile_start)`, so persisted tile and
   accumulator state retain `WindowId`.
 - `WindowData` is one materialized WRO snapshot. Evaluation filters its rows by
@@ -83,7 +106,7 @@ pub struct WindowData {
 ```rust
 #[async_trait]
 pub trait WindowOperatorStore: Send + Sync + Debug {
-    async fn load_meta(&self, partition: &PartitionKey) -> Result<KeyState>;
+    async fn load_key_state(&self, partition: &PartitionKey) -> Result<KeyState>;
     async fn load_raw(
         &self,
         partition: &PartitionKey,
@@ -100,13 +123,21 @@ pub trait WindowOperatorStore: Send + Sync + Debug {
         ts_column_index: usize,
         events: &RecordBatch,
         tiles: &TileMap,
-        meta: &KeyState,
+        state: &KeyState,
+        triggers: &[WindowTrigger],
     ) -> Result<()>;
-    async fn store_meta(&self, partition: &PartitionKey, meta: &KeyState)
-        -> Result<()>;
-    async fn flush(&self) -> Result<()> {
-        Ok(())
-    }
+    fn stream_due<'a>(
+        &'a self,
+        namespace: &'a StateNamespace,
+        after: Option<Cursor>,
+        through: Cursor,
+    ) -> BoxStream<'a, Result<Vec<DueWindowWork>>>;
+    async fn store_key_state(
+        &self,
+        partition: &PartitionKey,
+        state: &KeyState,
+    ) -> Result<()>;
+    /// Complete pending writes before capturing the returned snapshot.
     async fn checkpoint(
         &self,
         namespace: &StateNamespace,
@@ -135,12 +166,14 @@ pub trait WindowRequestStore: Send + Sync + Debug {
   ordered by `Cursor`. Their Arrow schema includes `__seq_no: UInt64`.
 - Tiles are unique by `(granularity, tile_start)` and restricted to requested
   runs. Missing tiles mean empty intervals.
-- `commit_events` atomically publishes raw rows, replacement tiles, and meta.
-  `ts_column_index` plus `__seq_no` identifies each raw cursor. Retries are
-  idempotent.
-- `store_meta` publishes only progress and retention state.
-- `checkpoint` resolves pending writes, flushes them, and returns a
-  backend-specific snapshot. Scylla returns only the aligned backend version.
+- `commit_events` atomically publishes raw rows, replacement tiles, key state,
+  and triggers. `ts_column_index` plus `__seq_no` identifies each raw cursor.
+  Retries are idempotent.
+- `stream_due` owns backend pagination for one stable watermark range and
+  returns bounded trigger groups with their corresponding key state.
+- `store_key_state` publishes only sequence/evaluation state.
+- `checkpoint` completes pending writes and returns a backend-specific
+  snapshot. Scylla returns only the aligned backend version.
 - `restore` starts store access from the supplied checkpoint base. For Scylla,
   the current fenced attempt inherits reads from that immutable version.
 - The namespace argument scopes checkpoint and restore when one store instance
@@ -153,29 +186,34 @@ pub trait WindowRequestStore: Send + Sync + Debug {
 - Methods must not broaden ranges or return partial results.
 
 `InMemWindowStore` is the reference backend. One lock provides the WRO snapshot
-boundary, and its checkpoint embeds the serialized namespace state.
+boundary, and its checkpoint embeds serialized partition state and triggers.
 Asynchronous physical retention is not emulated.
 
 ## Runtime flows
 
 WO ingest:
 
-1. Load meta, drop rows at or behind `processed_pos`, and assign sequence IDs.
+1. Load key state, drop rows at or behind the task watermark, and assign
+   sequence IDs.
 2. Load and update affected tiles.
-3. Atomically `commit_events(..., events, tiles, meta)`.
+3. For emitting WO, create one `RowEmit` trigger per accepted row.
+4. Atomically `commit_events(..., events, tiles, state, triggers)`. State-only
+   WO publishes raw rows and tiles without row triggers.
 
 WO advance:
 
-1. Load meta and derive the unprocessed cursor range.
-2. Load that raw range to discover the exact emit cursors.
+1. Stream backend-sized trigger pages for
+   `(watermark_frontier, incoming_watermark]`.
+2. Group each page by key and use every trigger cursor as an exact emit point.
 3. Build per-cursor plans. Sliding aggregates plan leave bands; rebuild
    aggregates plan raw edges plus interior tiles.
-4. Merge the plans, then load historical raw edges and tiles concurrently.
+4. Merge emit-row and historical coverage, then load raw rows and tiles
+   concurrently.
    Small ranges remain all-raw. Large slide leave bands may also use tiles.
 5. Evaluate using those same plans. New rows are always raw; rebuild interiors
    do not overfetch raw rows.
-6. Publish updated progress, accumulators, and `retention_floor` with
-   `store_meta`.
+6. Publish updated `KeyEvaluationState` with `store_key_state`.
+7. Advance and forward the task watermark only after all due work succeeds.
 
 Tile-based slide retraction is limited to aggregates whose states can be
 subtracted safely (`SUM`, `COUNT`, and `AVG`). Other sliding aggregates retract
@@ -226,8 +264,8 @@ Epoch is one task-wide counter within an attempt. Every publication, regardless
 of key, gets the next epoch. A new attempt may restart at zero because
 `(attempt, epoch)` remains unique. Scylla stores the two fields separately.
 Scylla uses `WindowBackendSnapshot::Versioned`; the in-memory backend uses
-`InMemory` with a serialized namespace snapshot. Namespace remains in the
-operator's checkpoint envelope.
+`InMemory` with a serialized namespace snapshot. Namespace and the last fully
+processed watermark remain in the operator's `WindowStateSnapshot` envelope.
 
 ### Tables
 
@@ -300,6 +338,35 @@ CREATE TABLE window_key_states (
         epoch
     )
 ) WITH CLUSTERING ORDER BY (epoch DESC);
+
+CREATE TABLE window_triggers (
+    namespace blob,
+    attempt blob,
+    bucket_start bigint,
+    trigger_shard int,
+    fire_ts bigint,
+    fire_seq bigint,
+    business_key blob,
+    trigger_kind tinyint,
+    window_id bigint,
+    epoch bigint,
+    PRIMARY KEY (
+        (namespace, attempt, bucket_start, trigger_shard),
+        fire_ts,
+        fire_seq,
+        business_key,
+        trigger_kind,
+        window_id,
+        epoch
+    )
+) WITH CLUSTERING ORDER BY (
+    fire_ts ASC,
+    fire_seq ASC,
+    business_key ASC,
+    trigger_kind ASC,
+    window_id ASC,
+    epoch DESC
+);
 ```
 
 - `window_head`: per-key ownership fence plus writer and WRO-visible version
@@ -314,6 +381,15 @@ CREATE TABLE window_key_states (
   granularity.
 - `window_key_states`: versioned `KeyState` history used by current WO reads and
   checkpoint recovery.
+- `window_triggers`: immutable due work ordered by event time. Time buckets and
+  `trigger_shard` bound each Scylla partition:
+  `stable_hash(business_key) % trigger_shard_count`. Without it, every trigger
+  in one namespace, attempt, and time bucket would share one hot, potentially
+  oversized partition. `stream_due` queries all shards for each relevant time
+  bucket and merges their results by trigger cursor. The shard is only a
+  physical storage concern, not a window, task, or rescaling key group; its
+  count must remain stable for the namespace. Row triggers use a sentinel
+  `window_id`; scheduled windows retain their actual `WindowId`.
 
 Raw payloads are Arrow-IPC one-row `RecordBatch` values including `__seq_no`..
 
@@ -334,13 +410,13 @@ or replace the expected previous owner. Only one competing WO can succeed.
 Fencing happens when a zombie tries to update a head now owned by the new WO:
 the conditional update fails, so the zombie's data is not published.
 
-### Publication
+### WO write
 
 For one key:
 
 1. Load writer `KeyState`.
 2. Allocate task epoch `E`.
-3. Write changed raw rows, tiles, and `KeyState` under `(attempt, E)`.
+3. Write changed raw rows, tiles, `KeyState`, and triggers under `(attempt, E)`.
 4. LWT-update the head, requiring the current owner and previous writer version.
 5. During normal operation, set both writer and serving versions to
    `(attempt, E)`. During recovery, advance only writer until catch-up.
@@ -350,9 +426,11 @@ The head update is the visibility boundary. Data written before a failed head
 update is orphaned. A new epoch starts only after the previous publication
 outcome is known. On success, advance the epoch; on failure, safely retry the
 same publication or abort the attempt. An ownership CAS failure stops the WO as
-fenced.
+fenced. Trigger rows from an unpublished attempt/epoch are orphaned with its
+other data and are not returned by `stream_due`.
 
-`store_meta` follows the same protocol but writes no raw or tile versions.
+`store_key_state` follows the same protocol but writes no raw, tile, or trigger
+versions.
 
 ### WO reads
 
@@ -364,6 +442,12 @@ then fall back to the base version for data not replaced by recovery writes.
 Logical runs are mapped to time buckets, loaded, merged, and filtered back to
 the exact requested ranges. Raw rows are deduplicated by `Cursor`; current
 tiles replace matching base tiles.
+
+`stream_due` maps its stable watermark range to trigger buckets and shards,
+overlays the recovery attempt over its checkpoint base, and filters trigger
+versions through each key's writer head. It batch-loads writer `KeyState`,
+groups triggers into `DueWindowWork`, and owns page sizing and continuation
+state for the lifetime of the stream.
 
 ### WRO reads
 
@@ -384,44 +468,46 @@ complete serving snapshot.
 
 At an aligned barrier:
 
-1. Drain all buffered keys to a defined checkpoint frontier.
-2. Resolve all in-flight publication outcomes and flush the backend.
-3. Capture `(current attempt, current task epoch)`.
-4. Return `WindowBackendSnapshot::Versioned`; the operator persists it in its
+1. Resolve all in-flight publication outcomes and complete pending writes.
+2. Capture `(current attempt, current task epoch)`.
+3. Return `WindowBackendSnapshot::Versioned`; the operator persists it in its
    checkpoint envelope.
-5. Continue processing at later epochs.
+4. Continue processing at later epochs.
 
 The checkpoint contains no keys or state payloads. For any key, checkpoint
 state is its newest version from the checkpoint attempt with epoch at or below
 the cutoff. Creating a checkpoint does not insert a recovery-base row; that row
 is created only when a new attempt restores this checkpoint.
 
-The operator stores namespace plus `WindowBackendSnapshot` in
-`WindowStateSnapshot`. For unchanged task assignment, restore passes that same
-versioned snapshot back to the store. It still does not drain `buffered_keys`;
-checkpoint integration must implement that frontier.
+The operator stores namespace, its last fully processed watermark, and
+`WindowBackendSnapshot` in `WindowStateSnapshot`. Durable triggers already
+represent work above that watermark, so checkpointing neither drains nor
+serializes an operator-local pending-key set. For unchanged task assignment,
+restore passes the same versioned snapshot back to the store.
 
 ### Recovery
 
-1. The replacement receives the restored version in
+1. The replacement worker has the restored version in
    `WindowBackendSnapshot::Versioned`.
-2. Create a new attempt, insert
-   `window_recovery_bases(new attempt -> restored checkpoint version)`, and
-   start epoch at zero. The row must exist before the attempt publishes data.
+2. During operator restore, the worker's Scylla store creates the new attempt,
+   inserts `window_recovery_bases(new attempt -> restored checkpoint version)`,
+   and starts its epoch at zero. The row must exist before the attempt
+   publishes data. The master only plans and sends the restore snapshot.
 3. Source restores its checkpoint offset and replays post-checkpoint input.
 4. On first access to a key, retain its old serving version, claim ownership,
    and restore writer `KeyState` from the checkpoint base.
-5. Replay into the new attempt and advance only writer state.
+5. Resume watermark work by streaming checkpoint-visible triggers above the
+   restored watermark while replay advances only writer state.
 6. Once append-only replay catches the old serving state, atomically switch
    serving to writer.
 7. Continue normal publication with writer and serving together.
 
 During recovery, writer and serving versions differ. Replay advances writer
 while WRO keeps using the old serving snapshot. While they differ, compare the
-writer `KeyState` with the retained serving state. Once `next_seq`, `max_seen`,
-and `processed_pos` reach the serving frontier, atomically promote writer to
-serving. Keys not touched after recovery may continue serving their old
-snapshot.
+writer `KeyState` with the retained serving state. Once `next_seq` and
+`evaluation.through` reach the serving state, atomically promote writer to
+serving. Keys without evaluation state compare only `next_seq`. Keys not
+touched after recovery may continue serving their old snapshot.
 
 ### WO cache
 
@@ -432,13 +518,16 @@ meta:
     PartitionKey -> (writer version, KeyState)
 data:
     (PartitionKey, family, bucket) -> materialized writer-view data
+triggers:
+    (namespace, attempt, bucket, shard) -> immutable due entries
 ```
 
 `family` is raw data or tiles at a specific granularity.
 
 The cache is cleared before each execution attempt. On a miss, run the normal
 WO bucket read and cache its materialized result. Successful writes replace or
-invalidate affected buckets.
+invalidate affected data buckets. Immutable trigger buckets may be cached and
+paged without becoming a separate source of truth.
 
 `writer_version` remains in the meta value because the next CAS needs it, but
 it is not part of the cache key.
@@ -451,7 +540,10 @@ scans are assembled from bucket point reads. WRO bypasses cache.
 Retain versions reachable from writer heads, serving heads, recovery bases, and
 retained completed checkpoints. We should have a separet maintenance task (per worker?) that independently performs:
 
-- logical retention below `retention_floor`;
+- trigger cleanup at or below watermarks no longer reachable from retained
+  checkpoints;
+- logical raw/tile retention below the floor derived from watermark, maximum
+  window length, and lateness;
 - MVCC cleanup of unreachable versions;
 - orphan cleanup for failed or zombie writes;
 
@@ -475,8 +567,8 @@ state growth visible to normal flow control.
 
 ### CDC and late events
 
-The current flow is append-only. An event is accepted while its cursor is
-ahead of `processed_pos`; an event at or behind that frontier is dropped.
+The current flow is append-only. An event is accepted while its timestamp is
+ahead of the task watermark; an event at or behind that frontier is dropped.
 `lateness` only extends retention and does not provide a late-update grace
 period or revise already emitted results.
 

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -539,6 +539,19 @@ it is not part of the cache key.
 It needs point get, put, invalidation, and optionally batched gets. Logical
 scans are assembled from bucket point reads. WRO bypasses cache.
 
+### Scylla consistency
+
+Minimal setup is single DC, RF=3. Because we need read-your-write after publish,
+use `LOCAL_QUORUM` for both data reads and writes (`W+R > RF`). Head claim/publish
+is LWT with `LOCAL_SERIAL` + learn `LOCAL_QUORUM`:
+
+- **WO write:** non-LWT data @ `LOCAL_QUORUM`; one head LWT per publish (fence + visibility).
+- **WO read (cache miss):** head lookup + data @ `LOCAL_QUORUM` (writer pointer).
+- **WRO read:** head pin + data @ `LOCAL_QUORUM` (serving pointer) for one coherent snapshot.
+
+**Possible future improvement:** generation + `USING TIMESTAMP` may avoid LWT on
+each publish; still quorum everywhere. Explore it only if LWT latency hurts.
+
 ### State Prune/Cleanup
 
 Retain versions reachable from writer heads, serving heads, recovery bases, and

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -4,6 +4,10 @@
 `WindowRequestStore` serves coherent WRO point lookups. Physical layout, MVCC,
 serialization, and caching stay inside the backend.
 
+For detailed window-operator semantics, evaluation flow, and module structure,
+see the [window operator README](README.md). This document focuses on store
+contracts and the proposed Scylla backend.
+
 The current data contract is append-only. CDC and late-event correction will
 require explicit mutation semantics rather than implicit delete markers - this is future work
 

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -105,6 +105,27 @@ pub struct WindowStateSnapshot {
 - `WindowData` is one materialized WRO snapshot. Evaluation filters its rows by
   cursor; batches need not be mapped back to individual runs.
 
+## Worker state topology
+
+Physical stores are worker-scoped and shared by `OperatorKind` (one backend
+instance per kind). Logical isolation is `StateNamespace` (pipeline + owner
+operator + task). WRO reuses the WO owner namespace.
+
+`OperatorStore` is the generic maintenance port (same `Arc` as the window
+backend). The worker cleaner runs one tick:
+
+1. for each registered kind in parallel,
+2. `try_join_all` over that kind's task states,
+3. `store.maintain(ns, task_state)`.
+
+Window eligibility is read from `OperatorTaskState` (watermark →
+`retention_cutoff`); there is no separate cut/meta publish on the data-plane
+trait. Pipeline `StateSpec.maintenance_*` (default on) enables the cleaner.
+
+See the [window operator README](README.md) for the runtime retention contract
+and how InMem implements `maintain` today. Scylla's `maintain` body is still
+proposed below.
+
 ## Store traits
 
 ```rust
@@ -191,7 +212,8 @@ pub trait WindowRequestStore: Send + Sync + Debug {
 
 `InMemWindowStore` is the reference backend. One lock provides the WRO snapshot
 boundary, and its checkpoint embeds serialized partition state and triggers.
-Asynchronous physical retention is not emulated.
+It implements `OperatorStore::maintain` and prunes eagerly under the same
+retention contract as Scylla (control flow identical; lag ~0).
 
 ## Runtime flows
 
@@ -218,6 +240,8 @@ WO advance:
    do not overfetch raw rows.
 6. Publish updated `KeyEvaluationState` with `store_key_state`.
 7. Advance and forward the task watermark only after all due work succeeds.
+   Physical prune is not awaited here; the worker cleaner applies it via
+   `maintain`.
 
 Tile-based slide retraction is limited to aggregates whose states can be
 subtracted safely (`SUM`, `COUNT`, and `AVG`). Other sliding aggregates retract
@@ -552,27 +576,41 @@ is LWT with `LOCAL_SERIAL` + learn `LOCAL_QUORUM`:
 **Possible future improvement:** generation + `USING TIMESTAMP` may avoid LWT on
 each publish; still quorum everywhere. Explore it only if LWT latency hurts.
 
-### State Prune/Cleanup
+### State prune / cleanup
 
-Retain versions reachable from writer heads, serving heads, recovery bases, and
-retained completed checkpoints. We should have a separet maintenance task (per worker?) that independently performs:
+**Eligibility (per task / namespace):** after watermark advance to `W`,
+`data_floor = W − max_window_length − lateness` (lateness default `0`).
+`max_window_length` is required because raw/tiles are shared across all window
+expressions on the op — shorter windows over-retain; longer ones must not
+under-retain.
 
-- trigger cleanup at or below watermarks no longer reachable from retained
-  checkpoints;
-- logical raw/tile retention below the floor derived from watermark, maximum
-  window length, and lateness;
-- MVCC cleanup of unreachable versions;
-- orphan cleanup for failed or zombie writes;
+**Executor (per worker):** `StateRegistry::run_maintenance_once` — parallel
+loop per `OperatorKind`, then per-task `OperatorStore::maintain(ns, state)`.
+Not on the master; not inside WO `poll_next`.
 
-TTL/TWCS may perform physical expiry when consistent with logical retention.
+**Window `maintain` body:**
+- drop consumed triggers (`fire_at.ts ≤ W`);
+- prune raw rows with `ts < data_floor` and tiles fully below the floor;
+- Scylla additionally: MVCC cleanup of versions unreachable from writer heads,
+  serving heads, recovery bases, and retained checkpoints; orphan/zombie
+  cleanup for failed writes.
+
+TTL/TWCS may expire physical SSTables only when consistent with logical
+`data_floor`. InMem applies the same logical rules immediately inside
+`maintain`.
 
 ## Future next steps
+
+Worker maintenance **orchestration** (`OperatorStore::maintain`, cleaner loop,
+`StateSpec.maintenance_*`) is decided in the runtime; Scylla's `maintain`
+implementation remains TODO.
 
 ### Namespaced cache quota
 
 Assign each state consumer its own memory and local-disk quota. This prevents
 one operator or namespace from consuming the shared cache and gives concurrent
-consumers a predictable fair share of local resources.
+consumers a predictable fair share of local resources. The worker
+`StateResourceTracker` is the scaffold for charging/releasing those quotas.
 
 ### Mem pressure / backpressure
 
@@ -580,7 +618,8 @@ Track both local cache pressure (mem+disk) and logical remote-state usage. If ev
 spill cannot keep a consumer within its cache quota, or its retained remote
 state reaches a configured logical limit, backpressure its upstream tasks.
 Remote state must not act as a bottomless overflow sink; these limits make
-state growth visible to normal flow control.
+state growth visible to normal flow control. `StateResourceTracker` will surface
+pressure signals; maintenance paths must not block on admission.
 
 ### CDC and late events
 

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -421,20 +421,23 @@ read, not a second partition hop. Restore still does not copy rows.
 attempt clauses.
 
 **GC default: skinny index + per-key data PK. Do not cluster `business_key`
-under `(namespace, key_group, bucket)`.** `load_raw` is per-key; a key group
-is unbounded, so that clustering would make one partition (compaction,
-repair, hot token) hold every key in the group+bucket. Keep `business_key`
-in the data partition key so each key+bucket stays small.
+under `(namespace, key_group, bucket)` on the data tables.** `load_raw` is
+per-key; a key group is unbounded, so that clustering would make one data
+partition (compaction, repair, hot token) hold every key in the group+bucket.
+Keep `business_key` in the **data** partition key so each key+bucket stays
+small.
 
-That data layout cannot list “this key group” or `bucket_start < data_floor`,
-so `commit_events` also writes a payload-free index
-`(namespace, key_group, bucket_start) → business_key`. `maintain` walks
-event-time `bucket_start` values below `data_floor` (configured bucket width;
-empty index partitions are skipped), pages each partition, and deletes the
-per-key data partitions. If the key count per group+bucket grows large, shard
-the index (`index_shard = hash(business_key) % N`) so each index partition
-stays bounded. TWCS/TTL on write-time cannot replace this: event-time buckets
-≠ write time, and replay rewrites old buckets.
+That data layout cannot list `bucket_start < data_floor`, so `commit_events`
+also writes one payload-free index. **`bucket_start` is clustering on the
+index, not a partition-key component** — otherwise `maintain` cannot
+`SELECT … AND bucket_start < data_floor` and would have to probe historical
+bucket ids (unbounded). Do not add a second `live_buckets` table.
+
+After prune, each index partition is one key group and holds only live
+buckets: `keys_in_group × (retention / bucket_width)`, skinny cells. Shard
+with `index_shard` on the PK later if a hot group is too wide — not v1.
+TWCS/TTL on write-time cannot replace this: event-time buckets ≠ write time,
+and replay rewrites old buckets.
 
 ```sql
 CREATE TABLE window_head (
@@ -460,16 +463,17 @@ CREATE TABLE window_recovery_bases (
     PRIMARY KEY ((namespace, recovery_attempt), range_start)
 );
 
--- Skinny GC index only: no payloads. v1: one partition per group+bucket.
--- If that partition grows too wide, add index_shard to the partition key
--- (hash(business_key) % N) and page all shards in maintain.
+-- Skinny GC index only: no payloads, no attempt/epoch.
+-- bucket_start is clustering so maintain can range `< data_floor`.
+-- Do not add a second live_buckets table. Shard with index_shard later
+-- if a hot group is too wide — not v1.
 CREATE TABLE window_kg_buckets (
     namespace blob,
     key_group int,
     bucket_start bigint,
     business_key blob,
-    PRIMARY KEY ((namespace, key_group, bucket_start), business_key)
-);
+    PRIMARY KEY ((namespace, key_group), bucket_start, business_key)
+) WITH CLUSTERING ORDER BY (bucket_start ASC, business_key ASC);
 
 CREATE TABLE window_raw (
     namespace blob,
@@ -568,12 +572,19 @@ CREATE TABLE window_triggers (
   `KeyState`, and lets a later rescale inherit different cutoffs from different
   source tasks.
 - `window_kg_buckets`: skinny GC index, not a source of truth for reads.
-  `commit_events` upserts `business_key` under
-  `(namespace, key_group, bucket_start)` — no payload columns. `maintain`
-  pages each owned group’s buckets below `data_floor` (by event-time bucket
-  id, not a cross-bucket clustering scan) and deletes the matching **per-key**
-  raw/tile partitions, then the index rows. Shard the index partition key if
-  one group+bucket has too many keys.
+  One table. `commit_events` does an unversioned upsert of `business_key`
+  (no `attempt`/`epoch`, no payload). A failed head LWT may leave a stale
+  index row; `maintain` deletes it. `maintain` per owned `key_group`:
+
+  ```cql
+  SELECT * FROM window_kg_buckets
+   WHERE namespace = ? AND key_group = ?
+     AND bucket_start < ?
+  ```
+
+  then deletes those per-key raw/tile partitions and the matching index
+  rows. After prune, the partition holds only live buckets. `index_shard`
+  on the PK is later, not v1.
 - `window_raw`: **one CQL row per event**, clustered by event time. `payload`
   is that event only (Arrow-IPC including `__seq_no`). Do not pack a batch
   into one blob — that breaks time clustering, overlay, and per-event GC.
@@ -624,8 +635,9 @@ For one key:
 1. Load writer `KeyState`.
 2. Allocate writer epoch `E`.
 3. Derive `key_group` from the key hash and the client's `max_p`.
-4. Write changed raw rows, tiles, `KeyState`, triggers, and `window_kg_buckets`
-   under `(job attempt, E)`.
+4. Write changed raw rows, tiles, `KeyState`, and triggers under
+   `(job attempt, E)`. Upsert `window_kg_buckets` unversioned (not under
+   `E`; failed head LWT may leave a stale index row for `maintain` to drop).
 5. LWT-update the head, requiring the current `owner_writer` and previous
    writer version.
 6. During normal operation, set both writer and serving versions to
@@ -804,10 +816,11 @@ owned range from `OperatorTaskState`.
 **Window `maintain` body:**
 - drop consumed triggers (`fire_at.ts ≤ W`) with a `fire_ts` clustering
   range delete on shards overlapping the task's key-group range;
-- from `window_kg_buckets`, for each owned group and each event-time
-  `bucket_start` fully below `data_floor`, page `business_key`s (and index
-  shards if enabled); delete each per-key raw/tile partition; drop the
-  index rows. Do not rely on TWCS/TTL for this (write-time ≠ event-time;
+- from `window_kg_buckets`, per owned `key_group`,
+  `SELECT … WHERE namespace = ? AND key_group = ? AND bucket_start < data_floor`;
+  page the result; delete each per-key raw/tile partition and the matching
+  index rows (including stale rows from a failed head LWT). Do not probe
+  historical bucket ids. Do not rely on TWCS/TTL (write-time ≠ event-time;
   replay rewrites old buckets);
 - drop unreachable MVCC generations (`attempt` / `epoch` not reachable
   from writer heads, serving heads, recovery bases, or retained

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -427,11 +427,15 @@ partition (compaction, repair, hot token) hold every key in the group+bucket.
 Keep `business_key` in the **data** partition key so each key+bucket stays
 small.
 
-That data layout cannot list `bucket_start < data_floor`, so `commit_events`
-also writes one payload-free index. **`bucket_start` is clustering on the
-index, not a partition-key component** — otherwise `maintain` cannot
-`SELECT … AND bucket_start < data_floor` and would have to probe historical
-bucket ids (unbounded). Do not add a second `live_buckets` table.
+That data layout cannot list expired buckets, so `commit_events` also writes
+one payload-free index. **`bucket_start` is clustering on the index, not a
+partition-key component** — otherwise `maintain` cannot range-scan buckets
+and would have to probe historical bucket ids (unbounded). Do not add a
+second `live_buckets` table. Bind `floor_bucket` = first bucket that still
+overlaps `data_floor` (`align_down(data_floor, width)`). Only drop buckets
+whose entire range is below the floor: `bucket_start + width <= data_floor`,
+i.e. `bucket_start < floor_bucket`. Do not bind `data_floor` as if it were a
+`bucket_start`.
 
 After prune, each index partition is one key group and holds only live
 buckets: `keys_in_group × (retention / bucket_width)`, skinny cells. Shard
@@ -579,12 +583,14 @@ CREATE TABLE window_triggers (
   ```cql
   SELECT * FROM window_kg_buckets
    WHERE namespace = ? AND key_group = ?
-     AND bucket_start < ?
+     AND bucket_start < ?   -- floor_bucket, not data_floor
   ```
 
-  then deletes those per-key raw/tile partitions and the matching index
-  rows. After prune, the partition holds only live buckets. `index_shard`
-  on the PK is later, not v1.
+  For each hit, delete that key's `window_raw` partition for the bucket
+  **and** every `window_tiles` partition for the same key+bucket (all
+  `granularity_ms` from task state). Then delete the index row. After prune,
+  the partition holds only live buckets. `index_shard` on the PK is later,
+  not v1.
 - `window_raw`: **one CQL row per event**, clustered by event time. `payload`
   is that event only (Arrow-IPC including `__seq_no`). Do not pack a batch
   into one blob — that breaks time clustering, overlay, and per-event GC.
@@ -771,7 +777,7 @@ meta:
 data:
     (PartitionKey, family, bucket) -> materialized writer-view data
 triggers:
-    (namespace, attempt, bucket, kg_shard) -> immutable due entries
+    (namespace, bucket, kg_shard) -> immutable due entries
 ```
 
 `family` is raw data or tiles at a specific granularity.
@@ -817,15 +823,21 @@ owned range from `OperatorTaskState`.
 - drop consumed triggers (`fire_at.ts ≤ W`) with a `fire_ts` clustering
   range delete on shards overlapping the task's key-group range;
 - from `window_kg_buckets`, per owned `key_group`,
-  `SELECT … WHERE namespace = ? AND key_group = ? AND bucket_start < data_floor`;
-  page the result; delete each per-key raw/tile partition and the matching
-  index rows (including stale rows from a failed head LWT). Do not probe
-  historical bucket ids. Do not rely on TWCS/TTL (write-time ≠ event-time;
-  replay rewrites old buckets);
-- drop unreachable MVCC generations (`attempt` / `epoch` not reachable
-  from writer heads, serving heads, recovery bases, or retained
-  checkpoints; orphan/zombie writes). After this, overlay filters stay
-  one or two attempt clauses.
+  `SELECT … AND bucket_start < floor_bucket` (`floor_bucket =
+  align_down(data_floor, width)`; do not bind `data_floor` — a bucket with
+  `bucket_start < data_floor` can still cover `[data_floor, data_floor +
+  width)`). Page the result. For each `(business_key, bucket_start)`, delete
+  the per-key `window_raw` partition and every `window_tiles` partition for
+  that key+bucket (each `granularity_ms` from task state), then the index
+  row (including stale rows from a failed head LWT). Do not probe historical
+  bucket ids. Do not rely on TWCS/TTL (write-time ≠ event-time; replay
+  rewrites old buckets);
+- drop unreachable MVCC generations for keys still present in **live**
+  `window_kg_buckets` rows for the owned groups (`window_head` is per-key and
+  cannot be scanned). Drop `attempt` / `epoch` not reachable from writer
+  heads, serving heads, recovery bases, or retained checkpoints;
+  orphan/zombie writes. After this, overlay filters stay one or two attempt
+  clauses.
 
 **In-flight WRO:** `load_window_data` pins the key's serving version at
 start. `maintain` must not drop that version while the request can still

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -110,11 +110,11 @@ pub trait WindowOperatorStore: Send + Sync + Debug {
     async fn checkpoint(
         &self,
         namespace: &StateNamespace,
-    ) -> Result<WindowCheckpointMeta>;
+    ) -> Result<WindowBackendSnapshot>;
     async fn restore(
         &self,
         namespace: &StateNamespace,
-        meta: &WindowRestoreMeta,
+        snapshot: &WindowBackendSnapshot,
     ) -> Result<()>;
 }
 #[async_trait]
@@ -139,8 +139,8 @@ pub trait WindowRequestStore: Send + Sync + Debug {
   `ts_column_index` plus `__seq_no` identifies each raw cursor. Retries are
   idempotent.
 - `store_meta` publishes only progress and retention state.
-- `checkpoint` resolves pending writes, flushes them, and returns the backend
-  version at the aligned barrier. It does not serialize window payloads.
+- `checkpoint` resolves pending writes, flushes them, and returns a
+  backend-specific snapshot. Scylla returns only the aligned backend version.
 - `restore` starts store access from the supplied checkpoint base. For Scylla,
   the current fenced attempt inherits reads from that immutable version.
 - The namespace argument scopes checkpoint and restore when one store instance
@@ -153,7 +153,8 @@ pub trait WindowRequestStore: Send + Sync + Debug {
 - Methods must not broaden ranges or return partial results.
 
 `InMemWindowStore` is the reference backend. One lock provides the WRO snapshot
-boundary; asynchronous physical retention is not emulated.
+boundary, and its checkpoint embeds the serialized namespace state.
+Asynchronous physical retention is not emulated.
 
 ## Runtime flows
 
@@ -211,12 +212,9 @@ pub struct StateVersion {
     pub epoch: u64,
 }
 
-pub struct WindowCheckpointMeta {
-    pub version: StateVersion,
-}
-
-pub struct WindowRestoreMeta {
-    pub base_version: StateVersion,
+pub enum WindowBackendSnapshot {
+    InMemory { snapshot: Vec<u8> }, // in mem uses whole snapshot
+    Versioned { version: StateVersion }, // this is for scylla
 }
 ```
 
@@ -227,9 +225,9 @@ It is both the writer fence and the recovery branch ID.
 Epoch is one task-wide counter within an attempt. Every publication, regardless
 of key, gets the next epoch. A new attempt may restart at zero because
 `(attempt, epoch)` remains unique. Scylla stores the two fields separately.
-The process-local in-memory backend keeps cloned snapshots indexed by a local
-version; those versions are valid only while that store instance survives.
-Namespace remains in the operator's checkpoint envelope.
+Scylla uses `WindowBackendSnapshot::Versioned`; the in-memory backend uses
+`InMemory` with a serialized namespace snapshot. Namespace remains in the
+operator's checkpoint envelope.
 
 ### Tables
 
@@ -389,8 +387,8 @@ At an aligned barrier:
 1. Drain all buffered keys to a defined checkpoint frontier.
 2. Resolve all in-flight publication outcomes and flush the backend.
 3. Capture `(current attempt, current task epoch)`.
-4. Return `WindowCheckpointMeta`; master persists it with task/checkpoint
-   identity.
+4. Return `WindowBackendSnapshot::Versioned`; the operator persists it in its
+   checkpoint envelope.
 5. Continue processing at later epochs.
 
 The checkpoint contains no keys or state payloads. For any key, checkpoint
@@ -398,13 +396,15 @@ state is its newest version from the checkpoint attempt with epoch at or below
 the cutoff. Creating a checkpoint does not insert a recovery-base row; that row
 is created only when a new attempt restores this checkpoint.
 
-The operator stores namespace plus `WindowCheckpointMeta` and passes the
-corresponding `WindowRestoreMeta` back to the store on restore. It still does
-not drain `buffered_keys`; checkpoint integration must implement that frontier.
+The operator stores namespace plus `WindowBackendSnapshot` in
+`WindowStateSnapshot`. For unchanged task assignment, restore passes that same
+versioned snapshot back to the store. It still does not drain `buffered_keys`;
+checkpoint integration must implement that frontier.
 
 ### Recovery
 
-1. Master starts the replacement with `WindowRestoreMeta`.
+1. The replacement receives the restored version in
+   `WindowBackendSnapshot::Versioned`.
 2. Create a new attempt, insert
    `window_recovery_bases(new attempt -> restored checkpoint version)`, and
    start epoch at zero. The row must exist before the attempt publishes data.
@@ -491,6 +491,8 @@ only the materialization and merge rules would change.
 
 ### Rescaling
 
-When we introduce key groups, rescaling is simiply re-mapping key-group <->task in-between checkpoints. `WindowRestoreMeta` becomes a key-group-to-base-version
-mapping and window_recovery_bases gain key-group granularity. The core head, raw,
-tile, `KeyState`, WO, and WRO contracts remain unchanged.
+When we introduce key groups, rescaling is simiply re-mapping key-group <->task
+in-between checkpoints. The versioned backend snapshot becomes a
+key-group-to-base-version mapping and `window_recovery_bases` gain key-group
+granularity. The core head, raw, tile, `KeyState`, WO, and WRO contracts remain
+unchanged.

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -145,6 +145,9 @@ job-wide and must not change for a pipeline incarnation.
 - `WindowTrigger` is durable event-time work. Current RANGE windows create one
   `RowEmit` trigger per accepted row; `WindowEnd` is reserved for scheduled
   windows.
+- `TriggerResume` is an opaque `load_triggers` cursor. Scylla seeks from the
+  last **raw** clustering row (even if overlay-hidden), not the last visible
+  trigger. InMem resumes from the last visible trigger.
 - Tiles for all windows share `(granularity, tile_start)`, so persisted tile and
   accumulator state retain `WindowId`.
 - `WindowData` is one materialized WRO snapshot. Evaluation filters its rows by

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -85,6 +85,16 @@ pub struct DueWindowWork {
     pub key_state: KeyState,
     pub triggers: Vec<WindowTrigger>,
 }
+/// Opaque to the operator. Only the backend that produced it should pass it back.
+pub struct TriggerResume {
+    pub last: WindowTrigger,
+    /// Last raw clustering `(attempt, epoch)` when the store distinguishes
+    /// overlay-hidden rows from visible ones. Empty attempt = last visible.
+    pub raw_attempt: Vec<u8>,
+    pub raw_epoch: i64,
+    /// Scylla `(bucket, shard)` walk index. InMem ignores this.
+    pub part_idx: usize,
+}
 pub struct TileState {
     pub accumulator_state: Option<AccumulatorState>,
 }
@@ -161,9 +171,10 @@ AttemptToken    = job-level execution attempt
 ```
 
 The client derives `key_group` from `Key.hash` and bound `max_p`. It never
-trusts a caller-supplied group. `stream_due` / `checkpoint` / `restore` use
+trusts a caller-supplied group. `load_triggers` / `checkpoint` / `restore` use
 the bound range and do not take `owned` or `namespace`. Per-key calls must
-land in the bound range (routing bug otherwise).
+land in the bound range (routing bug otherwise). The operator helper
+`stream_due` pages `load_triggers` and is not a store method.
 
 WRO reuses the WO owner namespace. It addresses rows by `PartitionKey`
 (namespace + business key). Request routing still sends a lookup to the WRO
@@ -211,11 +222,13 @@ pub trait WindowOperatorStore: Send + Sync + Debug {
         state: &KeyState,
         triggers: &[WindowTrigger],
     ) -> Result<()>;
-    fn stream_due<'a>(
-        &'a self,
+    async fn load_triggers(
+        &self,
         after: Option<Cursor>,
         through: Cursor,
-    ) -> BoxStream<'a, Result<Vec<DueWindowWork>>>;
+        resume: Option<&TriggerResume>,
+        limit: usize,
+    ) -> Result<(Vec<WindowTrigger>, Option<TriggerResume>)>;
     async fn store_key_state(
         &self,
         partition: &PartitionKey,
@@ -249,9 +262,15 @@ pub trait WindowRequestStore: Send + Sync + Debug {
   and triggers. `ts_column_index` plus `__seq_no` identifies each raw cursor.
   Retries are idempotent. The backend derives `key_group` from the partition's
   business key; it does not trust a caller-supplied group.
-- `stream_due` owns backend pagination for one stable watermark range and
-  returns bounded trigger groups with their corresponding key state. It only
-  returns work for the client's bound key-group range.
+- `load_triggers` returns a bounded page of **visible** triggers in one
+  stable `(after, through]` plus an opaque resume, or none when the range is
+  exhausted. It only returns work for the client's bound key-group range.
+  The store does not group by key or load `key_state`. The operator helper
+  `stream_due` pages this call, groups by key, and attaches `key_state`.
+  Fetch size is `window.process_page_size` (4096), floored at
+  `process_key_concurrency`. Paginate only when a hop exceeds the cap.
+  Do not derive fetch size from key concurrency. Prefetch is later
+  ([#297](https://github.com/volga-project/volga/issues/297)).
 - `store_key_state` publishes only sequence/evaluation state.
 - `checkpoint` completes pending writes and returns a backend-specific
   snapshot of the client's bound range only. Scylla returns this writer's
@@ -601,7 +620,7 @@ CREATE TABLE window_triggers (
   is a clustering filter, not another hop.
 - `window_triggers`: immutable due work. Locality is
   `(namespace, bucket_start, kg_shard)`. Cluster by `fire_ts` first so
-  `stream_due` can slice `(after, through]` without `ALLOW FILTERING`.
+  `load_triggers` can slice `(after, through]` without `ALLOW FILTERING`.
   `key_group` is a regular column; the client drops rows outside the bound
   range (`kg_shard` already limits how many groups share a partition).
   Shard with the **same range formula as routing**, not
@@ -700,7 +719,7 @@ except under `OnCommit` after catch-up. Data rows are already stamped with
 invisible to WRO until a later promote names that epoch. A new epoch starts
 only after the previous write outcome is known. Ownership CAS failure stops
 the WO as fenced. Trigger rows from an unpublished attempt/epoch are not
-returned by `stream_due` (overlay).
+returned by `load_triggers` (overlay).
 
 `store_key_state` follows the same protocol but writes no raw, tile, trigger,
 or bucket-index rows.
@@ -719,18 +738,39 @@ Logical runs are mapped to time buckets, loaded, merged, and filtered back to
 the exact requested ranges. Raw rows are deduplicated by `Cursor`; current
 tiles replace matching base tiles.
 
-`stream_due` maps its stable watermark range to trigger buckets and the
-`kg_shard`s that overlap the client's bound range. Each query is
+`load_triggers` maps its stable watermark range to trigger buckets and the
+`kg_shard`s that overlap the client's bound range. One hop is `LIMIT` plus
+optional clustering seek `>` the last **raw** row (full tuple, not `fire_at`
+alone). Overlay-hidden rows still advance the seek so they are not
+re-read. The next `(bucket, shard)` resets the seek to `after`.
 
 ```text
+-- first page of a shard
 WHERE namespace = ? AND bucket_start = ? AND kg_shard = ?
-  AND fire_ts > ? AND fire_ts <= ?
+  AND fire_ts >= ? AND fire_ts <= ?
+LIMIT ?
+
+-- continue inside the same shard
+WHERE namespace = ? AND bucket_start = ? AND kg_shard = ?
+  AND (fire_ts, fire_seq, business_key, trigger_kind, window_id, attempt, epoch)
+      > (?, ?, ?, ?, ?, ?, ?)
+  AND fire_ts <= ?
+LIMIT ?
 ```
 
-then the client drops `key_group` outside the bound range and applies the
-same attempt/epoch visibility filter as raw overlay. It batch-loads writer
-`KeyState`, groups triggers into `DueWindowWork`, and owns page sizing and
-continuation state for the lifetime of the stream.
+The client drops `key_group` outside the bound range and applies the same
+attempt/epoch visibility filter as raw overlay. Resume is
+`(last raw row as a WindowTrigger, raw_attempt, raw_epoch, part_idx)`.
+Empty `raw_attempt` means start of the current shard (no seek).
+
+Do not use `OFFSET`, native `PagingState`, seek on `fire_ts` alone, or
+`execute_unpaged` of the whole range.
+
+The operator helper `stream_due` pages `load_triggers`, groups by key,
+loads writer `KeyState`, and yields `DueWindowWork`. It does not live on
+the store trait. Watermark still advances only after the full
+`(after, through]`. Prefetch is later
+([#297](https://github.com/volga-project/volga/issues/297)).
 
 ### WRO reads
 

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -648,16 +648,24 @@ range scan at restore.
 WRO always pins `serving_*` (one hop + payload). It does not discover epoch
 from `key_state` and does not read writer overlay.
 
-**Publish policy** (same `promote_serving` LWT: `SET serving_* IF owner =
-me`). Cadence is the freshness / ingest-p99 knob; it is not fencing:
+**Publish policy** (`ScyllaConfig.serving_publish`, same `promote_serving`
+LWT: `SET serving_* IF owner = me`). Cadence is the freshness / ingest-p99
+knob; it is not fencing. Catch-up freeze still wins: do not promote serving
+while N+1 is behind the pinned cut.
 
 | Policy | Ingest wait path | WRO freshness |
 | --- | --- | --- |
-| `OnCommit` (v1 default, after catch-up) | data + promote LWT | last promoted commit |
-| async / periodic / checkpoint | data only | last successful promote |
+| `on_commit` (default) | data + promote LWT after catch-up | last ingest |
+| `interval: { interval_ms }` | data only; promote this key when the interval elapses | last promote, at most `interval_ms` lag (continuous ingest) |
+| `checkpoint` | data only | last checkpoint flush |
 
-Do not advance `serving_*` while N+1 is catching up. A timer that publishes
-serving during replay is a mixed writer+serving read.
+Checkpoint always flushes serving for live keys (so a barrier is WRO-visible
+even under `interval` / `checkpoint`). Empty-key `INSERT IF NOT EXISTS` still
+names the first snapshot so WRO is not empty.
+
+A background timer is not required: interval is checked on the next ingest
+of that key, and checkpoint covers idle keys. Do not spawn a publisher
+during restore freeze.
 
 ### WO write
 
@@ -672,10 +680,11 @@ For one key:
    `E`; a later failed promote may leave a stale index row for `maintain`).
 5. **Empty key:** after data is durable, `INSERT IF NOT EXISTS` with serving
    `E` (first snapshot).
-6. **Owned, not recovering (or catch-up complete):** `promote_serving(E)` —
-   `SET serving_* IF owner = me` (v1 `OnCommit`). During recovery freeze,
-   skip this until writer `KeyState` has caught the pinned serving
-   `KeyState` (`next_seq` and, if present, `evaluation.through`).
+6. **Owned, not recovering (or catch-up complete):** `promote_serving(E)`
+   according to `serving_publish` (`on_commit` waits; `interval` /
+   `checkpoint` skip until due). During recovery freeze, skip until writer
+   `KeyState` has caught the pinned serving `KeyState` (`next_seq` and, if
+   present, `evaluation.through`).
 7. Update or invalidate affected WO cache entries.
 
 Each `(key, bucket)` (and each tile partition) is one Scylla partition.
@@ -787,7 +796,7 @@ future work.
    serving.
 6. Once append-only replay catches the old serving `KeyState`, `SET serving_*
    IF owner = me`.
-7. Continue under the configured publish policy (`OnCommit` / later periodic).
+7. Continue under `serving_publish` (`on_commit` / `interval` / `checkpoint`).
 
 During recovery, writer data and serving pins differ. Replay advances MVCC
 rows; WRO keeps using `serving_*`. Compare the writer `KeyState` with the
@@ -829,16 +838,16 @@ use `LOCAL_QUORUM` for both data reads and writes (`W+R > RF`). Head claim/publi
 is LWT with `LOCAL_SERIAL` + learn `LOCAL_QUORUM`:
 
 - **WO write:** non-LWT data @ `LOCAL_QUORUM`. Owner steal is one LWT on first
-  touch (fence, no serving change). Serving promote is a separate LWT
-  (`OnCommit` after catch-up in v1; later a periodic/checkpoint publisher).
+  touch (fence, no serving change). Serving promote is a separate LWT on the
+  configured cadence (`on_commit` / `interval` / `checkpoint`), never during
+  catch-up freeze.
 - **WO read (cache miss):** overlay on versioned tables @ `LOCAL_QUORUM`
   (not the serving pin).
 - **WRO read:** head pin + data @ `LOCAL_QUORUM` (serving pointer) for one
   coherent snapshot. Always this path; do not derive the pin from `max(epoch)`.
 
 **Not v1:** `USING TIMESTAMP` instead of owner CAS; derived-from-`key_state`
-WRO pins. Explore a non-`OnCommit` publisher if serving LWT dominates ingest
-p99 — same promote LWT, different cadence.
+WRO pins.
 
 ### State prune / cleanup
 

--- a/src/runtime/operators/window/STORE_DESIGN.md
+++ b/src/runtime/operators/window/STORE_DESIGN.md
@@ -378,8 +378,8 @@ write. It is not a per-key or per-key-group clock.
 | --- | --- |
 | Writer allocator | produces `E` |
 | Data rows | MVCC: this cell belongs to publish `E` |
-| Head `writer_(attempt, epoch)` | this key's latest publish |
-| Head `serving_(attempt, epoch)` | WRO pin; same number line, equal to writer except during recovery |
+| Head `writer_(attempt, epoch)` | optional watermark of this key's latest **writer** publish |
+| Head `serving_(attempt, epoch)` | WRO/GC pin — the only cut request reads. Not updated on ingest unless the publish policy says so |
 | Checkpoint cutoff | include versions with `epoch <= E` for keys in this range |
 
 Head `writer_epoch=5` on key A and `7` on key B means A and B were last
@@ -565,10 +565,11 @@ CREATE TABLE window_triggers (
 );
 ```
 
-- `window_head`: per-key writer fence plus writer and WRO-visible version
-  pointers; the LWT publication boundary. `owner_writer` is `WriterId`.
-  `writer_*` / `serving_*` are job-level `StateVersion`. Point get by
-  `(namespace, key_group, business_key)`.
+- `window_head`: one row per key (not versioned by attempt). `owner_writer` is
+  the fence. `serving_*` is the published snapshot WRO always pins.
+  `writer_*` may lag serving during recovery. Point get by
+  `(namespace, key_group, business_key)`. Do not put `attempt` in this PK —
+  that stores many names and the zombie race moves to the reader.
 - `window_recovery_bases`: immutable rows mapping a new job `recovery_attempt`
   to restored checkpoint cutoffs at **key-group range** granularity. Lookup for
   a key: find the row with `range_start <= key_group < range_end`. This lets a
@@ -577,7 +578,7 @@ CREATE TABLE window_triggers (
   source tasks.
 - `window_kg_buckets`: skinny GC index, not a source of truth for reads.
   One table. `commit_events` does an unversioned upsert of `business_key`
-  (no `attempt`/`epoch`, no payload). A failed head LWT may leave a stale
+  (no `attempt`/`epoch`, no payload). A failed serving promote may leave a stale
   index row; `maintain` deletes it. `maintain` per owned `key_group`:
 
   ```cql
@@ -618,36 +619,63 @@ CREATE TABLE window_triggers (
 
 ### Head semantics
 
-- `owner_writer` is the WO task execution allowed to publish this key.
-- `writer_(attempt, epoch)` is the private WO snapshot (job attempt + writer
-  epoch).
-- `serving_(attempt, epoch)` is the complete snapshot visible to WRO.
-- Writer and serving versions are equal normally and may differ during
-  recovery.
+`window_head` is a singleton lease, not an MVCC table. Data rows are versioned
+by `(attempt, epoch)` in their primary keys; overlay fences zombie **data**.
+Head is the **serving name**. A last-write-wins upsert lets dying attempt N
+overwrite `serving_*` after N+1 is live; WRO follows that pin. Owner LWT is
+the fence for that cell, not a workaround for a missing clustering key.
 
-When a new WO instance (initial or recovery) first writes a key, it
-LWT/CAS-claims `owner_writer`. Every later head update checks both owner and
-expected writer version.
+Three fields, three jobs — never one LWT that does all three on ingest:
 
-Claiming means conditionally setting `owner_writer`: insert it for a new head,
-or replace the expected previous owner. Only one competing WO can succeed.
-Fencing happens when a zombie tries to update a head now owned by the new WO:
-the conditional update fails, so the zombie's data is not published.
+| Column | Role |
+| --- | --- |
+| `owner_writer` | Who may change serving. Fence. |
+| `writer_(attempt, epoch)` | Optional writer watermark. |
+| `serving_(attempt, epoch)` | Snapshot WRO always `SELECT`s. |
+
+`owner_writer` is length-prefixed `attempt || vertex` (`WriterId` on the
+scope stays vertex). Claiming is **only** `SET owner_writer`:
+
+- empty key: `INSERT … IF NOT EXISTS` (may also set serving — there is no
+  prior cut);
+- restore, first touch: `UPDATE … SET owner_writer = me IF owner_writer =
+  previous`. **Do not** change `serving_*`.
+
+CAS not applied fences; do not fall through to a second LWT. Restore is a
+key-group range, head is per key, so steal is **lazy on first touch**, not a
+range scan at restore.
+
+WRO always pins `serving_*` (one hop + payload). It does not discover epoch
+from `key_state` and does not read writer overlay.
+
+**Publish policy** (same `promote_serving` LWT: `SET serving_* IF owner =
+me`). Cadence is the freshness / ingest-p99 knob; it is not fencing:
+
+| Policy | Ingest wait path | WRO freshness |
+| --- | --- | --- |
+| `OnCommit` (v1 default, after catch-up) | data + promote LWT | last promoted commit |
+| async / periodic / checkpoint | data only | last successful promote |
+
+Do not advance `serving_*` while N+1 is catching up. A timer that publishes
+serving during replay is a mixed writer+serving read.
 
 ### WO write
 
 For one key:
 
-1. Load writer `KeyState`.
+1. Load writer `KeyState` (overlay). On first access after restore, steal
+   `owner_writer` without moving serving.
 2. Allocate writer epoch `E`.
 3. Derive `key_group` from the key hash and the client's `max_p`.
 4. Write changed raw rows, tiles, `KeyState`, and triggers under
    `(job attempt, E)`. Upsert `window_kg_buckets` unversioned (not under
-   `E`; failed head LWT may leave a stale index row for `maintain` to drop).
-5. LWT-update the head, requiring the current `owner_writer` and previous
-   writer version.
-6. During normal operation, set both writer and serving versions to
-   `(job attempt, E)`. During recovery, advance only writer until catch-up.
+   `E`; a later failed promote may leave a stale index row for `maintain`).
+5. **Empty key:** after data is durable, `INSERT IF NOT EXISTS` with serving
+   `E` (first snapshot).
+6. **Owned, not recovering (or catch-up complete):** `promote_serving(E)` —
+   `SET serving_* IF owner = me` (v1 `OnCommit`). During recovery freeze,
+   skip this until writer `KeyState` has caught the pinned serving
+   `KeyState` (`next_seq` and, if present, `evaluation.through`).
 7. Update or invalidate affected WO cache entries.
 
 Each `(key, bucket)` (and each tile partition) is one Scylla partition.
@@ -655,15 +683,15 @@ Each `(key, bucket)` (and each tile partition) is one Scylla partition.
 mutation per event/tile row, one RTT per partition, not one RTT per event.
 Do not use logged BATCH. Do not batch across partitions (no cross-partition
 atomicity, coordinator penalty). Tiles, triggers, and other buckets are
-separate requests. The head LWT is the visibility boundary after those
-writes complete.
+separate requests.
 
-Data written before a failed head update is orphaned. A new epoch starts only
-after the previous publication outcome is known. On success, advance the
-epoch; on failure, safely retry the same publication or abort the attempt.
-An ownership CAS failure stops the WO as fenced. Trigger rows from an
-unpublished attempt/epoch are orphaned with its other data and are not
-returned by `stream_due`.
+Serving LWT is the WRO visibility boundary. It is **not** coupled to ingest
+except under `OnCommit` after catch-up. Data rows are already stamped with
+`E`; WO reload does not need head. Orphaned data from a failed promote is
+invisible to WRO until a later promote names that epoch. A new epoch starts
+only after the previous write outcome is known. Ownership CAS failure stops
+the WO as fenced. Trigger rows from an unpublished attempt/epoch are not
+returned by `stream_due` (overlay).
 
 `store_key_state` follows the same protocol but writes no raw, tile, trigger,
 or bucket-index rows.
@@ -751,21 +779,22 @@ future work.
    the attempt publishes data. The master only plans and sends the restore
    payload.
 3. Source restores its checkpoint offset and replays post-checkpoint input.
-4. On first access to a key, retain its old serving version, claim
-   `owner_writer`, and restore writer `KeyState` from the checkpoint base for
-   that key's range.
+4. On first access to a key, steal `owner_writer` (CAS). Leave `serving_*` at
+   the previous cut (or `restore_base` if head had never been published).
+   Restore writer `KeyState` from the checkpoint overlay for that key's range.
 5. Resume watermark work by streaming checkpoint-visible triggers above the
-   restored watermark while replay advances only writer state.
-6. Once append-only replay catches the old serving state, atomically switch
-   serving to writer.
-7. Continue normal publication with writer and serving together.
+   restored watermark while replay advances only writer state. Do not promote
+   serving.
+6. Once append-only replay catches the old serving `KeyState`, `SET serving_*
+   IF owner = me`.
+7. Continue under the configured publish policy (`OnCommit` / later periodic).
 
-During recovery, writer and serving versions differ. Replay advances writer
-while WRO keeps using the old serving snapshot. While they differ, compare the
-writer `KeyState` with the retained serving state. Once `next_seq` and
-`evaluation.through` reach the serving state, atomically promote writer to
-serving. Keys without evaluation state compare only `next_seq`. Keys not
-touched after recovery may continue serving their old snapshot.
+During recovery, writer data and serving pins differ. Replay advances MVCC
+rows; WRO keeps using `serving_*`. Compare the writer `KeyState` with the
+key_state row at the pinned serving version. Once `next_seq` and
+`evaluation.through` reach that state, promote. Keys without evaluation
+state compare only `next_seq`. Keys not touched after recovery keep their
+old serving snapshot. A zombie N publish after steal does not apply.
 
 ### WO cache
 
@@ -799,12 +828,17 @@ Minimal setup is single DC, RF=3. Because we need read-your-write after publish,
 use `LOCAL_QUORUM` for both data reads and writes (`W+R > RF`). Head claim/publish
 is LWT with `LOCAL_SERIAL` + learn `LOCAL_QUORUM`:
 
-- **WO write:** non-LWT data @ `LOCAL_QUORUM`; one head LWT per publish (fence + visibility).
-- **WO read (cache miss):** head lookup + data @ `LOCAL_QUORUM` (writer pointer).
-- **WRO read:** head pin + data @ `LOCAL_QUORUM` (serving pointer) for one coherent snapshot.
+- **WO write:** non-LWT data @ `LOCAL_QUORUM`. Owner steal is one LWT on first
+  touch (fence, no serving change). Serving promote is a separate LWT
+  (`OnCommit` after catch-up in v1; later a periodic/checkpoint publisher).
+- **WO read (cache miss):** overlay on versioned tables @ `LOCAL_QUORUM`
+  (not the serving pin).
+- **WRO read:** head pin + data @ `LOCAL_QUORUM` (serving pointer) for one
+  coherent snapshot. Always this path; do not derive the pin from `max(epoch)`.
 
-**Possible future improvement:** generation + `USING TIMESTAMP` may avoid LWT on
-each publish; still quorum everywhere. Explore it only if LWT latency hurts.
+**Not v1:** `USING TIMESTAMP` instead of owner CAS; derived-from-`key_state`
+WRO pins. Explore a non-`OnCommit` publisher if serving LWT dominates ingest
+p99 — same promote LWT, different cadence.
 
 ### State prune / cleanup
 
@@ -829,7 +863,7 @@ owned range from `OperatorTaskState`.
   width)`). Page the result. For each `(business_key, bucket_start)`, delete
   the per-key `window_raw` partition and every `window_tiles` partition for
   that key+bucket (each `granularity_ms` from task state), then the index
-  row (including stale rows from a failed head LWT). Do not probe historical
+  row (including stale rows from a failed serving promote). Do not probe historical
   bucket ids. Do not rely on TWCS/TTL (write-time ≠ event-time; replay
   rewrites old buckets);
 - drop unreachable MVCC generations for keys still present in **live**


### PR DESCRIPTION
Normative design for using Scylla as the remote state store behind the window
operator. This is the plan of record; it replaces the protocols drafted in
#298 and #299, both now closed.

Two ideas carry the whole thing.

**1. `Version = (attempt, epoch)`, visibility is a per-key-group cut
history.** Every row is stamped with a totally ordered version, and what a
reader sees is a short sorted list of at most one `(attempt, epoch)` prefix
per attempt. Older attempts keep their prefix forever, so pre-crash history
never disappears; a zombie's post-checkpoint writes sit above its prefix and
are excluded permanently, by every later attempt. `epoch` is a per-key-group
write-batch counter that starts at zero each attempt and needs no seeding,
because `attempt` is the high-order component of the order.

**2. Publication is the checkpoint.** On checkpoint *completion* the WO
writes its cut, the committed watermark and a retention floor into one
`window_kg_meta` row per key group. That single row is the entire interface
between the streaming side and the serving side.

The second idea is what makes the design small. Because the published cut is
exactly the cut a successor restores from, it only ever grows — so there is
no publish cadence, no ownership lease, no per-key pin, no `prev_E`, and no
clamp. The clamp was the largest source of complexity in the earlier drafts,
and it exists only if a reader can be shown writes belonging to a checkpoint
that later aborts. Waiting for completion removes the possibility instead of
repairing it.

### Read contract

Reads say what they want to see, which is the seam where the WO emit path and
WRO could previously disagree about the same query:

- `Committed` — as of the last completed checkpoint. A window the WO emitted
  over `[lo, hi]` and a WRO `Committed` read of `[lo, hi]` return the same
  rows. Deterministic and replayable.
- `Fresh` — head-scoped best effort. Interior tiles are read at the cut; only
  raw above `committed_wm` is read at the current attempt, so the extra cost
  is one bounded raw slice. Two consequences are stated rather than
  engineered away: a torn commit can appear as a subset of one batch's events
  (never a corrupt aggregate, since Fresh widens raw only), and a late arrival
  below the head is invisible until its checkpoint completes.

WRO is not watermark-driven and does not need to be. It needs one thing the
watermark used to be a proxy for: whether the requested range still exists.
The published `retention_floor` gives it that directly, as a coverage guard
that refuses uncovered historical ranges. A normal "as of now" query always
passes it.

Retention itself is derived from the committed watermark and published, and
**GC deletes only below the published floor**. One rule, two properties: the
reader's coverage guarantee, and a floor that cannot move backwards across a
failover.

### Freshness, honestly

`Committed` read-your-writes across the WO/WRO split is checkpoint-granular.
For event-time correctness that is rarely the binding constraint — watermark
lag usually dominates publication lag — and `Fresh` covers the cases where it
is. Both are in *Accepted divergences* rather than buried.

### Two master prerequisites

Neither is window work, and the backend refuses to open without them.

- **Durable attempt allocation** (#156). `attempt_id` resets to `0` on
  pipeline start, and `max(restored) + 1` collides because attempts 2 and 3
  commonly restore from the same checkpoint.
- **A checkpoint-completion notification to tasks.** The master already
  tracks `latest_complete_checkpoint` and emits
  `LifecycleEvent::CheckpointCompleted`, but never tells the tasks. Cheaper
  fallback: piggyback the last completed id on the next barrier and publish
  one checkpoint behind.

### Also here

`docs/window-store-impl.md` carries the work items. The existing Scylla stack
(#287–#293) was written against the previous protocol and needs rework rather
than extension — `window_head`, `window_recovery_bases`, the lease, steal,
promote and `serving_publish` all go away. #291 is the umbrella tracking that.
