### PR TITLE
Advance window state only on watermarks

### DIFF
--- a/src/api/compiler.rs
+++ b/src/api/compiler.rs
@@ -12,7 +12,6 @@ use crate::runtime::functions::source::parquet::ParquetSourceConfig;
 use crate::runtime::functions::source::request_source::RequestSourceConfig;
 use crate::runtime::operators::operator::OperatorConfig;
 use crate::runtime::operators::source::source_operator::SourceConfig;
-use crate::runtime::operators::window::spec::WindowAdvancePolicy;
 
 fn resolve_source_schema(src: &SourceSpec) -> arrow::datatypes::Schema {
     schema_from_json(&src.schema_json)
@@ -115,8 +114,6 @@ fn compile_logical_graph_from_parts(
 
         if let Some(node) = graph.get_node_by_index_mut(idx) {
             if let OperatorConfig::WindowConfig(ref mut cfg) = node.operator_config {
-                let preserve_on_ingest =
-                    matches!(cfg.spec.advance_policy, WindowAdvancePolicy::OnIngest);
                 if let Some(OperatorTuningSpec::Window(win)) = &operator_overrides.defaults.tuning {
                     cfg.set_spec(win.clone());
                 }
@@ -128,9 +125,6 @@ fn compile_logical_graph_from_parts(
                 // Pipeline event_time is the only compile-time retention source
                 // (override WindowOperatorSpec.lateness is ignored).
                 cfg.spec.lateness = event_time.window.allowed_lateness_ms;
-                if preserve_on_ingest {
-                    cfg.spec.advance_policy = WindowAdvancePolicy::OnIngest;
-                }
             }
         }
     }

--- a/src/api/logical_graph.rs
+++ b/src/api/logical_graph.rs
@@ -12,7 +12,6 @@ use crate::runtime::operators::sink::sink_operator::SinkConfig;
 use crate::runtime::operators::source::source_operator::SourceConfig;
 use crate::runtime::operators::window::operator::WindowOutputMode;
 use crate::runtime::operators::window::request::WindowRequestOperatorConfig;
-use crate::runtime::operators::window::spec::WindowAdvancePolicy;
 use crate::runtime::partition::PartitionType;
 use crate::api::spec::event_time::EventTimeSpec;
 use crate::runtime::watermark::{TimeHint, WatermarkAssignConfig};
@@ -397,7 +396,6 @@ impl LogicalGraph {
         if let Some(node) = self.graph.node_weight_mut(top_window_node) {
             if let OperatorConfig::WindowConfig(ref mut config) = node.operator_config {
                 config.output_mode = WindowOutputMode::StateOnly;
-                config.spec.advance_policy = WindowAdvancePolicy::OnIngest;
             }
         }
         

--- a/src/runtime/operators/window/README.md
+++ b/src/runtime/operators/window/README.md
@@ -49,10 +49,11 @@ accumulator capability, optional tiling, and WRO current-row behavior.
 
 `WindowSpec` controls:
 
-- `advance_policy`: advance on watermarks, or on every ingest for state-only
-  request-serving topologies.
 - `lateness`: retention padding behind the largest window.
 - `tiling`: default tile granularities, with optional per-window overrides.
+
+Window state advances only on watermarks. State-only request-serving topologies
+still publish ingested raw rows and tiles immediately.
 
 The implementation currently requires timestamp-millisecond `ORDER BY` columns
 and `RANGE` frames.

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -19,7 +19,7 @@ use crate::runtime::operators::window::config::{BuiltWindows, WindowConfig};
 use crate::runtime::operators::window::eval::advance_key;
 use crate::runtime::operators::window::frame_utils::require_range_frame;
 use crate::runtime::operators::window::model::{Cursor, WindowId};
-use crate::runtime::operators::window::spec::{WindowAdvancePolicy, WindowSpec};
+use crate::runtime::operators::window::spec::WindowSpec;
 use crate::runtime::operators::window::state::{WindowOperatorState, WindowStateSnapshot};
 use crate::runtime::operators::window::store::{open_window_operator_store, StateNamespace};
 use crate::runtime::operators::window::TileConfig;
@@ -67,7 +67,6 @@ pub struct WindowOperator {
     state: Option<Arc<WindowOperatorState>>,
     buffered_keys: HashSet<Key>,
     output_mode: WindowOutputMode,
-    advance_policy: WindowAdvancePolicy,
     output_schema: SchemaRef,
     input_schema: SchemaRef,
     ts_column_index: usize,
@@ -91,14 +90,6 @@ impl WindowOperator {
             _ => panic!("Expected WindowConfig, got {:?}", config),
         };
 
-        if matches!(
-            window_operator_config.spec.advance_policy,
-            WindowAdvancePolicy::OnIngest
-        ) && window_operator_config.output_mode != WindowOutputMode::StateOnly
-        {
-            panic!("OnIngest advance is only valid for state-only WO");
-        }
-
         let built = BuiltWindows::for_wo(
             &window_operator_config.window_exec,
             &window_operator_config.tiling_configs,
@@ -116,7 +107,6 @@ impl WindowOperator {
             state: None,
             buffered_keys: HashSet::new(),
             output_mode: window_operator_config.output_mode,
-            advance_policy: window_operator_config.spec.advance_policy,
             output_schema: built.output_schema,
             input_schema: built.input_schema,
             ts_column_index: built.ts_column_index,
@@ -269,14 +259,8 @@ impl OperatorTrait for WindowOperator {
                         .insert_batch(key, keyed_message.base.record_batch.clone())
                         .await;
                     if dropped < input_rows {
-                        if self.output_mode == WindowOutputMode::StateOnly
-                            && matches!(self.advance_policy, WindowAdvancePolicy::OnIngest)
-                        {
-                            let max = max_seen.expect("accepted ingest must update max_seen");
-                            let _ = self.process_key(key, max).await;
-                        } else {
-                            self.buffered_keys.insert(key.clone());
-                        }
+                        debug_assert!(max_seen.is_some());
+                        self.buffered_keys.insert(key.clone());
                     }
                     OperatorPollResult::Continue
                 }

--- a/src/runtime/operators/window/spec.rs
+++ b/src/runtime/operators/window/spec.rs
@@ -2,21 +2,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::runtime::operators::window::tile::TileConfig;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub enum WindowAdvancePolicy {
-    /// Advance only on watermarks.
-    OnWatermark,
-    /// Advance on every keyed message for state-only request serving.
-    OnIngest,
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct WindowSpec {
     /// State retention after advance (`processed − max_wl − lateness`).
     /// Streaming late data is at or behind `processed_pos`.
     pub lateness: Option<i64>,
-    pub advance_policy: WindowAdvancePolicy,
     /// Default tiling for all windows (overridable per-window via `tiling_configs`).
     pub tiling: Option<TileConfig>,
 }
@@ -25,7 +16,6 @@ impl Default for WindowSpec {
     fn default() -> Self {
         Self {
             lateness: None,
-            advance_policy: WindowAdvancePolicy::OnWatermark,
             tiling: None,
         }
     }

--- a/src/runtime/operators/window/tests/semantics.rs
+++ b/src/runtime/operators/window/tests/semantics.rs
@@ -9,14 +9,13 @@ use crate::runtime::operators::window::operator::{WindowOperatorConfig, WindowOu
 use crate::runtime::operators::window::request::{
     WindowRequestOperator, WindowRequestOperatorConfig,
 };
-use crate::runtime::operators::window::spec::WindowAdvancePolicy;
 use crate::runtime::operators::window::spec::WindowSpec;
 use crate::runtime::operators::window::store::{
     InMemWindowStore, PartitionKey, StateNamespace, WindowOperatorStore,
 };
 use crate::runtime::operators::window::tests::harness::{
-    assert_window_values, batch, key, keyed_message, runtime_context, window_exec_from_sql,
-    Harness, WoWroHarness,
+    assert_window_values, batch, key, keyed_message, runtime_context, watermark_message,
+    window_exec_from_sql, Harness, WoWroHarness,
 };
 
 const SQL: &str = r#"SELECT timestamp, value, partition_key, SUM(value) OVER w as sum_val
@@ -145,24 +144,33 @@ async fn lateness_config_sets_retention_floor_in_meta() {
 }
 
 #[tokio::test]
-async fn on_ingest_advances_state_only_without_watermark() {
+async fn state_only_publishes_on_ingest_and_advances_on_watermark() {
     let exec = window_exec_from_sql(SQL).await;
     let mut cfg = WindowOperatorConfig::new(exec);
     cfg.output_mode = WindowOutputMode::StateOnly;
-    cfg.spec.advance_policy = WindowAdvancePolicy::OnIngest;
     let mut h = Harness::new(cfg).await;
     h.ingest(batch(vec![1000, 2000], vec![1.0, 2.0], vec!["A", "A"]), "A")
         .await;
 
     let partition = PartitionKey::new(&h.namespace, &key("A"));
     let meta = h.store.load_meta(&partition).await.expect("meta");
-    assert_eq!(meta.processed_pos, Some(Cursor::new(2000, 1)));
+    assert_eq!(meta.processed_pos, None);
 
     let mut wro = open_wro(h.store.clone(), h.namespace.clone()).await;
     assert_eq!(
         request_sum(&mut wro, "A", 2000).await,
         ScalarValue::Float64(Some(3.0))
     );
+
+    h.op.set_input(Some(Box::pin(futures::stream::iter(vec![
+        watermark_message(2000),
+    ]))));
+    assert!(matches!(
+        h.op.poll_next().await,
+        OperatorPollResult::Continue
+    ));
+    let meta = h.store.load_meta(&partition).await.expect("meta");
+    assert_eq!(meta.processed_pos, Some(Cursor::new(2000, 1)));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- remove `WindowAdvancePolicy` and ingest-driven window advancement from streaming and request execution modes
- keep state-only request data immediately visible while moving `processed_pos` only on watermarks
- document the unified semantics and replace the old `OnIngest` test with focused publication/advancement coverage

Follow-up WRO freshness work is tracked in #163.

## Test plan
- [x] `cargo test --lib runtime::operators::window::tests`
- [x] `cargo test --lib api::compiler::tests`
- [x] `cargo test --lib api::logical_graph::tests`

Made with [Cursor](https://cursor.com)