### PR TITLE
Instrument window recovery late-row race

### DIFF
--- a/src/runtime/operators/source/source_operator.rs
+++ b/src/runtime/operators/source/source_operator.rs
@@ -196,6 +196,13 @@ impl OperatorTrait for SourceOperator {
             !position.is_empty(),
             "checkpointable source produced empty position"
         );
+        if std::env::var_os("VOLGA_CHECKPOINT_DIAGNOSTICS").is_some() {
+            println!(
+                "[CHECKPOINT_DIAG] source records_generated={:?} checkpoint_bytes={}",
+                function.emit_count(),
+                position.len()
+            );
+        }
         Ok(SerializedCheckpoint::new(position))
     }
 

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -20,7 +20,9 @@ use crate::runtime::operators::window::frame_utils::require_range_frame;
 use crate::runtime::operators::window::model::{Cursor, WindowId};
 use crate::runtime::operators::window::spec::WindowSpec;
 use crate::runtime::operators::window::state::{WindowOperatorState, WindowStateSnapshot};
-use crate::runtime::operators::window::store::{open_window_operator_store, StateNamespace};
+use crate::runtime::operators::window::store::{
+    checkpoint_summary, open_window_operator_store, StateNamespace, WindowBackendSnapshot,
+};
 use crate::runtime::operators::window::TileConfig;
 use crate::runtime::runtime_context::RuntimeContext;
 use datafusion::physical_plan::windows::BoundedWindowAggExec;
@@ -216,11 +218,25 @@ impl OperatorTrait for WindowOperator {
         self.base.operator_config()
     }
 
-    async fn checkpoint(&mut self, _checkpoint_id: u64) -> Result<SerializedCheckpoint> {
+    async fn checkpoint(&mut self, checkpoint_id: u64) -> Result<SerializedCheckpoint> {
         let snapshot = self
             .state_ref()
             .checkpoint(self.watermark_frontier)
             .await?;
+        if std::env::var_os("VOLGA_CHECKPOINT_DIAGNOSTICS").is_some() {
+            if let WindowBackendSnapshot::InMemory { snapshot: backend } = &snapshot.backend {
+                let summary = checkpoint_summary(backend)?;
+                println!(
+                    "[CHECKPOINT_DIAG] window checkpoint_id={checkpoint_id} watermark={:?} partitions={} raw_rows={} triggers={} min_cursor={:?} max_cursor={:?}",
+                    snapshot.watermark_frontier,
+                    summary.partitions,
+                    summary.raw_rows,
+                    summary.triggers,
+                    summary.min_cursor,
+                    summary.max_cursor,
+                );
+            }
+        }
         Ok(SerializedCheckpoint::new(bincode::serialize(&snapshot)?))
     }
 
@@ -250,6 +266,13 @@ impl OperatorTrait for WindowOperator {
                             self.output_mode == WindowOutputMode::Emit,
                         )
                         .await;
+                    if dropped > 0 && std::env::var_os("VOLGA_CHECKPOINT_DIAGNOSTICS").is_some()
+                    {
+                        println!(
+                            "[CHECKPOINT_DIAG] window dropped_late_rows={dropped} watermark={:?}",
+                            self.watermark_frontier
+                        );
+                    }
                     debug_assert!(dropped <= input_rows);
                     OperatorPollResult::Continue
                 }

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -43,6 +43,38 @@ struct PartitionCheckpoint {
     tiles: TileMap,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InMemCheckpointSummary {
+    pub partitions: usize,
+    pub raw_rows: usize,
+    pub triggers: usize,
+    pub min_cursor: Option<Cursor>,
+    pub max_cursor: Option<Cursor>,
+}
+
+pub fn checkpoint_summary(snapshot: &[u8]) -> Result<InMemCheckpointSummary> {
+    let checkpoint: InMemCheckpoint = bincode::deserialize(snapshot)?;
+    let mut raw_rows = 0;
+    let mut min_cursor: Option<Cursor> = None;
+    let mut max_cursor: Option<Cursor> = None;
+    for partition in checkpoint.partitions.values() {
+        raw_rows += partition.raw.len();
+        if let Some(cursor) = partition.raw.first_key_value().map(|(cursor, _)| *cursor) {
+            min_cursor = Some(min_cursor.map_or(cursor, |current| current.min(cursor)));
+        }
+        if let Some(cursor) = partition.raw.last_key_value().map(|(cursor, _)| *cursor) {
+            max_cursor = Some(max_cursor.map_or(cursor, |current| current.max(cursor)));
+        }
+    }
+    Ok(InMemCheckpointSummary {
+        partitions: checkpoint.partitions.len(),
+        raw_rows,
+        triggers: checkpoint.triggers.len(),
+        min_cursor,
+        max_cursor,
+    })
+}
+
 #[derive(Debug, Default)]
 struct InMemState {
     partitions: HashMap<PartitionKey, PartitionState>,

--- a/src/runtime/operators/window/store/backend/mod.rs
+++ b/src/runtime/operators/window/store/backend/mod.rs
@@ -15,7 +15,7 @@ use super::WindowData;
 
 mod inmem;
 
-pub use inmem::InMemWindowStore;
+pub use inmem::{checkpoint_summary, InMemCheckpointSummary, InMemWindowStore};
 
 pub async fn open_window_operator_store(
     config: &OperatorStateBackendConfig,

--- a/src/runtime/operators/window/store/mod.rs
+++ b/src/runtime/operators/window/store/mod.rs
@@ -6,8 +6,8 @@ pub use crate::runtime::operators::window::model::{
     WindowTriggerKind,
 };
 pub use backend::{
-    open_window_operator_store, open_window_request_store, AttemptToken, DueWindowWork,
-    DueWorkStream, InMemWindowStore, StateVersion, WindowBackendSnapshot, WindowOperatorStore,
-    WindowRequestStore,
+    checkpoint_summary, open_window_operator_store, open_window_request_store, AttemptToken,
+    DueWindowWork, DueWorkStream, InMemCheckpointSummary, InMemWindowStore, StateVersion,
+    WindowBackendSnapshot, WindowOperatorStore, WindowRequestStore,
 };
 pub use data::{WindowData, WindowView};

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -681,6 +681,7 @@ impl StreamTask {
                         } else {
                             None
                         };
+                        let mut checkpoint_propagation = None;
                         if let Message::CheckpointBarrier(ref barrier) = message {
                             let checkpoint_id = barrier.checkpoint_id;
                             let propagation_phase = if is_source {
@@ -688,15 +689,6 @@ impl StreamTask {
                             } else {
                                 crate::runtime::master::server::master_service::CheckpointPropagationPhase::Aligned
                             };
-                            Self::report_checkpoint_propagation(
-                                &mut master_client,
-                                checkpoint_id,
-                                vertex_id.as_ref(),
-                                runtime_context.task_index(),
-                                execution_attempt_id,
-                                propagation_phase,
-                            )
-                            .await?;
 
                             if crate::runtime::operators::operator::operator_config_requires_checkpoint(operator.operator_config()) {
                                 println!(
@@ -737,6 +729,7 @@ impl StreamTask {
                             if let Some(ctrl) = &data_reader_control {
                                 ctrl.unblock_all();
                             }
+                            checkpoint_propagation = Some((checkpoint_id, propagation_phase));
                         }
 
                         // if vertex_id == "Window_1_2" {
@@ -779,6 +772,18 @@ impl StreamTask {
                             vertex_id.clone(),
                             status.clone()
                         ).await;
+
+                        if let Some((checkpoint_id, propagation_phase)) = checkpoint_propagation {
+                            Self::report_checkpoint_propagation(
+                                &mut master_client,
+                                checkpoint_id,
+                                vertex_id.as_ref(),
+                                runtime_context.task_index(),
+                                execution_attempt_id,
+                                propagation_phase,
+                            )
+                            .await?;
+                        }
 
                         if let Some(wm) = injected_wm {
                             let mut injected = Message::Watermark(wm);


### PR DESCRIPTION
## Summary
- delay checkpoint propagation acknowledgement until barrier processing and forwarding complete
- add opt-in source/window checkpoint diagnostics and late-row-drop reporting
- document the reproduction and proposed attempt-fencing fix in #169

## Test plan
- `VOLGA_CHECKPOINT_DIAGNOSTICS=1 scripts/test stress --env local --test test_local_multi_worker_window_checkpoint_restore --runs-per-shard 20 --shards 1`

Depends on the checkpoint runner PR for the reusable stress command.

Made with [Cursor](https://cursor.com)