### PR TITLE
Limit inline in-memory checkpoints

### DIFF
--- a/src/runtime/operators/window/README.md
+++ b/src/runtime/operators/window/README.md
@@ -154,7 +154,9 @@ partitioning, publication, fencing, caching, and cleanup. They must preserve:
 `InMemWindowStore` is the reference backend. It keeps partition state in memory,
 uses one read lock as the WRO snapshot boundary, and embeds complete namespace
 snapshots, including durable triggers, in checkpoint data. Its live state
-remains process-local and is not a cross-worker backend.
+remains process-local and is not a cross-worker backend. It is intended only
+for development and tests: inline checkpoint snapshots are limited to 3 MiB to
+stay below the gRPC control-plane message limit.
 
 ## Checkpoint and restore
 

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -22,6 +22,18 @@ use crate::runtime::operators::window::store::{
     KeyState, PartitionKey, StateNamespace, TileMap, WindowData,
 };
 
+const MAX_INLINE_CHECKPOINT_BYTES: usize = 3 * 1024 * 1024;
+
+fn validate_checkpoint_size(snapshot: &[u8]) -> Result<()> {
+    anyhow::ensure!(
+        snapshot.len() <= MAX_INLINE_CHECKPOINT_BYTES,
+        "in-memory window checkpoint is {} bytes, exceeding the development/test inline limit of {} bytes; use a durable state backend for larger state",
+        snapshot.len(),
+        MAX_INLINE_CHECKPOINT_BYTES,
+    );
+    Ok(())
+}
+
 #[derive(Debug, Clone, Default)]
 struct PartitionState {
     meta: KeyState,
@@ -49,7 +61,8 @@ struct InMemState {
     triggers: BTreeSet<WindowTrigger>,
 }
 
-/// Reference backend. One read lock is the WRO snapshot boundary.
+/// Development/test reference backend with inline checkpoints limited to 3 MiB.
+/// One read lock is the WRO snapshot boundary.
 #[derive(Debug, Clone, Default)]
 pub struct InMemWindowStore {
     state: Arc<RwLock<InMemState>>,
@@ -262,9 +275,9 @@ impl WindowOperatorStore for InMemWindowStore {
                 .cloned()
                 .collect(),
         };
-        Ok(WindowBackendSnapshot::InMemory {
-            snapshot: bincode::serialize(&checkpoint)?,
-        })
+        let snapshot = bincode::serialize(&checkpoint)?;
+        validate_checkpoint_size(&snapshot)?;
+        Ok(WindowBackendSnapshot::InMemory { snapshot })
     }
 
     async fn restore(
@@ -277,6 +290,7 @@ impl WindowOperatorStore for InMemWindowStore {
                 "in-memory window store requires in-memory restore data"
             ));
         };
+        validate_checkpoint_size(snapshot)?;
         let checkpoint: InMemCheckpoint = bincode::deserialize(snapshot)?;
         anyhow::ensure!(
             checkpoint.namespace.as_slice() == namespace.bytes.as_slice(),

--- a/src/runtime/operators/window/store/backend/mod.rs
+++ b/src/runtime/operators/window/store/backend/mod.rs
@@ -41,6 +41,7 @@ pub struct StateVersion {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WindowBackendSnapshot {
+    /// Development/test-only inline snapshot.
     InMemory { snapshot: Vec<u8> },
     Versioned { version: StateVersion },
 }


### PR DESCRIPTION
## Summary
- classify the in-memory window backend and its inline snapshots as development/test-only
- reject inline checkpoint and restore payloads larger than 3 MiB before they enter the gRPC control plane
- track production-scale external checkpoint blobs in #167

## Test plan
- [x] `cargo test checkpoint_restores_complete_namespace_into_fresh_store`
- [x] Existing checkpoint-size validation path compiled by the targeted window store tests


Made with [Cursor](https://cursor.com)