### PR TITLE
Persist window work as durable triggers

### DIFF
--- a/kubevolga/internal/controller/kube_pipeline_spec.schema.json
+++ b/kubevolga/internal/controller/kube_pipeline_spec.schema.json
@@ -98,7 +98,7 @@
       ]
     },
     "EventTimeSpec": {
-      "description": "Pipeline-wide event-time defaults (SQL / streaming).\n\nWatermark knobs are shared; window `allowed_lateness_ms` is retention-only\n(prune after advance). Streaming late ingest is `ts ≤ processed_pos`.",
+      "description": "Pipeline-wide event-time defaults (SQL / streaming).\n\nWatermark knobs are shared; window `allowed_lateness_ms` is retention-only\n(prune after advance). Streaming late ingest is `ts ≤ task watermark`.",
       "type": "object",
       "properties": {
         "watermark": {

--- a/src/api/spec/event_time.rs
+++ b/src/api/spec/event_time.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// Pipeline-wide event-time defaults (SQL / streaming).
 ///
 /// Watermark knobs are shared; window `allowed_lateness_ms` is retention-only
-/// (prune after advance). Streaming late ingest is `ts ≤ processed_pos`.
+/// (prune after advance). Streaming late ingest is `ts ≤ task watermark`.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct EventTimeSpec {
     #[serde(default)]

--- a/src/runtime/operators/window/README.md
+++ b/src/runtime/operators/window/README.md
@@ -32,14 +32,12 @@ half-open logical ranges:
 
 `KeyState` is the WO metadata for one partition:
 
-- `max_seen`: greatest ingested cursor.
-- `processed_pos`: frontier already reflected in streaming results and saved
-  sliding accumulators.
-- `accumulators`: saved state for retractable windows.
-- `first_ingested`: cold-start lower bound.
 - `next_seq`: dense per-key sequence allocator.
-- `retention_floor`: data before this cursor is outside the configured
-  supported horizon.
+- optional evaluation state containing the last fired trigger and saved
+  retractable accumulators. State-only WO does not maintain evaluation state.
+
+The operator separately tracks the last fully processed watermark. It is the
+late-data boundary and is included in the operator checkpoint.
 
 ## Configuration
 
@@ -63,31 +61,32 @@ and `RANGE` frames.
 `WindowOperatorState::insert_batch` performs one partition update:
 
 1. Load `KeyState`.
-2. Drop rows whose generated cursor is at or behind `processed_pos`.
+2. Drop rows whose timestamp is at or behind the task watermark.
 3. Assign the internal `__seq_no` column to accepted rows.
-4. Update `max_seen`, `first_ingested`, and `next_seq`.
+4. Update `next_seq`.
 5. Plan and load every tile bucket touched by the accepted rows.
 6. Update each configured window's accumulator state in those tiles.
-7. Atomically commit raw rows, updated tiles, and metadata through
-   `WindowOperatorStore::commit_events`.
+7. Atomically commit raw rows, updated tiles, metadata, and durable row
+   triggers through `WindowOperatorStore::commit_events`.
 
 The input batch must not contain `__seq_no`; WO owns that column. Late rows are
-dropped relative to the processed cursor, not merely relative to `max_seen`.
+dropped relative to the task watermark, including rows for previously unseen
+keys.
 
 ## WO advance and streaming evaluation
 
-`eval::advance_key` advances one partition to a requested cursor, bounded by
-`max_seen`:
+Emitting WO pages durable triggers through the requested watermark:
 
-1. Load metadata and skip work if the requested frontier is already processed.
-2. Load newly eligible raw rows and derive the exact emit cursors.
+1. Load a backend-sized page of due triggers grouped by partition.
+2. Use trigger cursors as exact emit points.
 3. Build one `EvalPlan` per emitted result and window expression.
-4. Flatten all plan coverage, merge overlapping raw/tile runs, and load the
-   historical data once.
+4. Merge emit-row and historical coverage, then load raw rows and tiles once.
 5. Evaluate each window by sliding or rebuilding.
-6. Save the new accumulator state and `processed_pos`.
-7. Publish `retention_floor` when lateness is configured.
-8. Assemble output rows when `WindowOutputMode::Emit` is enabled.
+6. Save evaluation state through the final trigger.
+7. Advance and forward the watermark after every due page succeeds.
+
+State-only WO publishes raw rows and tiles on ingest but creates no row
+triggers or evaluation state.
 
 Retractable accumulators reuse their saved state. For each result they retract
 the planned leave band, add the new end row, and evaluate. Tile-state
@@ -135,8 +134,8 @@ store access.
 `WindowOperatorStore` is the sole-writer interface:
 
 - load partition metadata and exact raw/tile runs;
-- atomically commit ingest data and metadata;
-- publish metadata after advancement;
+- atomically commit ingest data, metadata, and triggers;
+- page due triggers and publish evaluation state after advancement;
 - flush, checkpoint, and restore a namespace.
 
 `WindowRequestStore` exposes one operation that returns raw rows and tiles from
@@ -154,8 +153,8 @@ partitioning, publication, fencing, caching, and cleanup. They must preserve:
 
 `InMemWindowStore` is the reference backend. It keeps partition state in memory,
 uses one read lock as the WRO snapshot boundary, and embeds complete namespace
-snapshots in checkpoint data. Its live state remains process-local and is not
-a cross-worker backend.
+snapshots, including durable triggers, in checkpoint data. Its live state
+remains process-local and is not a cross-worker backend.
 
 ## Checkpoint and restore
 
@@ -163,6 +162,7 @@ a cross-worker backend.
 namespace, then returns `WindowStateSnapshot` containing:
 
 - the namespace bytes;
+- the last fully processed watermark;
 - backend-specific `WindowBackendSnapshot`.
 
 The operator serializes the snapshot as `SerializedCheckpoint`. The master
@@ -191,7 +191,7 @@ giving evaluators one ordered view.
 ## Module map
 
 ```text
-operator.rs       WO runtime operator and advance policy
+operator.rs       WO runtime operator and watermark processing
 request.rs        WRO runtime operator
 state.rs          WO ingest state plus checkpoint/restore bridge
 spec.rs           shared window runtime settings
@@ -199,7 +199,7 @@ config.rs         DataFusion expression-to-window configuration
 model.rs          cursors, keys, metadata, runs, and tile models
 tile.rs           tile configuration, planning, projection, and updates
 eval/
-  advance.rs      WO multi-phase load planning and advancement
+  advance.rs      trigger-driven WO planning and advancement
   eval_plan.rs    per-result slide/rebuild plans
   coverage_plan.rs exact raw/tile geometry and run merging
   accumulate.rs   apply coverage to DataFusion accumulators
@@ -221,10 +221,10 @@ tests/            WO/WRO semantics, tiling, planning, and matrix coverage
 
 - WO is the only mutator for a partition.
 - Cursor identity and ordering include both timestamp and sequence number.
-- Rows at or behind `processed_pos` are not accepted by streaming ingest.
+- Rows at or behind the task watermark are not accepted by streaming ingest.
 - Raw rows remain sufficient to produce a correct result.
 - Tiles cover only complete aligned intervals selected by the plan.
-- Sliding accumulator state corresponds exactly to `processed_pos`.
+- Sliding accumulator state corresponds exactly to its saved trigger cursor.
 - WRO evaluates one coherent published snapshot and never depends on WO's
   private sliding accumulator.
 - Retention publication is metadata; physical deletion is backend work.

--- a/src/runtime/operators/window/eval/advance.rs
+++ b/src/runtime/operators/window/eval/advance.rs
@@ -9,67 +9,60 @@ use datafusion::scalar::ScalarValue;
 
 use crate::runtime::operators::window::config::WindowConfig;
 use crate::runtime::operators::window::frame_utils::{get_window_length_ms, require_range_frame};
-use crate::runtime::operators::window::model::{Cursor, RawRun, WindowId};
-use crate::runtime::operators::window::store::{PartitionKey, WindowData, WindowOperatorStore};
+use crate::runtime::operators::window::model::{
+    Cursor, KeyEvaluationState, RawRun, WindowId, WindowTriggerKind,
+};
+use crate::runtime::operators::window::store::{DueWindowWork, WindowData, WindowOperatorStore};
 use crate::runtime::operators::window::{window_supports_tile_slide, AccumulatorType};
 
 use super::coverage_plan::{merge_raw_runs, merge_tile_runs};
-use super::emit::{emit_ends, emit_input_rows};
+use super::emit::emit_input_rows;
 use super::eval_plan::{append_coverage_runs, plan_rebuilds, plan_slides};
 use super::output::assemble_window_batch;
 use super::rebuild::produce_rebuild;
 use super::slide::produce_slide;
 
-/// Advance one key to `advance_to` (typically `Cursor(wm, u64::MAX)`).
-///
-/// The WO is the sole mutator, so its data reads need no shared snapshot.
-pub async fn advance_key(
+/// Evaluate one page of durable row triggers for a key.
+pub async fn advance_due_work(
     store: &dyn WindowOperatorStore,
-    partition: &PartitionKey,
+    work: DueWindowWork,
     window_configs: &BTreeMap<WindowId, WindowConfig>,
-    advance_to: Cursor,
     emit: bool,
     ts_column_index: usize,
     output_schema: &SchemaRef,
     input_schema: &SchemaRef,
-    lateness_ms: Option<i64>,
-) -> Result<(RecordBatch, bool)> {
-    let mut max_wl = 0i64;
+) -> Result<RecordBatch> {
     for cfg in window_configs.values() {
         require_range_frame(cfg.window_expr.get_window_frame());
-        max_wl = max_wl.max(get_window_length_ms(cfg.window_expr.get_window_frame()));
     }
 
-    let mut key_state = store.load_meta(partition).await?;
-
-    let Some(max_seen) = key_state.max_seen else {
-        return Ok((RecordBatch::new_empty(output_schema.clone()), false));
+    let DueWindowWork {
+        partition,
+        mut key_state,
+        triggers,
+    } = work;
+    let prev = key_state
+        .evaluation
+        .as_ref()
+        .map(|evaluation| evaluation.through);
+    let mut ends = triggers
+        .into_iter()
+        .filter(|trigger| matches!(trigger.kind, WindowTriggerKind::RowEmit))
+        .map(|trigger| trigger.fire_at)
+        .filter(|cursor| prev.map_or(true, |prev| *cursor > prev))
+        .collect::<Vec<_>>();
+    ends.sort_unstable();
+    ends.dedup();
+    let Some(first) = ends.first().copied() else {
+        return Ok(RecordBatch::new_empty(output_schema.clone()));
     };
-
-    let effective = advance_to.min(Cursor::new(max_seen.ts, u64::MAX));
-    let still_pending = max_seen > effective;
-
-    if let Some(p) = key_state.processed_pos {
-        if effective <= p {
-            return Ok((RecordBatch::new_empty(output_schema.clone()), still_pending));
-        }
-    }
-
-    let prev = key_state.processed_pos;
-    let first_ingested = key_state.first_ingested;
-    let update_from = prev
-        .map(Cursor::next)
-        .or(first_ingested)
-        .unwrap_or(Cursor::new(effective.ts, 0));
-    let update_run = RawRun {
-        from: update_from,
-        to: Cursor::after_timestamp(effective.ts),
-    };
-    let mut raw_batches = store.load_raw(partition, &[update_run]).await?;
-    let ends = emit_ends(&raw_batches, ts_column_index, prev, effective);
+    let last = *ends.last().expect("non-empty trigger ends");
 
     let mut plans = BTreeMap::new();
-    let mut historical_raw_runs = Vec::new();
+    let mut raw_runs = vec![RawRun {
+        from: prev.map(Cursor::next).unwrap_or(first),
+        to: Cursor::after_timestamp(last.ts),
+    }];
     let mut tile_runs = Vec::new();
     for (window_id, cfg) in window_configs {
         let wl = get_window_length_ms(cfg.window_expr.get_window_frame());
@@ -79,29 +72,32 @@ pub async fn advance_key(
                 .as_ref()
                 .filter(|_| window_supports_tile_slide(&cfg.window_expr));
             let plans = plan_slides(&ends, prev, wl, tile_cfg);
-            append_coverage_runs(&plans, &mut historical_raw_runs, &mut tile_runs);
+            append_coverage_runs(&plans, &mut raw_runs, &mut tile_runs);
             plans
         } else {
-            let floor = window_start_floor(prev, first_ingested, wl);
-            let plans = plan_rebuilds(&ends, wl, cfg.tiling.as_ref(), floor);
-            append_coverage_runs(&plans, &mut historical_raw_runs, &mut tile_runs);
+            let plans = plan_rebuilds(&ends, wl, cfg.tiling.as_ref());
+            append_coverage_runs(&plans, &mut raw_runs, &mut tile_runs);
             plans
         };
         plans.insert(*window_id, plans_for_window);
     }
 
-    let historical_raw_runs = merge_raw_runs(historical_raw_runs);
+    let raw_runs = merge_raw_runs(raw_runs);
     let tile_runs = merge_tile_runs(tile_runs);
-    let (historical_raw, tiles) = tokio::try_join!(
-        store.load_raw(partition, &historical_raw_runs),
-        store.load_tiles(partition, &tile_runs),
+    let (raw_batches, tiles) = tokio::try_join!(
+        store.load_raw(&partition, &raw_runs),
+        store.load_tiles(&partition, &tile_runs),
     )?;
-    raw_batches.extend(historical_raw);
     let batch = WindowData::new(raw_batches, tiles);
 
     let mut values_by_window: Vec<Vec<ScalarValue>> = Vec::new();
+    let mut accumulators = key_state
+        .evaluation
+        .take()
+        .map(|evaluation| evaluation.accumulators)
+        .unwrap_or_default();
     for (window_id, cfg) in window_configs {
-        let acc = key_state.accumulators.get(window_id).cloned();
+        let acc = accumulators.get(window_id).cloned();
         let view = batch.for_window(*window_id, ts_column_index, &cfg.window_expr);
         let plans = plans.get(window_id).expect("window plan");
         let (values, new_acc) = if cfg.accumulator_type == AccumulatorType::RetractableAccumulator {
@@ -111,44 +107,28 @@ pub async fn advance_key(
         };
 
         if let Some(acc) = new_acc {
-            key_state.accumulators.insert(*window_id, acc);
+            accumulators.insert(*window_id, acc);
         } else {
-            key_state.accumulators.remove(window_id);
+            accumulators.remove(window_id);
         }
         values_by_window.push(values);
     }
 
-    // Shared frontier: last emit cursor, else watermark (even when no rows).
-    key_state.processed_pos = ends.last().copied().or(Some(effective));
-    if let (Some(lateness), Some(processed)) = (lateness_ms, key_state.processed_pos) {
-        key_state.retention_floor = Some(Cursor::new(
-            processed
-                .ts
-                .saturating_sub(max_wl)
-                .saturating_sub(lateness.max(0)),
-            0,
-        ));
-    }
-    store.store_meta(partition, &key_state).await?;
+    key_state.evaluation = Some(KeyEvaluationState {
+        through: last,
+        accumulators,
+    });
+    store.commit_advance(&partition, &key_state).await?;
 
     if !emit {
-        return Ok((RecordBatch::new_empty(output_schema.clone()), still_pending));
+        return Ok(RecordBatch::new_empty(output_schema.clone()));
     }
 
     if ends.is_empty() || values_by_window.iter().all(|v| v.is_empty()) {
-        return Ok((RecordBatch::new_empty(output_schema.clone()), still_pending));
+        return Ok(RecordBatch::new_empty(output_schema.clone()));
     }
 
     let emit_input = emit_input_rows(batch.raw_batches(), ts_column_index, &ends, input_schema)?;
     let out = assemble_window_batch(emit_input, values_by_window, output_schema, input_schema);
-    Ok((out, still_pending))
-}
-
-fn window_start_floor(
-    prev: Option<Cursor>,
-    first_ingested: Option<Cursor>,
-    window_length: i64,
-) -> Option<i64> {
-    prev.or(first_ingested)
-        .map(|cursor| cursor.ts.saturating_sub(window_length.max(0)))
+    Ok(out)
 }

--- a/src/runtime/operators/window/eval/advance.rs
+++ b/src/runtime/operators/window/eval/advance.rs
@@ -1,4 +1,4 @@
-//! Watermark advance: meta → exact raw/tile ranges → slide | rebuild → emit.
+//! Watermark advance: due triggers → exact raw/tile ranges → slide | rebuild → emit.
 
 use std::collections::BTreeMap;
 
@@ -8,7 +8,7 @@ use arrow::datatypes::SchemaRef;
 use datafusion::scalar::ScalarValue;
 
 use crate::runtime::operators::window::config::WindowConfig;
-use crate::runtime::operators::window::frame_utils::{get_window_length_ms, require_range_frame};
+use crate::runtime::operators::window::frame_utils::get_window_length_ms;
 use crate::runtime::operators::window::model::{
     Cursor, KeyEvaluationState, RawRun, WindowId, WindowTriggerKind,
 };
@@ -27,15 +27,10 @@ pub async fn advance_key(
     store: &dyn WindowOperatorStore,
     work: DueWindowWork,
     window_configs: &BTreeMap<WindowId, WindowConfig>,
-    emit: bool,
     ts_column_index: usize,
     output_schema: &SchemaRef,
     input_schema: &SchemaRef,
 ) -> Result<RecordBatch> {
-    for cfg in window_configs.values() {
-        require_range_frame(cfg.window_expr.get_window_frame());
-    }
-
     let DueWindowWork {
         partition,
         mut key_state,
@@ -45,12 +40,19 @@ pub async fn advance_key(
         .evaluation
         .as_ref()
         .map(|evaluation| evaluation.through);
-    let mut ends = triggers
-        .into_iter()
-        .filter(|trigger| matches!(trigger.kind, WindowTriggerKind::RowEmit))
-        .map(|trigger| trigger.fire_at)
-        .filter(|cursor| prev.map_or(true, |prev| *cursor > prev))
-        .collect::<Vec<_>>();
+    let mut ends = Vec::with_capacity(triggers.len());
+    for trigger in triggers {
+        match trigger.kind {
+            WindowTriggerKind::RowEmit => {
+                if prev.map_or(true, |prev| trigger.fire_at > prev) {
+                    ends.push(trigger.fire_at);
+                }
+            }
+            WindowTriggerKind::WindowEnd { window_id } => {
+                anyhow::bail!("window-end trigger is not supported for window {window_id}");
+            }
+        }
+    }
     ends.sort_unstable();
     ends.dedup();
     let Some(first) = ends.first().copied() else {
@@ -118,13 +120,9 @@ pub async fn advance_key(
         through: last,
         accumulators,
     });
-    store.commit_advance(&partition, &key_state).await?;
+    store.store_key_state(&partition, &key_state).await?;
 
-    if !emit {
-        return Ok(RecordBatch::new_empty(output_schema.clone()));
-    }
-
-    if ends.is_empty() || values_by_window.iter().all(|v| v.is_empty()) {
+    if values_by_window.iter().all(|v| v.is_empty()) {
         return Ok(RecordBatch::new_empty(output_schema.clone()));
     }
 

--- a/src/runtime/operators/window/eval/advance.rs
+++ b/src/runtime/operators/window/eval/advance.rs
@@ -23,7 +23,7 @@ use super::rebuild::produce_rebuild;
 use super::slide::produce_slide;
 
 /// Evaluate one page of durable row triggers for a key.
-pub async fn advance_due_work(
+pub async fn advance_key(
     store: &dyn WindowOperatorStore,
     work: DueWindowWork,
     window_configs: &BTreeMap<WindowId, WindowConfig>,

--- a/src/runtime/operators/window/eval/emit.rs
+++ b/src/runtime/operators/window/eval/emit.rs
@@ -8,21 +8,6 @@ use datafusion::scalar::ScalarValue;
 use crate::runtime::operators::window::model::Cursor;
 use crate::runtime::operators::window::store::data::flatten_ordered;
 
-/// Emit ends in `(prev, advance_to]` from loaded batches.
-pub(super) fn emit_ends(
-    batches: &[RecordBatch],
-    ts_column_index: usize,
-    prev: Option<Cursor>,
-    advance_to: Cursor,
-) -> Vec<Cursor> {
-    let prev = prev.unwrap_or(Cursor::new(i64::MIN, 0));
-    flatten_ordered(batches, ts_column_index)
-        .into_iter()
-        .map(|(c, _, _)| c)
-        .filter(|c| *c > prev && *c <= advance_to)
-        .collect()
-}
-
 /// Map emit ends → input row scalars. Missing cursor → nulls.
 pub(super) fn emit_input_rows(
     batches: &[RecordBatch],

--- a/src/runtime/operators/window/eval/eval_plan.rs
+++ b/src/runtime/operators/window/eval/eval_plan.rs
@@ -13,17 +13,14 @@ pub(crate) struct EvalPlan {
     pub coverage: Option<CoveragePlan>,
 }
 
-/// `start_floor`: lower bound on window start (WO cold/`first_ingested`); `None` = `end − wl`.
 pub(crate) fn plan_rebuilds(
     ends: &[Cursor],
     wl: i64,
     tile_cfg: Option<&TileConfig>,
-    start_floor: Option<i64>,
 ) -> Vec<EvalPlan> {
     ends.iter()
         .map(|&end| {
             let start = end.ts.saturating_sub(wl);
-            let start = start_floor.map_or(start, |floor| start.max(floor));
             let from = Cursor::new(start, 0);
             let to = Cursor::after_timestamp(end.ts);
             EvalPlan {

--- a/src/runtime/operators/window/eval/mod.rs
+++ b/src/runtime/operators/window/eval/mod.rs
@@ -15,6 +15,6 @@ mod rebuild;
 mod slide;
 mod wro;
 
-pub use advance::advance_due_work;
+pub use advance::advance_key;
 pub use output::assemble_window_batch;
 pub use wro::evaluate_points;

--- a/src/runtime/operators/window/eval/mod.rs
+++ b/src/runtime/operators/window/eval/mod.rs
@@ -15,6 +15,6 @@ mod rebuild;
 mod slide;
 mod wro;
 
-pub use advance::advance_key;
+pub use advance::advance_due_work;
 pub use output::assemble_window_batch;
 pub use wro::evaluate_points;

--- a/src/runtime/operators/window/eval/wro.rs
+++ b/src/runtime/operators/window/eval/wro.rs
@@ -39,7 +39,7 @@ pub async fn evaluate_points(
             .iter()
             .map(|&ts| Cursor::new(ts, u64::MAX))
             .collect();
-        let window_plans = plan_rebuilds(&ends, wl, cfg.tiling.as_ref(), None);
+        let window_plans = plan_rebuilds(&ends, wl, cfg.tiling.as_ref());
         append_coverage_runs(&window_plans, &mut raw_runs, &mut tile_runs);
         plans.insert(*window_id, window_plans);
     }

--- a/src/runtime/operators/window/model.rs
+++ b/src/runtime/operators/window/model.rs
@@ -68,7 +68,7 @@ impl StateNamespace {
 }
 
 /// Collision-safe logical identity. Backends choose their own physical keys.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PartitionKey {
     pub namespace: Vec<u8>,
     pub business_key: Vec<u8>,
@@ -83,25 +83,36 @@ impl PartitionKey {
     }
 }
 
-/// State published by the WO for one partition.
 #[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct KeyState {
-    /// Greatest ingested cursor.
-    pub max_seen: Option<Cursor>,
-    /// Frontier reflected by WO accumulators and emitted output.
-    pub processed_pos: Option<Cursor>,
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KeyEvaluationState {
+    /// Last trigger reflected by the accumulators.
+    pub through: Cursor,
     #[serde_as(as = "BTreeMap<_, Vec<utils::ScalarValueAsBytes>>")]
     pub accumulators: BTreeMap<WindowId, AccumulatorState>,
-    /// Cold-start lower bound; not changed by retention.
-    #[serde(default)]
-    pub first_ingested: Option<Cursor>,
+}
+
+/// State published by the WO for one partition.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct KeyState {
     /// Per-key sequence allocator, independent of cursor ordering.
-    #[serde(default)]
     pub next_seq: u64,
-    /// Data before this cursor is outside the supported retention horizon.
-    #[serde(default)]
-    pub retention_floor: Option<Cursor>,
+    /// Watermark-driven evaluation state; absent for state-only operators.
+    pub evaluation: Option<KeyEvaluationState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum WindowTriggerKind {
+    RowEmit,
+    WindowEnd { window_id: WindowId },
+}
+
+/// Durable event-time work ordered by firing cursor.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct WindowTrigger {
+    pub fire_at: Cursor,
+    pub partition: PartitionKey,
+    pub kind: WindowTriggerKind,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -133,9 +133,7 @@ impl WindowOperator {
     }
 
     async fn process_due(&self, through: Cursor) -> RecordBatch {
-        let Some(state) = self.state.as_ref() else {
-            return RecordBatch::new_empty(self.output_schema.clone());
-        };
+        let state = self.state_ref();
         let after = self
             .watermark_frontier
             .map(|timestamp| Cursor::new(timestamp, u64::MAX));
@@ -153,13 +151,13 @@ impl WindowOperator {
                     state.store(),
                     work,
                     self.window_configs.as_ref(),
-                    true,
                     self.ts_column_index,
                     &self.output_schema,
                     &self.input_schema,
                 )
             });
             batches.extend(
+                // TODO add concurrency limit
                 future::try_join_all(futures)
                     .await
                     .expect("advance due window triggers"),

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -15,7 +15,7 @@ use crate::runtime::operators::operator::{
     MessageStream, OperatorBase, OperatorConfig, OperatorPollResult, OperatorTrait, OperatorType,
 };
 use crate::runtime::operators::window::config::{BuiltWindows, WindowConfig};
-use crate::runtime::operators::window::eval::advance_due_work;
+use crate::runtime::operators::window::eval::advance_key;
 use crate::runtime::operators::window::frame_utils::require_range_frame;
 use crate::runtime::operators::window::model::{Cursor, WindowId};
 use crate::runtime::operators::window::spec::WindowSpec;
@@ -148,7 +148,7 @@ impl WindowOperator {
                 .await
                 .expect("load due window triggers");
             let futures = page.work.into_iter().map(|work| {
-                advance_due_work(
+                advance_key(
                     state.store(),
                     work,
                     self.window_configs.as_ref(),

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
 
@@ -9,14 +9,13 @@ use async_trait::async_trait;
 use futures::future;
 
 use crate::common::message::Message;
-use crate::common::Key;
 use crate::common::MAX_WATERMARK_VALUE;
 use crate::runtime::checkpoint::{SerializedCheckpoint, SerializedRestore};
 use crate::runtime::operators::operator::{
     MessageStream, OperatorBase, OperatorConfig, OperatorPollResult, OperatorTrait, OperatorType,
 };
 use crate::runtime::operators::window::config::{BuiltWindows, WindowConfig};
-use crate::runtime::operators::window::eval::advance_key;
+use crate::runtime::operators::window::eval::advance_due_work;
 use crate::runtime::operators::window::frame_utils::require_range_frame;
 use crate::runtime::operators::window::model::{Cursor, WindowId};
 use crate::runtime::operators::window::spec::WindowSpec;
@@ -65,12 +64,11 @@ pub struct WindowOperator {
     base: OperatorBase,
     window_configs: Arc<BTreeMap<WindowId, WindowConfig>>,
     state: Option<Arc<WindowOperatorState>>,
-    buffered_keys: HashSet<Key>,
     output_mode: WindowOutputMode,
+    watermark_frontier: Option<i64>,
     output_schema: SchemaRef,
     input_schema: SchemaRef,
     ts_column_index: usize,
-    lateness: Option<i64>,
 }
 
 impl fmt::Debug for WindowOperator {
@@ -105,12 +103,11 @@ impl WindowOperator {
             base: OperatorBase::new(config),
             window_configs: windows,
             state: None,
-            buffered_keys: HashSet::new(),
             output_mode: window_operator_config.output_mode,
+            watermark_frontier: None,
             output_schema: built.output_schema,
             input_schema: built.input_schema,
             ts_column_index: built.ts_column_index,
-            lateness: window_operator_config.spec.lateness,
         }
     }
 
@@ -135,54 +132,46 @@ impl WindowOperator {
             .expect("WindowOperator must be opened first")
     }
 
-    async fn process_key(&self, key: &Key, advance_to: Cursor) -> (RecordBatch, bool) {
-        let emit = self.output_mode == WindowOutputMode::Emit;
-        let partition = self.state_ref().partition(key);
-        let (batch, pending) = advance_key(
-            self.state_ref().store(),
-            &partition,
-            self.window_configs.as_ref(),
-            advance_to,
-            emit,
-            self.ts_column_index,
-            &self.output_schema,
-            &self.input_schema,
-            self.lateness,
-        )
-        .await
-        .expect("advance_key");
-        (batch, pending)
-    }
-
-    async fn process_buffered(
-        &self,
-        keys: Vec<Key>,
-        advance_to: Cursor,
-    ) -> (RecordBatch, HashSet<Key>) {
-        if keys.is_empty() {
-            return (
-                RecordBatch::new_empty(self.output_schema.clone()),
-                HashSet::new(),
+    async fn process_due(&self, through: Cursor) -> RecordBatch {
+        let Some(state) = self.state.as_ref() else {
+            return RecordBatch::new_empty(self.output_schema.clone());
+        };
+        let after = self
+            .watermark_frontier
+            .map(|timestamp| Cursor::new(timestamp, u64::MAX));
+        let mut continuation = None;
+        let mut batches = Vec::new();
+        loop {
+            let page = state
+                .store()
+                .load_due_page(state.namespace(), after, through, continuation)
+                .await
+                .expect("load due window triggers");
+            let futures = page.work.into_iter().map(|work| {
+                advance_due_work(
+                    state.store(),
+                    work,
+                    self.window_configs.as_ref(),
+                    true,
+                    self.ts_column_index,
+                    &self.output_schema,
+                    &self.input_schema,
+                )
+            });
+            batches.extend(
+                future::try_join_all(futures)
+                    .await
+                    .expect("advance due window triggers"),
             );
+            let Some(next) = page.continuation else {
+                break;
+            };
+            continuation = Some(next);
         }
-
-        let futures: Vec<_> = keys
-            .iter()
-            .map(|k| async move { (k.clone(), self.process_key(k, advance_to).await) })
-            .collect();
-        let results = future::join_all(futures).await;
-
-        let mut batches = Vec::with_capacity(results.len());
-        let mut pending_keys = HashSet::new();
-        for (k, (batch, pending)) in results {
-            batches.push(batch);
-            if pending {
-                pending_keys.insert(k);
-            }
+        if batches.is_empty() {
+            return RecordBatch::new_empty(self.output_schema.clone());
         }
-
-        let out = arrow::compute::concat_batches(&self.output_schema, &batches).expect("concat");
-        (out, pending_keys)
+        arrow::compute::concat_batches(&self.output_schema, &batches).expect("concat")
     }
 }
 
@@ -233,15 +222,18 @@ impl OperatorTrait for WindowOperator {
     }
 
     async fn checkpoint(&mut self, _checkpoint_id: u64) -> Result<SerializedCheckpoint> {
-        // TODO: Drain buffered keys to a defined checkpoint frontier before flushing.
-        let snapshot = self.state_ref().checkpoint().await?;
+        let snapshot = self
+            .state_ref()
+            .checkpoint(self.watermark_frontier)
+            .await?;
         Ok(SerializedCheckpoint::new(bincode::serialize(&snapshot)?))
     }
 
     async fn restore(&mut self, restore: SerializedRestore) -> Result<()> {
         let bytes = restore.into_bytes();
         let snapshot: WindowStateSnapshot = bincode::deserialize(&bytes)?;
-        self.state_ref().restore(snapshot).await
+        self.watermark_frontier = self.state_ref().restore(snapshot).await?;
+        Ok(())
     }
 
     async fn poll_next(&mut self) -> OperatorPollResult {
@@ -254,14 +246,16 @@ impl OperatorTrait for WindowOperator {
                 Message::Keyed(keyed_message) => {
                     let key = keyed_message.key();
                     let input_rows = keyed_message.base.record_batch.num_rows();
-                    let (dropped, max_seen) = self
+                    let dropped = self
                         .state_ref()
-                        .insert_batch(key, keyed_message.base.record_batch.clone())
+                        .insert_batch(
+                            key,
+                            keyed_message.base.record_batch.clone(),
+                            self.watermark_frontier,
+                            self.output_mode == WindowOutputMode::Emit,
+                        )
                         .await;
-                    if dropped < input_rows {
-                        debug_assert!(max_seen.is_some());
-                        self.buffered_keys.insert(key.clone());
-                    }
+                    debug_assert!(dropped <= input_rows);
                     OperatorPollResult::Continue
                 }
                 Message::Watermark(watermark) => {
@@ -272,12 +266,18 @@ impl OperatorTrait for WindowOperator {
                     };
                     let advance_to = Cursor::new(wm_ts, u64::MAX);
 
-                    let keys: Vec<Key> = self.buffered_keys.iter().cloned().collect();
-                    let (result, pending_keys) = self.process_buffered(keys, advance_to).await;
-                    if watermark.watermark_value == MAX_WATERMARK_VALUE {
-                        self.buffered_keys.clear();
+                    let advances_frontier = self
+                        .watermark_frontier
+                        .map_or(true, |frontier| wm_ts > frontier);
+                    let result = if advances_frontier
+                        && self.output_mode == WindowOutputMode::Emit
+                    {
+                        self.process_due(advance_to).await
                     } else {
-                        self.buffered_keys = pending_keys;
+                        RecordBatch::new_empty(self.output_schema.clone())
+                    };
+                    if advances_frontier {
+                        self.watermark_frontier = Some(wm_ts);
                     }
 
                     self.base

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
-use futures::future;
+use futures::{future, TryStreamExt};
 
 use crate::common::message::Message;
 use crate::common::MAX_WATERMARK_VALUE;
@@ -139,15 +139,16 @@ impl WindowOperator {
         let after = self
             .watermark_frontier
             .map(|timestamp| Cursor::new(timestamp, u64::MAX));
-        let mut continuation = None;
+        let mut pages = state
+            .store()
+            .stream_due(state.namespace(), after, through);
         let mut batches = Vec::new();
-        loop {
-            let page = state
-                .store()
-                .load_due_page(state.namespace(), after, through, continuation)
-                .await
-                .expect("load due window triggers");
-            let futures = page.work.into_iter().map(|work| {
+        while let Some(work) = pages
+            .try_next()
+            .await
+            .expect("stream due window triggers")
+        {
+            let futures = work.into_iter().map(|work| {
                 advance_key(
                     state.store(),
                     work,
@@ -163,10 +164,6 @@ impl WindowOperator {
                     .await
                     .expect("advance due window triggers"),
             );
-            let Some(next) = page.continuation else {
-                break;
-            };
-            continuation = Some(next);
         }
         if batches.is_empty() {
             return RecordBatch::new_empty(self.output_schema.clone());

--- a/src/runtime/operators/window/spec.rs
+++ b/src/runtime/operators/window/spec.rs
@@ -5,8 +5,8 @@ use crate::runtime::operators::window::tile::TileConfig;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct WindowSpec {
-    /// State retention after advance (`processed − max_wl − lateness`).
-    /// Streaming late data is at or behind `processed_pos`.
+    /// State retention after advance (`watermark − max_wl − lateness`).
+    /// Streaming late data is at or behind the task watermark.
     pub lateness: Option<i64>,
     /// Default tiling for all windows (overridable per-window via `tiling_configs`).
     pub tiling: Option<TileConfig>,

--- a/src/runtime/operators/window/state.rs
+++ b/src/runtime/operators/window/state.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::Key;
 use crate::runtime::operators::window::config::WindowConfig;
-use crate::runtime::operators::window::model::{Cursor, WindowId};
+use crate::runtime::operators::window::model::{WindowId, WindowTrigger, WindowTriggerKind};
 use crate::runtime::operators::window::store::data::cursors_from_batch;
 use crate::runtime::operators::window::store::{
     PartitionKey, StateNamespace, WindowBackendSnapshot, WindowOperatorStore,
@@ -27,6 +27,7 @@ pub struct WindowOperatorState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WindowStateSnapshot {
     pub namespace: Vec<u8>,
+    pub watermark_frontier: Option<i64>,
     pub backend: WindowBackendSnapshot,
 }
 
@@ -49,63 +50,61 @@ impl WindowOperatorState {
         self.store.as_ref()
     }
 
+    pub fn namespace(&self) -> &StateNamespace {
+        &self.namespace
+    }
+
     pub fn partition(&self, key: &Key) -> PartitionKey {
         PartitionKey::new(&self.namespace, key)
     }
 
-    pub async fn checkpoint(&self) -> anyhow::Result<WindowStateSnapshot> {
+    pub async fn checkpoint(
+        &self,
+        watermark_frontier: Option<i64>,
+    ) -> anyhow::Result<WindowStateSnapshot> {
         Ok(WindowStateSnapshot {
             namespace: self.namespace.bytes.clone(),
+            watermark_frontier,
             backend: self.store.checkpoint(&self.namespace).await?,
         })
     }
 
-    pub async fn restore(&self, restore: WindowStateSnapshot) -> anyhow::Result<()> {
+    pub async fn restore(&self, restore: WindowStateSnapshot) -> anyhow::Result<Option<i64>> {
         anyhow::ensure!(
             restore.namespace == self.namespace.bytes,
             "window checkpoint namespace does not match runtime namespace",
         );
-        self.store.restore(&self.namespace, &restore.backend).await
+        self.store.restore(&self.namespace, &restore.backend).await?;
+        Ok(restore.watermark_frontier)
     }
 
-    /// Insert rows; returns `(dropped_count, max_seen after insert)`.
-    pub async fn insert_batch(&self, key: &Key, batch: RecordBatch) -> (usize, Option<Cursor>) {
+    pub async fn insert_batch(
+        &self,
+        key: &Key,
+        batch: RecordBatch,
+        watermark_frontier: Option<i64>,
+        schedule_row_triggers: bool,
+    ) -> usize {
         if batch.num_rows() == 0 {
-            return (0, None);
+            return 0;
         }
         let partition = self.partition(key);
 
         let mut key_state = self.store.load_meta(&partition).await.expect("key state");
-        // Drop before seq assign so `next_seq` stays a dense allocator.
         let (accepted, dropped) = drop_late_entries(
             &batch,
             self.ts_column_index,
-            key_state.processed_pos,
-            key_state.next_seq,
+            watermark_frontier,
         );
         if accepted.num_rows() == 0 {
-            return (dropped, key_state.max_seen);
+            return dropped;
         }
 
         let start_seq = key_state.next_seq;
         let with_seq = append_seq_no_column(&accepted, start_seq);
-        // Dedicated allocator (not max_seen.seq — that is ts-first cursor order).
         key_state.next_seq = start_seq
             .checked_add(accepted.num_rows() as u64)
             .expect("per-key sequence exhausted");
-
-        if let Some((batch_min, batch_max)) =
-            cursor_range_from_batch(&with_seq, self.ts_column_index)
-        {
-            key_state.max_seen = Some(match key_state.max_seen {
-                Some(prev) => prev.max(batch_max),
-                None => batch_max,
-            });
-            key_state.first_ingested = Some(match key_state.first_ingested {
-                Some(prev) => prev.min(batch_min),
-                None => batch_min,
-            });
-        }
 
         // Load and update every tile touched by this batch.
         let mut tile_runs = Vec::new();
@@ -142,6 +141,20 @@ impl WindowOperatorState {
             );
         }
 
+        let triggers = if schedule_row_triggers {
+            cursors_from_batch(&with_seq, self.ts_column_index)
+                .expect("stored batch cursor columns")
+                .into_iter()
+                .map(|fire_at| WindowTrigger {
+                    fire_at,
+                    partition: partition.clone(),
+                    kind: WindowTriggerKind::RowEmit,
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+
         self.store
             .commit_events(
                 &partition,
@@ -149,10 +162,11 @@ impl WindowOperatorState {
                 &with_seq,
                 &updated_tiles,
                 &key_state,
+                &triggers,
             )
             .await
             .expect("atomic ingest write");
-        (dropped, key_state.max_seen)
+        dropped
     }
 }
 
@@ -180,23 +194,11 @@ fn append_seq_no_column(batch: &RecordBatch, start_seq: u64) -> RecordBatch {
     RecordBatch::try_new(schema, columns).expect("append seq")
 }
 
-/// Min and max cursors in the batch (`None` if empty).
-fn cursor_range_from_batch(
-    batch: &RecordBatch,
-    ts_column_index: usize,
-) -> Option<(Cursor, Cursor)> {
-    let cursors = cursors_from_batch(batch, ts_column_index).ok()?;
-    let min = cursors.iter().copied().min()?;
-    let max = cursors.iter().copied().max()?;
-    Some((min, max))
-}
-
-/// Drop rows at or behind the processed cursor.
+/// Drop rows at or behind the task watermark.
 fn drop_late_entries(
     batch: &RecordBatch,
     ts_column_index: usize,
-    processed_pos: Option<Cursor>,
-    next_seq: u64,
+    watermark_frontier: Option<i64>,
 ) -> (RecordBatch, usize) {
     let ts = batch
         .column(ts_column_index)
@@ -205,11 +207,7 @@ fn drop_late_entries(
         .expect("ts");
     let mut keep = Vec::new();
     for i in 0..batch.num_rows() {
-        let seq_no = next_seq
-            .checked_add(keep.len() as u64)
-            .expect("per-key sequence exhausted");
-        let cursor = Cursor::new(ts.value(i), seq_no);
-        if processed_pos.map_or(true, |processed| cursor > processed) {
+        if watermark_frontier.map_or(true, |watermark| ts.value(i) > watermark) {
             keep.push(i as u32);
         }
     }

--- a/src/runtime/operators/window/state.rs
+++ b/src/runtime/operators/window/state.rs
@@ -90,7 +90,11 @@ impl WindowOperatorState {
         }
         let partition = self.partition(key);
 
-        let mut key_state = self.store.load_meta(&partition).await.expect("key state");
+        let mut key_state = self
+            .store
+            .load_key_state(&partition)
+            .await
+            .expect("key state");
         let (accepted, dropped) = drop_late_entries(
             &batch,
             self.ts_column_index,

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -1,6 +1,6 @@
 //! In-memory window store implementation and behavior tests.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::Cursor as IoCursor;
 use std::sync::Arc;
 
@@ -12,9 +12,12 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
-use crate::runtime::operators::window::model::{Cursor, RawRun, TileRun};
+use crate::runtime::operators::window::model::{Cursor, RawRun, TileRun, WindowTrigger};
 
-use super::{WindowBackendSnapshot, WindowOperatorStore, WindowRequestStore};
+use super::{
+    DueContinuation, DuePage, DueWindowWork, WindowBackendSnapshot, WindowOperatorStore,
+    WindowRequestStore,
+};
 use crate::runtime::operators::window::store::data::cursors_from_batch;
 use crate::runtime::operators::window::store::{
     KeyState, PartitionKey, StateNamespace, TileMap, WindowData,
@@ -31,6 +34,7 @@ struct PartitionState {
 struct InMemCheckpoint {
     namespace: Vec<u8>,
     partitions: HashMap<PartitionKey, PartitionCheckpoint>,
+    triggers: Vec<WindowTrigger>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -40,10 +44,16 @@ struct PartitionCheckpoint {
     tiles: TileMap,
 }
 
+#[derive(Debug, Default)]
+struct InMemState {
+    partitions: HashMap<PartitionKey, PartitionState>,
+    triggers: BTreeSet<WindowTrigger>,
+}
+
 /// Reference backend. One read lock is the WRO snapshot boundary.
 #[derive(Debug, Clone, Default)]
 pub struct InMemWindowStore {
-    partitions: Arc<RwLock<HashMap<PartitionKey, PartitionState>>>,
+    state: Arc<RwLock<InMemState>>,
 }
 
 impl InMemWindowStore {
@@ -97,8 +107,9 @@ impl InMemWindowStore {
 #[async_trait]
 impl WindowOperatorStore for InMemWindowStore {
     async fn load_meta(&self, partition: &PartitionKey) -> Result<KeyState> {
-        let partitions = self.partitions.read().await;
-        Ok(partitions
+        let state = self.state.read().await;
+        Ok(state
+            .partitions
             .get(partition)
             .map(|state| state.meta.clone())
             .unwrap_or_default())
@@ -109,16 +120,18 @@ impl WindowOperatorStore for InMemWindowStore {
         partition: &PartitionKey,
         runs: &[RawRun],
     ) -> Result<Vec<RecordBatch>> {
-        let partitions = self.partitions.read().await;
-        Ok(partitions
+        let state = self.state.read().await;
+        Ok(state
+            .partitions
             .get(partition)
             .map(|state| Self::select_raw(state, runs))
             .unwrap_or_default())
     }
 
     async fn load_tiles(&self, partition: &PartitionKey, runs: &[TileRun]) -> Result<TileMap> {
-        let partitions = self.partitions.read().await;
-        Ok(partitions
+        let state = self.state.read().await;
+        Ok(state
+            .partitions
             .get(partition)
             .map(|state| Self::select_tiles(state, runs))
             .unwrap_or_default())
@@ -131,10 +144,15 @@ impl WindowOperatorStore for InMemWindowStore {
         events: &RecordBatch,
         tiles: &TileMap,
         meta: &KeyState,
+        triggers: &[WindowTrigger],
     ) -> Result<()> {
         let cursors = cursors_from_batch(events, ts_column_index)?;
-        let mut partitions = self.partitions.write().await;
-        let state = partitions.entry(partition.clone()).or_default();
+        anyhow::ensure!(
+            triggers.iter().all(|trigger| &trigger.partition == partition),
+            "window trigger partition does not match committed partition"
+        );
+        let mut store = self.state.write().await;
+        let state = store.partitions.entry(partition.clone()).or_default();
         for (row, cursor) in cursors.into_iter().enumerate() {
             state.raw.insert(cursor, events.slice(row, 1));
         }
@@ -142,20 +160,85 @@ impl WindowOperatorStore for InMemWindowStore {
             state.tiles.insert(*key, value.clone());
         }
         state.meta = meta.clone();
+        store.triggers.extend(triggers.iter().cloned());
         Ok(())
     }
 
-    async fn store_meta(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()> {
-        let mut partitions = self.partitions.write().await;
-        let state = partitions.entry(partition.clone()).or_default();
+    async fn load_due_page(
+        &self,
+        namespace: &StateNamespace,
+        after: Option<Cursor>,
+        through: Cursor,
+        continuation: Option<DueContinuation>,
+    ) -> Result<DuePage> {
+        const PAGE_SIZE: usize = 256;
+
+        let resume_after = continuation
+            .map(|continuation| bincode::deserialize::<WindowTrigger>(&continuation.0))
+            .transpose()?;
+        let store = self.state.read().await;
+        let mut selected = store
+            .triggers
+            .iter()
+            .filter(|trigger| trigger.partition.namespace == namespace.bytes)
+            .filter(|trigger| after.map_or(true, |after| trigger.fire_at > after))
+            .filter(|trigger| trigger.fire_at <= through)
+            .filter(|trigger| {
+                resume_after
+                    .as_ref()
+                    .map_or(true, |resume_after| *trigger > resume_after)
+            })
+            .take(PAGE_SIZE + 1)
+            .cloned()
+            .collect::<Vec<_>>();
+        let has_more = selected.len() > PAGE_SIZE;
+        if has_more {
+            selected.pop();
+        }
+        let next = has_more
+            .then(|| selected.last())
+            .flatten()
+            .map(|trigger| bincode::serialize(trigger))
+            .transpose()?
+            .map(DueContinuation);
+
+        let mut grouped = BTreeMap::<PartitionKey, Vec<WindowTrigger>>::new();
+        for trigger in selected {
+            grouped
+                .entry(trigger.partition.clone())
+                .or_default()
+                .push(trigger);
+        }
+        let work = grouped
+            .into_iter()
+            .map(|(partition, triggers)| DueWindowWork {
+                key_state: store
+                    .partitions
+                    .get(&partition)
+                    .map(|state| state.meta.clone())
+                    .unwrap_or_default(),
+                partition,
+                triggers,
+            })
+            .collect();
+        Ok(DuePage {
+            work,
+            continuation: next,
+        })
+    }
+
+    async fn commit_advance(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()> {
+        let mut store = self.state.write().await;
+        let state = store.partitions.entry(partition.clone()).or_default();
         state.meta = meta.clone();
         Ok(())
     }
 
     async fn checkpoint(&self, namespace: &StateNamespace) -> Result<WindowBackendSnapshot> {
         self.flush().await?;
-        let partitions = self.partitions.read().await;
-        let snapshot = partitions
+        let store = self.state.read().await;
+        let snapshot = store
+            .partitions
             .iter()
             .filter(|(partition, _)| partition.namespace.as_slice() == namespace.bytes.as_slice())
             .map(|(partition, state)| {
@@ -177,6 +260,12 @@ impl WindowOperatorStore for InMemWindowStore {
         let checkpoint = InMemCheckpoint {
             namespace: namespace.bytes.clone(),
             partitions: snapshot,
+            triggers: store
+                .triggers
+                .iter()
+                .filter(|trigger| trigger.partition.namespace == namespace.bytes)
+                .cloned()
+                .collect(),
         };
         Ok(WindowBackendSnapshot::InMemory {
             snapshot: bincode::serialize(&checkpoint)?,
@@ -217,10 +306,15 @@ impl WindowOperatorStore for InMemWindowStore {
                 ))
             })
             .collect::<Result<HashMap<_, _>>>()?;
-        let mut partitions = self.partitions.write().await;
-        partitions
+        let mut store = self.state.write().await;
+        store
+            .partitions
             .retain(|partition, _| partition.namespace.as_slice() != namespace.bytes.as_slice());
-        partitions.extend(restored);
+        store.partitions.extend(restored);
+        store
+            .triggers
+            .retain(|trigger| trigger.partition.namespace.as_slice() != namespace.bytes.as_slice());
+        store.triggers.extend(checkpoint.triggers);
         Ok(())
     }
 }
@@ -233,8 +327,8 @@ impl WindowRequestStore for InMemWindowStore {
         raw_runs: &[RawRun],
         tile_runs: &[TileRun],
     ) -> Result<WindowData> {
-        let partitions = self.partitions.read().await;
-        let Some(state) = partitions.get(partition) else {
+        let store = self.state.read().await;
+        let Some(state) = store.partitions.get(partition) else {
             return Ok(WindowData::new(Vec::new(), TileMap::new()));
         };
         Ok(WindowData::new(
@@ -249,7 +343,9 @@ mod tests {
     use super::*;
 
     use crate::runtime::operators::window::aggs::test_utils;
-    use crate::runtime::operators::window::model::{TileRun, TimeGranularity, WindowTiles};
+    use crate::runtime::operators::window::model::{
+        KeyEvaluationState, TileRun, TimeGranularity, WindowTiles, WindowTriggerKind,
+    };
     use crate::runtime::operators::window::store::{data::RowIdx, StateVersion};
 
     fn partition() -> PartitionKey {
@@ -297,12 +393,7 @@ mod tests {
     }
 
     fn assert_meta(actual: &KeyState, expected: &KeyState) {
-        assert_eq!(actual.max_seen, expected.max_seen);
-        assert_eq!(actual.processed_pos, expected.processed_pos);
-        assert_eq!(actual.accumulators, expected.accumulators);
-        assert_eq!(actual.first_ingested, expected.first_ingested);
-        assert_eq!(actual.next_seq, expected.next_seq);
-        assert_eq!(actual.retention_floor, expected.retention_floor);
+        assert_eq!(actual, expected);
     }
 
     #[tokio::test]
@@ -338,7 +429,7 @@ mod tests {
             .is_empty());
 
         store
-            .store_meta(
+            .commit_advance(
                 &partition,
                 &KeyState {
                     next_seq: 1,
@@ -363,6 +454,7 @@ mod tests {
                 &events,
                 &TileMap::new(),
                 &KeyState::default(),
+                &[],
             )
             .await
             .unwrap();
@@ -404,6 +496,7 @@ mod tests {
                 &batch(&[]),
                 &stored_tiles,
                 &KeyState::default(),
+                &[],
             )
             .await
             .unwrap();
@@ -430,7 +523,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn store_meta_leaves_raw_and_tiles_unchanged() {
+    async fn commit_advance_leaves_raw_and_tiles_unchanged() {
         let store = InMemWindowStore::new();
         let partition = partition();
         let stored_tiles = tiles(&[(TimeGranularity::Seconds(1), 1_000, 7)]);
@@ -441,19 +534,22 @@ mod tests {
                 &batch(&[(1_000, 4)]),
                 &stored_tiles,
                 &KeyState::default(),
+                &[],
             )
             .await
             .unwrap();
         let updated_meta = KeyState {
-            max_seen: Some(Cursor::new(2_000, 5)),
-            processed_pos: Some(Cursor::new(1_000, 4)),
-            first_ingested: Some(Cursor::new(1_000, 4)),
             next_seq: 6,
-            retention_floor: Some(Cursor::new(500, 0)),
-            ..Default::default()
+            evaluation: Some(KeyEvaluationState {
+                through: Cursor::new(1_000, 4),
+                accumulators: BTreeMap::new(),
+            }),
         };
 
-        store.store_meta(&partition, &updated_meta).await.unwrap();
+        store
+            .commit_advance(&partition, &updated_meta)
+            .await
+            .unwrap();
 
         assert_meta(&store.load_meta(&partition).await.unwrap(), &updated_meta);
         assert_eq!(
@@ -488,7 +584,6 @@ mod tests {
         let store = InMemWindowStore::new();
         let partition = partition();
         let meta = KeyState {
-            max_seen: Some(Cursor::new(2_000, 2)),
             next_seq: 3,
             ..Default::default()
         };
@@ -501,6 +596,7 @@ mod tests {
                 &batch(&[(2_000, 2), (1_000, 1)]),
                 &stored_tiles,
                 &meta,
+                &[],
             )
             .await
             .unwrap();
@@ -548,6 +644,7 @@ mod tests {
                     (TimeGranularity::Seconds(1), 3_000, 7),
                 ]),
                 &KeyState::default(),
+                &[],
             )
             .await
             .unwrap();
@@ -595,20 +692,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn due_triggers_are_range_filtered_and_backend_paged() {
+        let store = InMemWindowStore::new();
+        let partition = partition();
+        let namespace = StateNamespace::new(&partition.namespace);
+        let triggers = (0..300)
+            .map(|seq_no| WindowTrigger {
+                fire_at: Cursor::new(seq_no as i64, seq_no),
+                partition: partition.clone(),
+                kind: WindowTriggerKind::RowEmit,
+            })
+            .collect::<Vec<_>>();
+        store
+            .commit_events(
+                &partition,
+                0,
+                &batch(&[]),
+                &TileMap::new(),
+                &KeyState::default(),
+                &triggers,
+            )
+            .await
+            .unwrap();
+
+        let first = store
+            .load_due_page(
+                &namespace,
+                Some(Cursor::new(9, u64::MAX)),
+                Cursor::new(299, u64::MAX),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.work[0].triggers.len(), 256);
+        let second = store
+            .load_due_page(
+                &namespace,
+                Some(Cursor::new(9, u64::MAX)),
+                Cursor::new(299, u64::MAX),
+                first.continuation,
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.work[0].triggers.len(), 34);
+        assert!(second.continuation.is_none());
+    }
+
+    #[tokio::test]
     async fn checkpoint_restores_complete_namespace_into_fresh_store() {
         let source = InMemWindowStore::new();
         let partition = partition();
         let namespace = StateNamespace::new(&partition.namespace);
-        let mut meta = KeyState {
-            max_seen: Some(Cursor::new(2_000, 2)),
-            processed_pos: Some(Cursor::new(1_000, 1)),
-            first_ingested: Some(Cursor::new(1_000, 1)),
+        let mut accumulators = BTreeMap::new();
+        accumulators.insert(
+            7,
+            vec![datafusion::scalar::ScalarValue::Float64(Some(3.0))],
+        );
+        let meta = KeyState {
             next_seq: 3,
-            retention_floor: Some(Cursor::new(500, 0)),
-            ..Default::default()
+            evaluation: Some(KeyEvaluationState {
+                through: Cursor::new(1_000, 1),
+                accumulators,
+            }),
         };
-        meta.accumulators
-            .insert(7, vec![datafusion::scalar::ScalarValue::Float64(Some(3.0))]);
+        let triggers = [
+            WindowTrigger {
+                fire_at: Cursor::new(1_000, 1),
+                partition: partition.clone(),
+                kind: WindowTriggerKind::RowEmit,
+            },
+            WindowTrigger {
+                fire_at: Cursor::new(2_000, 2),
+                partition: partition.clone(),
+                kind: WindowTriggerKind::RowEmit,
+            },
+        ];
         source
             .commit_events(
                 &partition,
@@ -616,6 +774,7 @@ mod tests {
                 &batch(&[(1_000, 1), (2_000, 2)]),
                 &tiles(&[(TimeGranularity::Seconds(1), 1_000, 7)]),
                 &meta,
+                &triggers,
             )
             .await
             .unwrap();
@@ -625,6 +784,17 @@ mod tests {
         restored.restore(&namespace, &checkpoint).await.unwrap();
 
         assert_meta(&restored.load_meta(&partition).await.unwrap(), &meta);
+        let due = restored
+            .load_due_page(
+                &namespace,
+                Some(Cursor::new(1_000, u64::MAX)),
+                Cursor::new(2_000, u64::MAX),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(due.work.len(), 1);
+        assert_eq!(due.work[0].triggers, vec![triggers[1].clone()]);
         assert_eq!(
             raw_cursors(
                 &restored
@@ -658,7 +828,7 @@ mod tests {
         let checkpoint_partition = partition();
         let checkpoint_namespace = StateNamespace::new(&checkpoint_partition.namespace);
         source
-            .store_meta(
+            .commit_advance(
                 &checkpoint_partition,
                 &KeyState {
                     next_seq: 11,
@@ -675,7 +845,7 @@ mod tests {
             business_key: b"other-key".to_vec(),
         };
         restored
-            .store_meta(
+            .commit_advance(
                 &other_partition,
                 &KeyState {
                     next_seq: 22,

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -15,8 +15,7 @@ use tokio::sync::RwLock;
 use crate::runtime::operators::window::model::{Cursor, RawRun, TileRun, WindowTrigger};
 
 use super::{
-    DueContinuation, DuePage, DueWindowWork, WindowBackendSnapshot, WindowOperatorStore,
-    WindowRequestStore,
+    DueWindowWork, DueWorkStream, WindowBackendSnapshot, WindowOperatorStore, WindowRequestStore,
 };
 use crate::runtime::operators::window::store::data::cursors_from_batch;
 use crate::runtime::operators::window::store::{
@@ -164,67 +163,64 @@ impl WindowOperatorStore for InMemWindowStore {
         Ok(())
     }
 
-    async fn load_due_page(
-        &self,
-        namespace: &StateNamespace,
+    fn stream_due<'a>(
+        &'a self,
+        namespace: &'a StateNamespace,
         after: Option<Cursor>,
         through: Cursor,
-        continuation: Option<DueContinuation>,
-    ) -> Result<DuePage> {
+    ) -> DueWorkStream<'a> {
         const PAGE_SIZE: usize = 256;
 
-        let resume_after = continuation
-            .map(|continuation| bincode::deserialize::<WindowTrigger>(&continuation.0))
-            .transpose()?;
-        let store = self.state.read().await;
-        let mut selected = store
-            .triggers
-            .iter()
-            .filter(|trigger| trigger.partition.namespace == namespace.bytes)
-            .filter(|trigger| after.map_or(true, |after| trigger.fire_at > after))
-            .filter(|trigger| trigger.fire_at <= through)
-            .filter(|trigger| {
-                resume_after
-                    .as_ref()
-                    .map_or(true, |resume_after| *trigger > resume_after)
-            })
-            .take(PAGE_SIZE + 1)
-            .cloned()
-            .collect::<Vec<_>>();
-        let has_more = selected.len() > PAGE_SIZE;
-        if has_more {
-            selected.pop();
-        }
-        let next = has_more
-            .then(|| selected.last())
-            .flatten()
-            .map(|trigger| bincode::serialize(trigger))
-            .transpose()?
-            .map(DueContinuation);
+        let store = self.clone();
+        let namespace = namespace.bytes.clone();
+        Box::pin(futures::stream::try_unfold(
+            (store, None::<WindowTrigger>),
+            move |(store, resume_after)| {
+                let namespace = namespace.clone();
+                async move {
+                    let state = store.state.read().await;
+                    let selected = state
+                        .triggers
+                        .iter()
+                        .filter(|trigger| trigger.partition.namespace == namespace)
+                        .filter(|trigger| after.map_or(true, |after| trigger.fire_at > after))
+                        .filter(|trigger| trigger.fire_at <= through)
+                        .filter(|trigger| {
+                            resume_after
+                                .as_ref()
+                                .map_or(true, |resume_after| *trigger > resume_after)
+                        })
+                        .take(PAGE_SIZE)
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    let Some(next) = selected.last().cloned() else {
+                        return Ok(None);
+                    };
 
-        let mut grouped = BTreeMap::<PartitionKey, Vec<WindowTrigger>>::new();
-        for trigger in selected {
-            grouped
-                .entry(trigger.partition.clone())
-                .or_default()
-                .push(trigger);
-        }
-        let work = grouped
-            .into_iter()
-            .map(|(partition, triggers)| DueWindowWork {
-                key_state: store
-                    .partitions
-                    .get(&partition)
-                    .map(|state| state.meta.clone())
-                    .unwrap_or_default(),
-                partition,
-                triggers,
-            })
-            .collect();
-        Ok(DuePage {
-            work,
-            continuation: next,
-        })
+                    let mut grouped = BTreeMap::<PartitionKey, Vec<WindowTrigger>>::new();
+                    for trigger in selected {
+                        grouped
+                            .entry(trigger.partition.clone())
+                            .or_default()
+                            .push(trigger);
+                    }
+                    let work = grouped
+                        .into_iter()
+                        .map(|(partition, triggers)| DueWindowWork {
+                            key_state: state
+                                .partitions
+                                .get(&partition)
+                                .map(|partition_state| partition_state.meta.clone())
+                                .unwrap_or_default(),
+                            partition,
+                            triggers,
+                        })
+                        .collect();
+                    drop(state);
+                    Ok(Some((work, (store, Some(next)))))
+                }
+            },
+        ))
     }
 
     async fn commit_advance(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()> {
@@ -340,6 +336,7 @@ impl WindowRequestStore for InMemWindowStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::TryStreamExt;
 
     use crate::runtime::operators::window::aggs::test_utils;
     use crate::runtime::operators::window::model::{
@@ -714,27 +711,16 @@ mod tests {
             .await
             .unwrap();
 
-        let first = store
-            .load_due_page(
-                &namespace,
-                Some(Cursor::new(9, u64::MAX)),
-                Cursor::new(299, u64::MAX),
-                None,
-            )
-            .await
-            .unwrap();
-        assert_eq!(first.work[0].triggers.len(), 256);
-        let second = store
-            .load_due_page(
-                &namespace,
-                Some(Cursor::new(9, u64::MAX)),
-                Cursor::new(299, u64::MAX),
-                first.continuation,
-            )
-            .await
-            .unwrap();
-        assert_eq!(second.work[0].triggers.len(), 34);
-        assert!(second.continuation.is_none());
+        let mut due = store.stream_due(
+            &namespace,
+            Some(Cursor::new(9, u64::MAX)),
+            Cursor::new(299, u64::MAX),
+        );
+        let first = due.try_next().await.unwrap().unwrap();
+        assert_eq!(first[0].triggers.len(), 256);
+        let second = due.try_next().await.unwrap().unwrap();
+        assert_eq!(second[0].triggers.len(), 34);
+        assert!(due.try_next().await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -783,17 +769,14 @@ mod tests {
         restored.restore(&namespace, &checkpoint).await.unwrap();
 
         assert_meta(&restored.load_meta(&partition).await.unwrap(), &meta);
-        let due = restored
-            .load_due_page(
-                &namespace,
-                Some(Cursor::new(1_000, u64::MAX)),
-                Cursor::new(2_000, u64::MAX),
-                None,
-            )
-            .await
-            .unwrap();
-        assert_eq!(due.work.len(), 1);
-        assert_eq!(due.work[0].triggers, vec![triggers[1].clone()]);
+        let mut due = restored.stream_due(
+            &namespace,
+            Some(Cursor::new(1_000, u64::MAX)),
+            Cursor::new(2_000, u64::MAX),
+        );
+        let work = due.try_next().await.unwrap().unwrap();
+        assert_eq!(work.len(), 1);
+        assert_eq!(work[0].triggers, vec![triggers[1].clone()]);
         assert_eq!(
             raw_cursors(
                 &restored

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -235,7 +235,6 @@ impl WindowOperatorStore for InMemWindowStore {
     }
 
     async fn checkpoint(&self, namespace: &StateNamespace) -> Result<WindowBackendSnapshot> {
-        self.flush().await?;
         let store = self.state.read().await;
         let snapshot = store
             .partitions

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -105,7 +105,7 @@ impl InMemWindowStore {
 
 #[async_trait]
 impl WindowOperatorStore for InMemWindowStore {
-    async fn load_meta(&self, partition: &PartitionKey) -> Result<KeyState> {
+    async fn load_key_state(&self, partition: &PartitionKey) -> Result<KeyState> {
         let state = self.state.read().await;
         Ok(state
             .partitions
@@ -223,7 +223,7 @@ impl WindowOperatorStore for InMemWindowStore {
         ))
     }
 
-    async fn commit_advance(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()> {
+    async fn store_key_state(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()> {
         let mut store = self.state.write().await;
         let state = store.partitions.entry(partition.clone()).or_default();
         state.meta = meta.clone();
@@ -404,7 +404,7 @@ mod tests {
         }];
 
         assert_meta(
-            &store.load_meta(&partition).await.unwrap(),
+            &store.load_key_state(&partition).await.unwrap(),
             &KeyState::default(),
         );
         assert!(store
@@ -425,7 +425,7 @@ mod tests {
             .is_empty());
 
         store
-            .commit_advance(
+            .store_key_state(
                 &partition,
                 &KeyState {
                     next_seq: 1,
@@ -519,7 +519,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn commit_advance_leaves_raw_and_tiles_unchanged() {
+    async fn store_key_state_leaves_raw_and_tiles_unchanged() {
         let store = InMemWindowStore::new();
         let partition = partition();
         let stored_tiles = tiles(&[(TimeGranularity::Seconds(1), 1_000, 7)]);
@@ -543,11 +543,14 @@ mod tests {
         };
 
         store
-            .commit_advance(&partition, &updated_meta)
+            .store_key_state(&partition, &updated_meta)
             .await
             .unwrap();
 
-        assert_meta(&store.load_meta(&partition).await.unwrap(), &updated_meta);
+        assert_meta(
+            &store.load_key_state(&partition).await.unwrap(),
+            &updated_meta,
+        );
         assert_eq!(
             raw_cursors(
                 &store
@@ -597,7 +600,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_meta(&store.load_meta(&partition).await.unwrap(), &meta);
+        assert_meta(&store.load_key_state(&partition).await.unwrap(), &meta);
         assert_eq!(
             raw_cursors(
                 &store
@@ -768,7 +771,7 @@ mod tests {
         let restored = InMemWindowStore::new();
         restored.restore(&namespace, &checkpoint).await.unwrap();
 
-        assert_meta(&restored.load_meta(&partition).await.unwrap(), &meta);
+        assert_meta(&restored.load_key_state(&partition).await.unwrap(), &meta);
         let mut due = restored.stream_due(
             &namespace,
             Some(Cursor::new(1_000, u64::MAX)),
@@ -810,7 +813,7 @@ mod tests {
         let checkpoint_partition = partition();
         let checkpoint_namespace = StateNamespace::new(&checkpoint_partition.namespace);
         source
-            .commit_advance(
+            .store_key_state(
                 &checkpoint_partition,
                 &KeyState {
                     next_seq: 11,
@@ -827,7 +830,7 @@ mod tests {
             business_key: b"other-key".to_vec(),
         };
         restored
-            .commit_advance(
+            .store_key_state(
                 &other_partition,
                 &KeyState {
                     next_seq: 22,
@@ -843,14 +846,18 @@ mod tests {
 
         assert_eq!(
             restored
-                .load_meta(&checkpoint_partition)
+                .load_key_state(&checkpoint_partition)
                 .await
                 .unwrap()
                 .next_seq,
             11
         );
         assert_eq!(
-            restored.load_meta(&other_partition).await.unwrap().next_seq,
+            restored
+                .load_key_state(&other_partition)
+                .await
+                .unwrap()
+                .next_seq,
             22
         );
     }

--- a/src/runtime/operators/window/store/backend/mod.rs
+++ b/src/runtime/operators/window/store/backend/mod.rs
@@ -84,9 +84,7 @@ pub trait WindowOperatorStore: Send + Sync + std::fmt::Debug {
         continuation: Option<DueContinuation>,
     ) -> Result<DuePage>;
     async fn commit_advance(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()>;
-    async fn flush(&self) -> Result<()> {
-        Ok(())
-    }
+    /// Complete all pending writes before capturing the returned snapshot.
     async fn checkpoint(&self, namespace: &StateNamespace) -> Result<WindowBackendSnapshot>;
     async fn restore(
         &self,

--- a/src/runtime/operators/window/store/backend/mod.rs
+++ b/src/runtime/operators/window/store/backend/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use arrow::array::RecordBatch;
 use async_trait::async_trait;
+use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 
 use crate::api::spec::state::{OperatorStateBackendConfig, RequestStoreConfig};
@@ -51,14 +52,7 @@ pub struct DueWindowWork {
     pub triggers: Vec<WindowTrigger>,
 }
 
-#[derive(Debug, Clone)]
-pub struct DueContinuation(pub Vec<u8>);
-
-#[derive(Debug, Clone)]
-pub struct DuePage {
-    pub work: Vec<DueWindowWork>,
-    pub continuation: Option<DueContinuation>,
-}
+pub type DueWorkStream<'a> = BoxStream<'a, Result<Vec<DueWindowWork>>>;
 
 /// Store operations used by the sole Window Operator for a partition.
 #[async_trait]
@@ -76,13 +70,12 @@ pub trait WindowOperatorStore: Send + Sync + std::fmt::Debug {
         meta: &KeyState,
         triggers: &[WindowTrigger],
     ) -> Result<()>;
-    async fn load_due_page(
-        &self,
-        namespace: &StateNamespace,
+    fn stream_due<'a>(
+        &'a self,
+        namespace: &'a StateNamespace,
         after: Option<Cursor>,
         through: Cursor,
-        continuation: Option<DueContinuation>,
-    ) -> Result<DuePage>;
+    ) -> DueWorkStream<'a>;
     async fn commit_advance(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()>;
     /// Complete all pending writes before capturing the returned snapshot.
     async fn checkpoint(&self, namespace: &StateNamespace) -> Result<WindowBackendSnapshot>;

--- a/src/runtime/operators/window/store/backend/mod.rs
+++ b/src/runtime/operators/window/store/backend/mod.rs
@@ -57,7 +57,7 @@ pub type DueWorkStream<'a> = BoxStream<'a, Result<Vec<DueWindowWork>>>;
 /// Store operations used by the sole Window Operator for a partition.
 #[async_trait]
 pub trait WindowOperatorStore: Send + Sync + std::fmt::Debug {
-    async fn load_meta(&self, partition: &PartitionKey) -> Result<KeyState>;
+    async fn load_key_state(&self, partition: &PartitionKey) -> Result<KeyState>;
     async fn load_raw(&self, partition: &PartitionKey, runs: &[RawRun])
         -> Result<Vec<RecordBatch>>;
     async fn load_tiles(&self, partition: &PartitionKey, runs: &[TileRun]) -> Result<TileMap>;
@@ -76,7 +76,7 @@ pub trait WindowOperatorStore: Send + Sync + std::fmt::Debug {
         after: Option<Cursor>,
         through: Cursor,
     ) -> DueWorkStream<'a>;
-    async fn commit_advance(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()>;
+    async fn store_key_state(&self, partition: &PartitionKey, state: &KeyState) -> Result<()>;
     /// Complete all pending writes before capturing the returned snapshot.
     async fn checkpoint(&self, namespace: &StateNamespace) -> Result<WindowBackendSnapshot>;
     async fn restore(

--- a/src/runtime/operators/window/store/backend/mod.rs
+++ b/src/runtime/operators/window/store/backend/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::spec::state::{OperatorStateBackendConfig, RequestStoreConfig};
 use crate::runtime::operators::window::model::{
-    KeyState, PartitionKey, RawRun, StateNamespace, TileMap, TileRun,
+    Cursor, KeyState, PartitionKey, RawRun, StateNamespace, TileMap, TileRun, WindowTrigger,
 };
 
 use super::WindowData;
@@ -44,6 +44,22 @@ pub enum WindowBackendSnapshot {
     Versioned { version: StateVersion },
 }
 
+#[derive(Debug, Clone)]
+pub struct DueWindowWork {
+    pub partition: PartitionKey,
+    pub key_state: KeyState,
+    pub triggers: Vec<WindowTrigger>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DueContinuation(pub Vec<u8>);
+
+#[derive(Debug, Clone)]
+pub struct DuePage {
+    pub work: Vec<DueWindowWork>,
+    pub continuation: Option<DueContinuation>,
+}
+
 /// Store operations used by the sole Window Operator for a partition.
 #[async_trait]
 pub trait WindowOperatorStore: Send + Sync + std::fmt::Debug {
@@ -58,8 +74,16 @@ pub trait WindowOperatorStore: Send + Sync + std::fmt::Debug {
         events: &RecordBatch,
         tiles: &TileMap,
         meta: &KeyState,
+        triggers: &[WindowTrigger],
     ) -> Result<()>;
-    async fn store_meta(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()>;
+    async fn load_due_page(
+        &self,
+        namespace: &StateNamespace,
+        after: Option<Cursor>,
+        through: Cursor,
+        continuation: Option<DueContinuation>,
+    ) -> Result<DuePage>;
+    async fn commit_advance(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()>;
     async fn flush(&self) -> Result<()> {
         Ok(())
     }

--- a/src/runtime/operators/window/store/mod.rs
+++ b/src/runtime/operators/window/store/mod.rs
@@ -2,10 +2,12 @@ pub mod backend;
 pub mod data;
 
 pub use crate::runtime::operators::window::model::{
-    KeyState, PartitionKey, StateNamespace, TileMap,
+    KeyEvaluationState, KeyState, PartitionKey, StateNamespace, TileMap, WindowTrigger,
+    WindowTriggerKind,
 };
 pub use backend::{
-    open_window_operator_store, open_window_request_store, AttemptToken, InMemWindowStore,
-    StateVersion, WindowBackendSnapshot, WindowOperatorStore, WindowRequestStore,
+    open_window_operator_store, open_window_request_store, AttemptToken, DueContinuation, DuePage,
+    DueWindowWork, InMemWindowStore, StateVersion, WindowBackendSnapshot, WindowOperatorStore,
+    WindowRequestStore,
 };
 pub use data::{WindowData, WindowView};

--- a/src/runtime/operators/window/store/mod.rs
+++ b/src/runtime/operators/window/store/mod.rs
@@ -6,8 +6,8 @@ pub use crate::runtime::operators::window::model::{
     WindowTriggerKind,
 };
 pub use backend::{
-    open_window_operator_store, open_window_request_store, AttemptToken, DueContinuation, DuePage,
-    DueWindowWork, InMemWindowStore, StateVersion, WindowBackendSnapshot, WindowOperatorStore,
+    open_window_operator_store, open_window_request_store, AttemptToken, DueWindowWork,
+    DueWorkStream, InMemWindowStore, StateVersion, WindowBackendSnapshot, WindowOperatorStore,
     WindowRequestStore,
 };
 pub use data::{WindowData, WindowView};

--- a/src/runtime/operators/window/tests/io_planning.rs
+++ b/src/runtime/operators/window/tests/io_planning.rs
@@ -5,12 +5,12 @@ use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
 use datafusion::scalar::ScalarValue;
 
-use crate::runtime::operators::window::model::{RawRun, TileRun};
+use crate::runtime::operators::window::model::{Cursor, RawRun, TileRun, WindowTrigger};
 use crate::runtime::operators::window::operator::WindowOperatorConfig;
 use crate::runtime::operators::window::spec::WindowSpec;
 use crate::runtime::operators::window::store::{
-    InMemWindowStore, KeyState, PartitionKey, StateNamespace, TileMap, WindowBackendSnapshot,
-    WindowData, WindowOperatorStore, WindowRequestStore,
+    DueContinuation, DuePage, InMemWindowStore, KeyState, PartitionKey, StateNamespace, TileMap,
+    WindowBackendSnapshot, WindowData, WindowOperatorStore, WindowRequestStore,
 };
 use crate::runtime::operators::window::tests::harness::{
     assert_window_values, batch, window_exec_from_sql, Harness, WoWroHarness,
@@ -69,14 +69,34 @@ impl WindowOperatorStore for RecordingWindowStore {
         events: &RecordBatch,
         tiles: &TileMap,
         meta: &KeyState,
+        triggers: &[WindowTrigger],
     ) -> Result<()> {
         self.inner
-            .commit_events(partition, ts_column_index, events, tiles, meta)
+            .commit_events(
+                partition,
+                ts_column_index,
+                events,
+                tiles,
+                meta,
+                triggers,
+            )
             .await
     }
 
-    async fn store_meta(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()> {
-        self.inner.store_meta(partition, meta).await
+    async fn load_due_page(
+        &self,
+        namespace: &StateNamespace,
+        after: Option<Cursor>,
+        through: Cursor,
+        continuation: Option<DueContinuation>,
+    ) -> Result<DuePage> {
+        self.inner
+            .load_due_page(namespace, after, through, continuation)
+            .await
+    }
+
+    async fn commit_advance(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()> {
+        self.inner.commit_advance(partition, meta).await
     }
 
     async fn checkpoint(&self, namespace: &StateNamespace) -> Result<WindowBackendSnapshot> {
@@ -172,13 +192,13 @@ FROM test_table"#;
     );
 
     let raw_reads = recording.raw_reads.lock().unwrap();
-    assert_eq!(raw_reads.len(), 2, "emit discovery + historical edges");
+    assert_eq!(raw_reads.len(), 1, "one merged emit and historical read");
     assert!(
-        raw_reads[1]
+        raw_reads[0]
             .iter()
             .all(|run| !(run.from.ts <= 300_000 && run.to.ts > 300_000)),
         "interior raw rows must not be loaded: {:?}",
-        raw_reads[1]
+        raw_reads[0]
     );
     let tile_reads = recording.tile_reads.lock().unwrap();
     assert!(
@@ -221,13 +241,13 @@ FROM test_table"#;
     );
 
     let raw_reads = recording.raw_reads.lock().unwrap();
-    assert_eq!(raw_reads.len(), 2, "emit discovery + leave-band edges");
+    assert_eq!(raw_reads.len(), 1, "one merged emit and leave-band read");
     assert!(
-        raw_reads[1]
+        raw_reads[0]
             .iter()
             .all(|run| !(run.from.ts <= 120_000 && run.to.ts > 120_000)),
         "leave-band interior raw rows must not be loaded: {:?}",
-        raw_reads[1]
+        raw_reads[0]
     );
     let tile_reads = recording.tile_reads.lock().unwrap();
     assert!(

--- a/src/runtime/operators/window/tests/io_planning.rs
+++ b/src/runtime/operators/window/tests/io_planning.rs
@@ -44,8 +44,8 @@ impl RecordingWindowStore {
 
 #[async_trait]
 impl WindowOperatorStore for RecordingWindowStore {
-    async fn load_meta(&self, partition: &PartitionKey) -> Result<KeyState> {
-        self.inner.load_meta(partition).await
+    async fn load_key_state(&self, partition: &PartitionKey) -> Result<KeyState> {
+        self.inner.load_key_state(partition).await
     }
 
     async fn load_raw(
@@ -92,8 +92,8 @@ impl WindowOperatorStore for RecordingWindowStore {
         self.inner.stream_due(namespace, after, through)
     }
 
-    async fn commit_advance(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()> {
-        self.inner.commit_advance(partition, meta).await
+    async fn store_key_state(&self, partition: &PartitionKey, state: &KeyState) -> Result<()> {
+        self.inner.store_key_state(partition, state).await
     }
 
     async fn checkpoint(&self, namespace: &StateNamespace) -> Result<WindowBackendSnapshot> {

--- a/src/runtime/operators/window/tests/io_planning.rs
+++ b/src/runtime/operators/window/tests/io_planning.rs
@@ -9,7 +9,7 @@ use crate::runtime::operators::window::model::{Cursor, RawRun, TileRun, WindowTr
 use crate::runtime::operators::window::operator::WindowOperatorConfig;
 use crate::runtime::operators::window::spec::WindowSpec;
 use crate::runtime::operators::window::store::{
-    DueContinuation, DuePage, InMemWindowStore, KeyState, PartitionKey, StateNamespace, TileMap,
+    DueWorkStream, InMemWindowStore, KeyState, PartitionKey, StateNamespace, TileMap,
     WindowBackendSnapshot, WindowData, WindowOperatorStore, WindowRequestStore,
 };
 use crate::runtime::operators::window::tests::harness::{
@@ -83,16 +83,13 @@ impl WindowOperatorStore for RecordingWindowStore {
             .await
     }
 
-    async fn load_due_page(
-        &self,
-        namespace: &StateNamespace,
+    fn stream_due<'a>(
+        &'a self,
+        namespace: &'a StateNamespace,
         after: Option<Cursor>,
         through: Cursor,
-        continuation: Option<DueContinuation>,
-    ) -> Result<DuePage> {
-        self.inner
-            .load_due_page(namespace, after, through, continuation)
-            .await
+    ) -> DueWorkStream<'a> {
+        self.inner.stream_due(namespace, after, through)
     }
 
     async fn commit_advance(&self, partition: &PartitionKey, meta: &KeyState) -> Result<()> {

--- a/src/runtime/operators/window/tests/semantics.rs
+++ b/src/runtime/operators/window/tests/semantics.rs
@@ -129,7 +129,7 @@ async fn watermark_rejects_late_rows_for_unseen_key() {
         .await;
 
     let partition = PartitionKey::new(&h.namespace, &key("B"));
-    let meta = h.store.load_meta(&partition).await.expect("meta");
+    let meta = h.store.load_key_state(&partition).await.expect("state");
     assert_eq!(meta.next_seq, 0);
 }
 
@@ -143,7 +143,7 @@ async fn state_only_publishes_on_ingest_and_advances_on_watermark() {
         .await;
 
     let partition = PartitionKey::new(&h.namespace, &key("A"));
-    let meta = h.store.load_meta(&partition).await.expect("meta");
+    let meta = h.store.load_key_state(&partition).await.expect("state");
     assert!(meta.evaluation.is_none());
     let mut due = h
         .store
@@ -163,7 +163,7 @@ async fn state_only_publishes_on_ingest_and_advances_on_watermark() {
         h.op.poll_next().await,
         OperatorPollResult::Continue
     ));
-    let meta = h.store.load_meta(&partition).await.expect("meta");
+    let meta = h.store.load_key_state(&partition).await.expect("state");
     assert!(meta.evaluation.is_none());
 }
 

--- a/src/runtime/operators/window/tests/semantics.rs
+++ b/src/runtime/operators/window/tests/semantics.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use datafusion::scalar::ScalarValue;
+use futures::TryStreamExt;
 
 use crate::runtime::checkpoint::SerializedRestore;
 use crate::runtime::operators::operator::{OperatorConfig, OperatorPollResult, OperatorTrait};
@@ -144,17 +145,10 @@ async fn state_only_publishes_on_ingest_and_advances_on_watermark() {
     let partition = PartitionKey::new(&h.namespace, &key("A"));
     let meta = h.store.load_meta(&partition).await.expect("meta");
     assert!(meta.evaluation.is_none());
-    let due = h
+    let mut due = h
         .store
-        .load_due_page(
-            &h.namespace,
-            None,
-            Cursor::new(2000, u64::MAX),
-            None,
-        )
-        .await
-        .expect("due page");
-    assert!(due.work.is_empty());
+        .stream_due(&h.namespace, None, Cursor::new(2000, u64::MAX));
+    assert!(due.try_next().await.expect("due page").is_none());
 
     let mut wro = open_wro(h.store.clone(), h.namespace.clone()).await;
     assert_eq!(

--- a/src/runtime/operators/window/tests/semantics.rs
+++ b/src/runtime/operators/window/tests/semantics.rs
@@ -9,7 +9,6 @@ use crate::runtime::operators::window::operator::{WindowOperatorConfig, WindowOu
 use crate::runtime::operators::window::request::{
     WindowRequestOperator, WindowRequestOperatorConfig,
 };
-use crate::runtime::operators::window::spec::WindowSpec;
 use crate::runtime::operators::window::store::{
     InMemWindowStore, PartitionKey, StateNamespace, WindowOperatorStore,
 };
@@ -56,7 +55,7 @@ async fn request_sum(wro: &mut WindowRequestOperator, partition: &str, ts: i64) 
 }
 
 #[tokio::test]
-async fn duplicate_timestamps_across_batches_follow_sequence_frontier() {
+async fn duplicate_timestamps_are_ordered_before_the_watermark() {
     let exec = window_exec_from_sql(SQL).await;
     let mut h = Harness::new(WindowOperatorConfig::new(exec)).await;
 
@@ -80,12 +79,7 @@ async fn duplicate_timestamps_across_batches_follow_sequence_frontier() {
         .await;
     let second = h.watermark_and_output(1000).await;
     let _ = h.drain_passthrough_watermark().await;
-    assert_window_values(
-        &second,
-        3,
-        &[vec![ScalarValue::Float64(Some(10.0))]],
-        "sequence-sensitive drop",
-    );
+    assert_eq!(second.num_rows(), 0);
 }
 
 #[tokio::test]
@@ -125,22 +119,17 @@ async fn watermark_without_ingest_is_empty_and_passes_through() {
 }
 
 #[tokio::test]
-async fn lateness_config_sets_retention_floor_in_meta() {
+async fn watermark_rejects_late_rows_for_unseen_key() {
     let exec = window_exec_from_sql(SQL).await;
-    let mut cfg = WindowOperatorConfig::new(exec);
-    cfg.spec = WindowSpec {
-        lateness: Some(2000),
-        ..Default::default()
-    };
-    let mut h = Harness::new(cfg).await;
-    h.ingest(batch(vec![10_000], vec![1.0], vec!["A"]), "A")
-        .await;
+    let mut h = Harness::new(WindowOperatorConfig::new(exec)).await;
     let _ = h.watermark_and_output(10_000).await;
     let _ = h.drain_passthrough_watermark().await;
+    h.ingest(batch(vec![9_000], vec![1.0], vec!["B"]), "B")
+        .await;
 
-    let partition = PartitionKey::new(&h.namespace, &key("A"));
+    let partition = PartitionKey::new(&h.namespace, &key("B"));
     let meta = h.store.load_meta(&partition).await.expect("meta");
-    assert_eq!(meta.retention_floor, Some(Cursor::new(3000, 0)));
+    assert_eq!(meta.next_seq, 0);
 }
 
 #[tokio::test]
@@ -154,7 +143,18 @@ async fn state_only_publishes_on_ingest_and_advances_on_watermark() {
 
     let partition = PartitionKey::new(&h.namespace, &key("A"));
     let meta = h.store.load_meta(&partition).await.expect("meta");
-    assert_eq!(meta.processed_pos, None);
+    assert!(meta.evaluation.is_none());
+    let due = h
+        .store
+        .load_due_page(
+            &h.namespace,
+            None,
+            Cursor::new(2000, u64::MAX),
+            None,
+        )
+        .await
+        .expect("due page");
+    assert!(due.work.is_empty());
 
     let mut wro = open_wro(h.store.clone(), h.namespace.clone()).await;
     assert_eq!(
@@ -170,7 +170,7 @@ async fn state_only_publishes_on_ingest_and_advances_on_watermark() {
         OperatorPollResult::Continue
     ));
     let meta = h.store.load_meta(&partition).await.expect("meta");
-    assert_eq!(meta.processed_pos, Some(Cursor::new(2000, 1)));
+    assert!(meta.evaluation.is_none());
 }
 
 #[tokio::test]
@@ -266,6 +266,38 @@ async fn operator_checkpoint_restores_into_fresh_store() {
     assert_eq!(
         request_sum(&mut wro, "A", 2000).await,
         ScalarValue::Float64(Some(3.0))
+    );
+}
+
+#[tokio::test]
+async fn pending_triggers_survive_checkpoint_restore() {
+    let exec = window_exec_from_sql(SQL).await;
+    let mut original = Harness::new(WindowOperatorConfig::new(exec.clone())).await;
+    original
+        .ingest(
+            batch(vec![1000, 2000], vec![1.0, 2.0], vec!["A", "A"]),
+            "A",
+        )
+        .await;
+
+    let checkpoint = original.op.checkpoint(1).await.expect("checkpoint");
+    let mut restored = Harness::new(WindowOperatorConfig::new(exec)).await;
+    restored
+        .op
+        .restore(SerializedRestore::new(checkpoint.into_bytes()))
+        .await
+        .expect("restore");
+
+    let output = restored.watermark_and_output(2000).await;
+    let _ = restored.drain_passthrough_watermark().await;
+    assert_window_values(
+        &output,
+        3,
+        &[
+            vec![ScalarValue::Float64(Some(1.0))],
+            vec![ScalarValue::Float64(Some(3.0))],
+        ],
+        "restored pending triggers",
     );
 }
 

--- a/src/runtime/operators/window/tests/tiling.rs
+++ b/src/runtime/operators/window/tests/tiling.rs
@@ -65,6 +65,7 @@ async fn ingest_tiles(
             batch,
             &by_key,
             &KeyState::default(),
+            &[],
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- replace the window operator's volatile pending-key set with backend-owned, cursor-ordered trigger pages
- simplify per-key state and checkpoint the task watermark alongside the backend snapshot
- make watermark evaluation consume exact trigger cursors in one merged raw/tile load while state-only WO remains ingest-published and trigger-free
- checkpoint and restore in-memory triggers atomically with partition state

The future Scylla layout remains documentation-only and will be synchronized separately on `docs/window-store-design`.

## Test plan
- [x] `cargo check --lib`
- [x] `cargo test --lib runtime::operators::window`
- [x] IDE diagnostics for changed window and event-time files

Made with [Cursor](https://cursor.com)