### PR TITLE
Track window late drops through task metadata

### DIFF
--- a/src/runtime/observability/mod.rs
+++ b/src/runtime/observability/mod.rs
@@ -1,7 +1,9 @@
 pub mod snapshot_types;
 pub mod snapshot_history;
+pub mod task_metadata;
 
 pub use snapshot_types::{
     task_meta, PipelineSnapshot, StreamTaskStatus, TaskSnapshot, WorkerSnapshot,
 };
 pub use snapshot_history::{PipelineDerivedStats, PipelineSnapshotEntry, PipelineSnapshotHistory};
+pub use task_metadata::TaskMetadataReporter;

--- a/src/runtime/observability/mod.rs
+++ b/src/runtime/observability/mod.rs
@@ -3,7 +3,7 @@ pub mod snapshot_history;
 pub mod task_metadata;
 
 pub use snapshot_types::{
-    task_meta, PipelineSnapshot, StreamTaskStatus, TaskSnapshot, WorkerSnapshot,
+    PipelineSnapshot, StreamTaskStatus, TaskSnapshot, WorkerSnapshot,
 };
 pub use snapshot_history::{PipelineDerivedStats, PipelineSnapshotEntry, PipelineSnapshotHistory};
-pub use task_metadata::TaskMetadataReporter;
+pub use task_metadata::TaskMetadata;

--- a/src/runtime/observability/snapshot_types.rs
+++ b/src/runtime/observability/snapshot_types.rs
@@ -34,6 +34,8 @@ impl From<u8> for StreamTaskStatus {
 /// Convention keys for [`TaskSnapshot::metadata`] / [`WorkerSnapshot::task_metadata`].
 pub mod task_meta {
     pub const RECORDS_GENERATED: &str = "records_generated";
+    pub const WINDOW_ROWS_ACCEPTED: &str = "window_rows_accepted";
+    pub const WINDOW_ROWS_DROPPED_LATE: &str = "window_rows_dropped_late";
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime/observability/snapshot_types.rs
+++ b/src/runtime/observability/snapshot_types.rs
@@ -8,6 +8,7 @@ use crate::runtime::VertexId;
 use crate::runtime::metrics::TaskMetrics;
 use anyhow::Result;
 use crate::storage::StorageStatsSnapshot;
+use super::task_metadata::TaskMetadata;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StreamTaskStatus {
@@ -31,20 +32,13 @@ impl From<u8> for StreamTaskStatus {
     }
 }
 
-/// Convention keys for [`TaskSnapshot::metadata`] / [`WorkerSnapshot::task_metadata`].
-pub mod task_meta {
-    pub const RECORDS_GENERATED: &str = "records_generated";
-    pub const WINDOW_ROWS_ACCEPTED: &str = "window_rows_accepted";
-    pub const WINDOW_ROWS_DROPPED_LATE: &str = "window_rows_dropped_late";
-}
-
 #[derive(Debug, Clone)]
 pub struct TaskSnapshot {
     pub vertex_id: VertexId,
     pub status: StreamTaskStatus,
     pub metrics: TaskMetrics,
-    /// Opaque string KV for harness/debug (e.g. source `records_generated`).
-    pub metadata: HashMap<String, String>,
+    /// Opaque operator data for harness/debug (e.g. source `records_generated`).
+    pub metadata: TaskMetadata,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,7 +54,7 @@ pub struct WorkerSnapshot {
     pub task_statuses: HashMap<VertexId, StreamTaskStatus>,
     pub worker_metrics: Option<WorkerAggregateMetrics>,
     pub task_operator_metrics: HashMap<VertexId, TaskOperatorMetrics>,
-    pub task_metadata: HashMap<VertexId, HashMap<String, String>>,
+    pub task_metadata: HashMap<VertexId, TaskMetadata>,
 }
 
 impl WorkerSnapshot {

--- a/src/runtime/observability/task_metadata.rs
+++ b/src/runtime/observability/task_metadata.rs
@@ -17,13 +17,6 @@ impl TaskMetadata {
             .insert(key.to_string(), value.to_string());
     }
 
-    pub fn insert(&self, key: impl Into<String>, value: impl Into<String>) {
-        self.values
-            .lock()
-            .expect("task metadata lock poisoned")
-            .insert(key.into(), value.into());
-    }
-
     pub fn increment_u64(&self, key: &str, delta: u64) {
         let mut values = self.values.lock().expect("task metadata lock poisoned");
         let next = values

--- a/src/runtime/observability/task_metadata.rs
+++ b/src/runtime/observability/task_metadata.rs
@@ -67,7 +67,7 @@ impl Serialize for TaskMetadata {
     }
 }
 
-impl<'de> Deserialize for TaskMetadata {
+impl<'de> Deserialize<'de> for TaskMetadata {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/src/runtime/observability/task_metadata.rs
+++ b/src/runtime/observability/task_metadata.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-/// Task-local operator data published into task snapshots for test and debugging use.
+use serde::{Deserialize, Serialize};
+
+/// Shared per-task key/value bag published into task and worker snapshots.
 #[derive(Clone, Debug, Default)]
-pub struct TaskMetadataReporter {
+pub struct TaskMetadata {
     values: Arc<Mutex<HashMap<String, String>>>,
 }
 
-impl TaskMetadataReporter {
+impl TaskMetadata {
     pub fn set(&self, key: &str, value: impl ToString) {
         self.values
             .lock()
@@ -15,20 +17,71 @@ impl TaskMetadataReporter {
             .insert(key.to_string(), value.to_string());
     }
 
+    pub fn insert(&self, key: impl Into<String>, value: impl Into<String>) {
+        self.values
+            .lock()
+            .expect("task metadata lock poisoned")
+            .insert(key.into(), value.into());
+    }
+
     pub fn increment_u64(&self, key: &str, delta: u64) {
         let mut values = self.values.lock().expect("task metadata lock poisoned");
-        let value = values
+        let next = values
             .get(key)
             .map(|value| value.parse::<u64>().expect("task metadata must be u64"))
             .unwrap_or_default()
             + delta;
-        values.insert(key.to_string(), value.to_string());
+        values.insert(key.to_string(), next.to_string());
     }
 
-    pub fn snapshot(&self) -> HashMap<String, String> {
+    pub fn get(&self, key: &str) -> Option<String> {
         self.values
             .lock()
             .expect("task metadata lock poisoned")
-            .clone()
+            .get(key)
+            .cloned()
+    }
+
+    pub fn extend(&self, other: &Self) {
+        let other = other
+            .values
+            .lock()
+            .expect("task metadata lock poisoned")
+            .clone();
+        self.values
+            .lock()
+            .expect("task metadata lock poisoned")
+            .extend(other);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.values
+            .lock()
+            .expect("task metadata lock poisoned")
+            .is_empty()
+    }
+}
+
+impl Serialize for TaskMetadata {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.values
+            .lock()
+            .expect("task metadata lock poisoned")
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize for TaskMetadata {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let values = HashMap::<String, String>::deserialize(deserializer)?;
+        Ok(Self {
+            values: Arc::new(Mutex::new(values)),
+        })
     }
 }

--- a/src/runtime/observability/task_metadata.rs
+++ b/src/runtime/observability/task_metadata.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Task-local operator data published into task snapshots for test and debugging use.
+#[derive(Clone, Debug, Default)]
+pub struct TaskMetadataReporter {
+    values: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl TaskMetadataReporter {
+    pub fn set(&self, key: &str, value: impl ToString) {
+        self.values
+            .lock()
+            .expect("task metadata lock poisoned")
+            .insert(key.to_string(), value.to_string());
+    }
+
+    pub fn increment_u64(&self, key: &str, delta: u64) {
+        let mut values = self.values.lock().expect("task metadata lock poisoned");
+        let value = values
+            .get(key)
+            .map(|value| value.parse::<u64>().expect("task metadata must be u64"))
+            .unwrap_or_default()
+            + delta;
+        values.insert(key.to_string(), value.to_string());
+    }
+
+    pub fn snapshot(&self) -> HashMap<String, String> {
+        self.values
+            .lock()
+            .expect("task metadata lock poisoned")
+            .clone()
+    }
+}

--- a/src/runtime/operators/operator.rs
+++ b/src/runtime/operators/operator.rs
@@ -11,7 +11,7 @@ use crate::runtime::operators::map::map_operator::MapOperator;
 use crate::runtime::operators::reduce::reduce_operator::ReduceOperator;
 use crate::runtime::operators::sink::sink_operator::{SinkConfig, SinkOperator};
 use crate::runtime::operators::source::source_operator::{SourceConfig, SourceOperator};
-use crate::runtime::operators::window::operator::{WindowOperatorConfig, WindowOperator};
+use crate::runtime::operators::window::operator::{WindowOperator, WindowOperatorConfig};
 use crate::runtime::operators::window::request::WindowRequestOperatorConfig;
 use crate::runtime::operators::window::WindowRequestOperator;
 use crate::runtime::runtime_context::RuntimeContext;

--- a/src/runtime/operators/source/mod.rs
+++ b/src/runtime/operators/source/mod.rs
@@ -3,4 +3,5 @@ pub mod source_operator;
 
 pub use source_handles::{
     race_interruptible, Interrupted, SourceHandle, SourceHandles, SourceInterrupt, SourceStats,
+    TASK_METADATA_RECORDS_GENERATED,
 };

--- a/src/runtime/operators/source/mod.rs
+++ b/src/runtime/operators/source/mod.rs
@@ -2,6 +2,6 @@ pub mod source_handles;
 pub mod source_operator;
 
 pub use source_handles::{
-    race_interruptible, Interrupted, SourceHandle, SourceHandles, SourceInterrupt, SourceStats,
-    TASK_METADATA_RECORDS_GENERATED,
+    race_interruptible, Interrupted, SourceHandle, SourceHandles, SourceInterrupt,
 };
+pub use source_operator::TASK_METADATA_RECORDS_GENERATED;

--- a/src/runtime/operators/source/source_handles.rs
+++ b/src/runtime/operators/source/source_handles.rs
@@ -10,6 +10,9 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
 
 use crate::runtime::VertexId;
+use crate::runtime::observability::TaskMetadata;
+
+pub const TASK_METADATA_RECORDS_GENERATED: &str = "records_generated";
 
 /// Latched cancel + notify for interruptible source waits (checkpoint barrier yield).
 #[derive(Debug, Default)]
@@ -156,14 +159,14 @@ impl SourceHandles {
         }
     }
 
-    pub fn task_metadata(&self, vertex_id: &VertexId) -> HashMap<String, String> {
+    pub fn task_metadata(&self, vertex_id: &VertexId) -> TaskMetadata {
         let guard = self.inner.lock().unwrap();
         let Some(handle) = guard.get(vertex_id) else {
-            return HashMap::new();
+            return TaskMetadata::default();
         };
-        let mut meta = HashMap::new();
+        let meta = TaskMetadata::default();
         meta.insert(
-            crate::runtime::observability::task_meta::RECORDS_GENERATED.to_string(),
+            TASK_METADATA_RECORDS_GENERATED,
             handle.stats.records_generated().to_string(),
         );
         meta

--- a/src/runtime/operators/source/source_handles.rs
+++ b/src/runtime/operators/source/source_handles.rs
@@ -1,18 +1,14 @@
-//! Per-source interrupt + emit stats for source tasks.
+//! Per-source interrupt handles for source tasks.
 //!
-//! - [`SourceInterrupt`]: checkpointable sources use `sleep` / `race` for prompt barrier yield.
-//! - [`SourceStats`]: rows emitted by [`super::source_operator::SourceOperator`]; task metadata.
+//! [`SourceInterrupt`]: checkpointable sources use `sleep` / `race` for prompt barrier yield.
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
 
 use crate::runtime::VertexId;
-use crate::runtime::observability::TaskMetadata;
-
-pub const TASK_METADATA_RECORDS_GENERATED: &str = "records_generated";
 
 /// Latched cancel + notify for interruptible source waits (checkpoint barrier yield).
 #[derive(Debug, Default)]
@@ -52,33 +48,6 @@ impl SourceInterrupt {
     }
 }
 
-/// Shared per-source emit counter for task metadata (updated by [`super::source_operator::SourceOperator`]).
-#[derive(Debug, Default)]
-pub struct SourceStats {
-    records_generated: AtomicU64,
-}
-
-impl SourceStats {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn records_generated(&self) -> u64 {
-        self.records_generated.load(Ordering::SeqCst)
-    }
-
-    pub fn add_records(&self, n: usize) {
-        if n > 0 {
-            self.records_generated
-                .fetch_add(n as u64, Ordering::SeqCst);
-        }
-    }
-
-    pub fn set_records_generated(&self, n: u64) {
-        self.records_generated.store(n, Ordering::SeqCst);
-    }
-}
-
 /// Race a future against an optional checkpoint interrupt.
 pub async fn race_interruptible<T>(
     interrupt: Option<&SourceInterrupt>,
@@ -90,11 +59,10 @@ pub async fn race_interruptible<T>(
     }
 }
 
-/// Per source-task shared interrupt + stats + cooperative stop.
+/// Per source-task shared interrupt + cooperative stop.
 #[derive(Debug)]
 pub struct SourceHandle {
     pub interrupt: Arc<SourceInterrupt>,
-    pub stats: Arc<SourceStats>,
     /// Latched by harness/master `StopSources`; source then returns Idle and finishes.
     pub stopped: Arc<AtomicBool>,
 }
@@ -103,7 +71,6 @@ impl SourceHandle {
     fn new() -> Self {
         Self {
             interrupt: Arc::new(SourceInterrupt::new()),
-            stats: Arc::new(SourceStats::new()),
             stopped: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -157,18 +124,5 @@ impl SourceHandles {
         for handle in self.inner.lock().unwrap().values() {
             handle.stop();
         }
-    }
-
-    pub fn task_metadata(&self, vertex_id: &VertexId) -> TaskMetadata {
-        let guard = self.inner.lock().unwrap();
-        let Some(handle) = guard.get(vertex_id) else {
-            return TaskMetadata::default();
-        };
-        let meta = TaskMetadata::default();
-        meta.insert(
-            TASK_METADATA_RECORDS_GENERATED,
-            handle.stats.records_generated().to_string(),
-        );
-        meta
     }
 }

--- a/src/runtime/operators/source/source_operator.rs
+++ b/src/runtime/operators/source/source_operator.rs
@@ -14,8 +14,11 @@ use crate::runtime::operators::operator::{
     operator_config_requires_checkpoint, MessageStream, OperatorBase, OperatorConfig,
     OperatorPollResult, OperatorTrait, OperatorType,
 };
+use crate::runtime::observability::TaskMetadata;
 use crate::runtime::runtime_context::RuntimeContext;
 use super::source_handles::{SourceHandle, SourceInterrupt};
+
+pub const TASK_METADATA_RECORDS_GENERATED: &str = "records_generated";
 
 #[derive(Debug, Clone)]
 pub struct VectorSourceConfig {
@@ -139,6 +142,7 @@ impl std::fmt::Display for SourceConfig {
 pub struct SourceOperator {
     base: OperatorBase,
     handle: Option<Arc<SourceHandle>>,
+    task_metadata: TaskMetadata,
 }
 
 impl SourceOperator {
@@ -151,6 +155,7 @@ impl SourceOperator {
         Self {
             base: OperatorBase::new_with_function(source_function, config),
             handle: None,
+            task_metadata: TaskMetadata::default(),
         }
     }
 
@@ -169,6 +174,8 @@ impl OperatorTrait for SourceOperator {
         if let Some(handles) = context.source_handles() {
             self.handle = Some(handles.register(context.vertex_id_arc()));
         }
+        self.task_metadata = context.task_metadata();
+        self.task_metadata.set(TASK_METADATA_RECORDS_GENERATED, 0);
         self.base.open(context).await?;
         Ok(())
     }
@@ -204,8 +211,8 @@ impl OperatorTrait for SourceOperator {
         let function = self.base.get_function_mut::<SourceFunction>().unwrap();
         anyhow::ensure!(!position.is_empty(), "empty source position on restore");
         function.restore_position(&position).await?;
-        if let (Some(handle), Some(n)) = (self.handle.as_ref(), function.emit_count()) {
-            handle.stats.set_records_generated(n);
+        if let Some(n) = function.emit_count() {
+            self.task_metadata.set(TASK_METADATA_RECORDS_GENERATED, n);
         }
         Ok(())
     }
@@ -232,13 +239,14 @@ impl OperatorTrait for SourceOperator {
                 OperatorPollResult::Ready(Message::Watermark(watermark))
             }
             FetchResult::Data(message) => {
-                if let Some(handle) = self.handle.as_ref() {
-                    match &message {
-                        Message::Regular(_) | Message::Keyed(_) => {
-                            handle.stats.add_records(message.num_records());
-                        }
-                        Message::Watermark(_) | Message::CheckpointBarrier(_) => {}
+                match &message {
+                    Message::Regular(_) | Message::Keyed(_) => {
+                        self.task_metadata.increment_u64(
+                            TASK_METADATA_RECORDS_GENERATED,
+                            message.num_records() as u64,
+                        );
                     }
+                    Message::Watermark(_) | Message::CheckpointBarrier(_) => {}
                 }
                 OperatorPollResult::Ready(message)
             }

--- a/src/runtime/operators/window/mod.rs
+++ b/src/runtime/operators/window/mod.rs
@@ -18,7 +18,9 @@ mod tests;
 
 pub use config::{BuiltWindows, WindowConfig};
 pub use model::{Cursor, Tile, TimeGranularity};
-pub use operator::{WindowOperator, WindowOutputMode};
+pub use operator::{
+    WindowOperator, WindowOutputMode, TASK_METADATA_ROWS_ACCEPTED, TASK_METADATA_ROWS_DROPPED_LATE,
+};
 pub use request::WindowRequestOperator;
 pub use store::{InMemWindowStore, StateNamespace, WindowOperatorStore, WindowRequestStore};
 pub use tile::TileConfig;

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -23,11 +23,14 @@ use crate::runtime::operators::window::state::{WindowOperatorState, WindowStateS
 use crate::runtime::operators::window::store::{open_window_operator_store, StateNamespace};
 use crate::runtime::operators::window::TileConfig;
 use crate::runtime::runtime_context::RuntimeContext;
-use crate::runtime::observability::{task_meta, TaskMetadataReporter};
+use crate::runtime::observability::TaskMetadata;
 use datafusion::physical_plan::windows::BoundedWindowAggExec;
 
 #[cfg(test)]
 use crate::runtime::operators::window::store::WindowOperatorStore;
+
+pub const TASK_METADATA_ROWS_ACCEPTED: &str = "window_rows_accepted";
+pub const TASK_METADATA_ROWS_DROPPED_LATE: &str = "window_rows_dropped_late";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WindowOutputMode {
@@ -70,7 +73,7 @@ pub struct WindowOperator {
     output_schema: SchemaRef,
     input_schema: SchemaRef,
     ts_column_index: usize,
-    task_metadata: TaskMetadataReporter,
+    task_metadata: TaskMetadata,
 }
 
 impl fmt::Debug for WindowOperator {
@@ -110,7 +113,7 @@ impl WindowOperator {
             output_schema: built.output_schema,
             input_schema: built.input_schema,
             ts_column_index: built.ts_column_index,
-            task_metadata: TaskMetadataReporter::default(),
+            task_metadata: TaskMetadata::default(),
         }
     }
 
@@ -178,9 +181,9 @@ impl OperatorTrait for WindowOperator {
     async fn open(&mut self, context: &RuntimeContext) -> Result<()> {
         self.base.open(context).await?;
         self.task_metadata = context.task_metadata();
-        self.task_metadata.set(task_meta::WINDOW_ROWS_ACCEPTED, 0);
+        self.task_metadata.set(TASK_METADATA_ROWS_ACCEPTED, 0);
         self.task_metadata
-            .set(task_meta::WINDOW_ROWS_DROPPED_LATE, 0);
+            .set(TASK_METADATA_ROWS_DROPPED_LATE, 0);
 
         if self.state.is_none() {
             let backend = context
@@ -259,11 +262,11 @@ impl OperatorTrait for WindowOperator {
                         .await;
                     debug_assert!(dropped <= input_rows);
                     self.task_metadata.increment_u64(
-                        task_meta::WINDOW_ROWS_ACCEPTED,
+                        TASK_METADATA_ROWS_ACCEPTED,
                         (input_rows - dropped) as u64,
                     );
                     self.task_metadata
-                        .increment_u64(task_meta::WINDOW_ROWS_DROPPED_LATE, dropped as u64);
+                        .increment_u64(TASK_METADATA_ROWS_DROPPED_LATE, dropped as u64);
                     OperatorPollResult::Continue
                 }
                 Message::Watermark(watermark) => {

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -23,6 +23,7 @@ use crate::runtime::operators::window::state::{WindowOperatorState, WindowStateS
 use crate::runtime::operators::window::store::{open_window_operator_store, StateNamespace};
 use crate::runtime::operators::window::TileConfig;
 use crate::runtime::runtime_context::RuntimeContext;
+use crate::runtime::observability::{task_meta, TaskMetadataReporter};
 use datafusion::physical_plan::windows::BoundedWindowAggExec;
 
 #[cfg(test)]
@@ -69,6 +70,7 @@ pub struct WindowOperator {
     output_schema: SchemaRef,
     input_schema: SchemaRef,
     ts_column_index: usize,
+    task_metadata: TaskMetadataReporter,
 }
 
 impl fmt::Debug for WindowOperator {
@@ -108,6 +110,7 @@ impl WindowOperator {
             output_schema: built.output_schema,
             input_schema: built.input_schema,
             ts_column_index: built.ts_column_index,
+            task_metadata: TaskMetadataReporter::default(),
         }
     }
 
@@ -174,6 +177,10 @@ impl WindowOperator {
 impl OperatorTrait for WindowOperator {
     async fn open(&mut self, context: &RuntimeContext) -> Result<()> {
         self.base.open(context).await?;
+        self.task_metadata = context.task_metadata();
+        self.task_metadata.set(task_meta::WINDOW_ROWS_ACCEPTED, 0);
+        self.task_metadata
+            .set(task_meta::WINDOW_ROWS_DROPPED_LATE, 0);
 
         if self.state.is_none() {
             let backend = context
@@ -251,6 +258,12 @@ impl OperatorTrait for WindowOperator {
                         )
                         .await;
                     debug_assert!(dropped <= input_rows);
+                    self.task_metadata.increment_u64(
+                        task_meta::WINDOW_ROWS_ACCEPTED,
+                        (input_rows - dropped) as u64,
+                    );
+                    self.task_metadata
+                        .increment_u64(task_meta::WINDOW_ROWS_DROPPED_LATE, dropped as u64);
                     OperatorPollResult::Continue
                 }
                 Message::Watermark(watermark) => {

--- a/src/runtime/operators/window/tests/harness.rs
+++ b/src/runtime/operators/window/tests/harness.rs
@@ -28,6 +28,7 @@ use crate::runtime::operators::window::store::{
 };
 use crate::runtime::operators::window::TileConfig;
 use crate::runtime::runtime_context::RuntimeContext;
+use crate::runtime::observability::TaskMetadataReporter;
 use crate::runtime::state::OperatorStates;
 
 pub fn test_input_schema() -> SchemaRef {
@@ -100,6 +101,7 @@ pub struct Harness {
     pub op: WindowOperator,
     pub store: Arc<InMemWindowStore>,
     pub namespace: StateNamespace,
+    pub task_metadata: TaskMetadataReporter,
 }
 
 impl Harness {
@@ -123,6 +125,7 @@ impl Harness {
         namespace: StateNamespace,
     ) -> Self {
         let ctx = runtime_context();
+        let task_metadata = ctx.task_metadata();
         let mut op = WindowOperator::new(OperatorConfig::WindowConfig(cfg));
         op.set_state_with_store_and_ns(operator_store, namespace.clone());
         op.open(&ctx).await.expect("open");
@@ -130,6 +133,7 @@ impl Harness {
             op,
             store,
             namespace,
+            task_metadata,
         }
     }
 

--- a/src/runtime/operators/window/tests/harness.rs
+++ b/src/runtime/operators/window/tests/harness.rs
@@ -28,7 +28,7 @@ use crate::runtime::operators::window::store::{
 };
 use crate::runtime::operators::window::TileConfig;
 use crate::runtime::runtime_context::RuntimeContext;
-use crate::runtime::observability::TaskMetadataReporter;
+use crate::runtime::observability::TaskMetadata;
 use crate::runtime::state::OperatorStates;
 
 pub fn test_input_schema() -> SchemaRef {
@@ -101,7 +101,7 @@ pub struct Harness {
     pub op: WindowOperator,
     pub store: Arc<InMemWindowStore>,
     pub namespace: StateNamespace,
-    pub task_metadata: TaskMetadataReporter,
+    pub task_metadata: TaskMetadata,
 }
 
 impl Harness {

--- a/src/runtime/operators/window/tests/semantics.rs
+++ b/src/runtime/operators/window/tests/semantics.rs
@@ -17,7 +17,9 @@ use crate::runtime::operators::window::tests::harness::{
     assert_window_values, batch, key, keyed_message, runtime_context, watermark_message,
     window_exec_from_sql, Harness, WoWroHarness,
 };
-use crate::runtime::observability::task_meta;
+use crate::runtime::operators::window::{
+    TASK_METADATA_ROWS_ACCEPTED, TASK_METADATA_ROWS_DROPPED_LATE,
+};
 
 const SQL: &str = r#"SELECT timestamp, value, partition_key, SUM(value) OVER w as sum_val
 FROM test_table
@@ -132,17 +134,14 @@ async fn watermark_rejects_late_rows_for_unseen_key() {
     let partition = PartitionKey::new(&h.namespace, &key("B"));
     let meta = h.store.load_key_state(&partition).await.expect("state");
     assert_eq!(meta.next_seq, 0);
-    let metadata = h.task_metadata.snapshot();
     assert_eq!(
-        metadata
-            .get(task_meta::WINDOW_ROWS_ACCEPTED)
-            .map(String::as_str),
+        h.task_metadata.get(TASK_METADATA_ROWS_ACCEPTED).as_deref(),
         Some("0")
     );
     assert_eq!(
-        metadata
-            .get(task_meta::WINDOW_ROWS_DROPPED_LATE)
-            .map(String::as_str),
+        h.task_metadata
+            .get(TASK_METADATA_ROWS_DROPPED_LATE)
+            .as_deref(),
         Some("1")
     );
 }

--- a/src/runtime/operators/window/tests/semantics.rs
+++ b/src/runtime/operators/window/tests/semantics.rs
@@ -17,6 +17,7 @@ use crate::runtime::operators::window::tests::harness::{
     assert_window_values, batch, key, keyed_message, runtime_context, watermark_message,
     window_exec_from_sql, Harness, WoWroHarness,
 };
+use crate::runtime::observability::task_meta;
 
 const SQL: &str = r#"SELECT timestamp, value, partition_key, SUM(value) OVER w as sum_val
 FROM test_table
@@ -131,6 +132,19 @@ async fn watermark_rejects_late_rows_for_unseen_key() {
     let partition = PartitionKey::new(&h.namespace, &key("B"));
     let meta = h.store.load_key_state(&partition).await.expect("state");
     assert_eq!(meta.next_seq, 0);
+    let metadata = h.task_metadata.snapshot();
+    assert_eq!(
+        metadata
+            .get(task_meta::WINDOW_ROWS_ACCEPTED)
+            .map(String::as_str),
+        Some("0")
+    );
+    assert_eq!(
+        metadata
+            .get(task_meta::WINDOW_ROWS_DROPPED_LATE)
+            .map(String::as_str),
+        Some("1")
+    );
 }
 
 #[tokio::test]

--- a/src/runtime/operators/window/tests/smoke.rs
+++ b/src/runtime/operators/window/tests/smoke.rs
@@ -7,8 +7,9 @@ use crate::runtime::operators::window::operator::WindowOperatorConfig;
 use crate::runtime::operators::window::tests::harness::{
     assert_window_values, batch, run_wo, window_exec_from_sql, Harness, WoWroHarness,
 };
-use crate::runtime::operators::window::{TileConfig, TimeGranularity};
-use crate::runtime::observability::task_meta;
+use crate::runtime::operators::window::{
+    TileConfig, TimeGranularity, TASK_METADATA_ROWS_ACCEPTED, TASK_METADATA_ROWS_DROPPED_LATE,
+};
 
 #[tokio::test]
 async fn drop_post_frontier_late_events() {
@@ -32,17 +33,14 @@ WINDOW w AS (
     let out = h.watermark_and_output(3000).await;
     let _ = h.drain_passthrough_watermark().await;
     assert_eq!(out.num_rows(), 0);
-    let metadata = h.task_metadata.snapshot();
     assert_eq!(
-        metadata
-            .get(task_meta::WINDOW_ROWS_ACCEPTED)
-            .map(String::as_str),
+        h.task_metadata.get(TASK_METADATA_ROWS_ACCEPTED).as_deref(),
         Some("2")
     );
     assert_eq!(
-        metadata
-            .get(task_meta::WINDOW_ROWS_DROPPED_LATE)
-            .map(String::as_str),
+        h.task_metadata
+            .get(TASK_METADATA_ROWS_DROPPED_LATE)
+            .as_deref(),
         Some("1")
     );
 }
@@ -64,17 +62,14 @@ WINDOW w AS (
     let wm = h.drain_passthrough_watermark().await;
     assert_eq!(wm, MAX_WATERMARK_VALUE);
     assert_eq!(out.num_rows(), 1);
-    let metadata = h.task_metadata.snapshot();
     assert_eq!(
-        metadata
-            .get(task_meta::WINDOW_ROWS_ACCEPTED)
-            .map(String::as_str),
+        h.task_metadata.get(TASK_METADATA_ROWS_ACCEPTED).as_deref(),
         Some("1")
     );
     assert_eq!(
-        metadata
-            .get(task_meta::WINDOW_ROWS_DROPPED_LATE)
-            .map(String::as_str),
+        h.task_metadata
+            .get(TASK_METADATA_ROWS_DROPPED_LATE)
+            .as_deref(),
         Some("0")
     );
 }

--- a/src/runtime/operators/window/tests/smoke.rs
+++ b/src/runtime/operators/window/tests/smoke.rs
@@ -8,6 +8,7 @@ use crate::runtime::operators::window::tests::harness::{
     assert_window_values, batch, run_wo, window_exec_from_sql, Harness, WoWroHarness,
 };
 use crate::runtime::operators::window::{TileConfig, TimeGranularity};
+use crate::runtime::observability::task_meta;
 
 #[tokio::test]
 async fn drop_post_frontier_late_events() {
@@ -31,6 +32,19 @@ WINDOW w AS (
     let out = h.watermark_and_output(3000).await;
     let _ = h.drain_passthrough_watermark().await;
     assert_eq!(out.num_rows(), 0);
+    let metadata = h.task_metadata.snapshot();
+    assert_eq!(
+        metadata
+            .get(task_meta::WINDOW_ROWS_ACCEPTED)
+            .map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        metadata
+            .get(task_meta::WINDOW_ROWS_DROPPED_LATE)
+            .map(String::as_str),
+        Some("1")
+    );
 }
 
 #[tokio::test]
@@ -50,6 +64,19 @@ WINDOW w AS (
     let wm = h.drain_passthrough_watermark().await;
     assert_eq!(wm, MAX_WATERMARK_VALUE);
     assert_eq!(out.num_rows(), 1);
+    let metadata = h.task_metadata.snapshot();
+    assert_eq!(
+        metadata
+            .get(task_meta::WINDOW_ROWS_ACCEPTED)
+            .map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        metadata
+            .get(task_meta::WINDOW_ROWS_DROPPED_LATE)
+            .map(String::as_str),
+        Some("0")
+    );
 }
 
 #[tokio::test]

--- a/src/runtime/runtime_context.rs
+++ b/src/runtime/runtime_context.rs
@@ -7,7 +7,7 @@ use crate::common::types::PipelineId;
 use crate::runtime::execution_graph::ExecutionGraph;
 use crate::{common::Message, runtime::functions::source::request_source::PendingRequest};
 use crate::runtime::operators::source::SourceHandles;
-use crate::runtime::observability::TaskMetadataReporter;
+use crate::runtime::observability::TaskMetadata;
 use crate::runtime::state::OperatorStates;
 use crate::runtime::VertexId;
 
@@ -24,7 +24,7 @@ pub struct RuntimeContext {
     pipeline_id: Option<PipelineId>,
     operator_id: Option<String>,
     source_handles: Option<SourceHandles>,
-    task_metadata: TaskMetadataReporter,
+    task_metadata: TaskMetadata,
 
     request_sink_source_request_receiver: Option<Arc<Mutex<mpsc::Receiver<PendingRequest>>>>,
     request_sink_source_response_sender: Option<mpsc::Sender<Message>>,
@@ -51,7 +51,7 @@ impl RuntimeContext {
             pipeline_id: None,
             operator_id: None,
             source_handles: None,
-            task_metadata: TaskMetadataReporter::default(),
+            task_metadata: TaskMetadata::default(),
             request_sink_source_request_receiver: None,
             request_sink_source_response_sender: None,
         }
@@ -121,7 +121,7 @@ impl RuntimeContext {
         self.source_handles.as_ref()
     }
 
-    pub fn task_metadata(&self) -> TaskMetadataReporter {
+    pub fn task_metadata(&self) -> TaskMetadata {
         self.task_metadata.clone()
     }
 

--- a/src/runtime/runtime_context.rs
+++ b/src/runtime/runtime_context.rs
@@ -7,6 +7,7 @@ use crate::common::types::PipelineId;
 use crate::runtime::execution_graph::ExecutionGraph;
 use crate::{common::Message, runtime::functions::source::request_source::PendingRequest};
 use crate::runtime::operators::source::SourceHandles;
+use crate::runtime::observability::TaskMetadataReporter;
 use crate::runtime::state::OperatorStates;
 use crate::runtime::VertexId;
 
@@ -23,6 +24,7 @@ pub struct RuntimeContext {
     pipeline_id: Option<PipelineId>,
     operator_id: Option<String>,
     source_handles: Option<SourceHandles>,
+    task_metadata: TaskMetadataReporter,
 
     request_sink_source_request_receiver: Option<Arc<Mutex<mpsc::Receiver<PendingRequest>>>>,
     request_sink_source_response_sender: Option<mpsc::Sender<Message>>,
@@ -49,6 +51,7 @@ impl RuntimeContext {
             pipeline_id: None,
             operator_id: None,
             source_handles: None,
+            task_metadata: TaskMetadataReporter::default(),
             request_sink_source_request_receiver: None,
             request_sink_source_response_sender: None,
         }
@@ -116,6 +119,10 @@ impl RuntimeContext {
 
     pub fn source_handles(&self) -> Option<&SourceHandles> {
         self.source_handles.as_ref()
+    }
+
+    pub fn task_metadata(&self) -> TaskMetadataReporter {
+        self.task_metadata.clone()
     }
 
     pub fn set_request_sink_source_request_receiver(

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -12,7 +12,7 @@ use crate::{
             METRIC_STREAM_TASK_MESSAGES_RECV, METRIC_STREAM_TASK_MESSAGES_SENT,
             METRIC_STREAM_TASK_RECORDS_RECV, METRIC_STREAM_TASK_RECORDS_SENT,
         },
-        observability::snapshot_types::{TaskSnapshot, StreamTaskStatus},
+        observability::{TaskMetadata, TaskSnapshot, StreamTaskStatus},
         operators::operator::{
             create_operator, MessageStream, OperatorConfig, OperatorPollResult, OperatorTrait,
             OperatorType,
@@ -856,11 +856,8 @@ impl StreamTask {
     }
 
     pub async fn get_state(&self) -> TaskSnapshot {
-        let mut metadata = self
-            .runtime_context
-            .source_handles()
-            .map(|handles| handles.task_metadata(&self.vertex_id))
-            .unwrap_or_default();
+        // Detach from the live bag so later operator writes do not mutate the snapshot.
+        let metadata = TaskMetadata::default();
         metadata.extend(&self.runtime_context.task_metadata());
         TaskSnapshot {
             vertex_id: self.vertex_id.clone(),

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -861,7 +861,7 @@ impl StreamTask {
             .source_handles()
             .map(|handles| handles.task_metadata(&self.vertex_id))
             .unwrap_or_default();
-        metadata.extend(self.runtime_context.task_metadata().snapshot());
+        metadata.extend(&self.runtime_context.task_metadata());
         TaskSnapshot {
             vertex_id: self.vertex_id.clone(),
             status: StreamTaskStatus::from(self.status.load(Ordering::SeqCst)),

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -856,11 +856,12 @@ impl StreamTask {
     }
 
     pub async fn get_state(&self) -> TaskSnapshot {
-        let metadata = self
+        let mut metadata = self
             .runtime_context
             .source_handles()
             .map(|handles| handles.task_metadata(&self.vertex_id))
             .unwrap_or_default();
+        metadata.extend(self.runtime_context.task_metadata().snapshot());
         TaskSnapshot {
             vertex_id: self.vertex_id.clone(),
             status: StreamTaskStatus::from(self.status.load(Ordering::SeqCst)),

--- a/src/runtime/worker.rs
+++ b/src/runtime/worker.rs
@@ -5,7 +5,7 @@ use crate::runtime::checkpoint::{SerializedRestore, TaskKey};
 use crate::runtime::VertexId;
 use crate::runtime::health::WorkerHealth;
 use crate::runtime::metrics::{MetricsLabels, TaskMetrics, WorkerAggregateMetrics};
-use crate::runtime::observability::snapshot_types::StreamTaskStatus;
+use crate::runtime::observability::{StreamTaskStatus, TaskMetadata};
 use crate::transport::{transport_backend_actor::TransportBackendType, TransportBackend, TransportBackendTrait};
 use crate::transport::transport_backend_actor::{TransportBackendActor, TransportBackendActorMessage};
 use std::{collections::HashMap};
@@ -245,7 +245,7 @@ impl Worker {
         let mut task_statuses: HashMap<VertexId, StreamTaskStatus> = HashMap::new();
         let mut task_metrics: HashMap<VertexId, TaskMetrics> = HashMap::new();
         let mut task_operator_metrics: HashMap<VertexId, TaskOperatorMetrics> = HashMap::new();
-        let mut task_metadata: HashMap<VertexId, HashMap<String, String>> = HashMap::new();
+        let mut task_metadata: HashMap<VertexId, TaskMetadata> = HashMap::new();
 
         for result in task_results {
             if let Ok((vertex_id, state)) = result {

--- a/src/tests/inprocess/watermark_streaming.rs
+++ b/src/tests/inprocess/watermark_streaming.rs
@@ -140,6 +140,28 @@ pub(crate) async fn run_watermark_window_pipeline(
     wait_for_status(&worker, StreamTaskStatus::Opened, Duration::from_secs(10)).await;
     worker.signal_tasks_run().await;
     wait_for_status(&worker, StreamTaskStatus::Finished, Duration::from_secs(60)).await;
+    let worker_snapshot = worker.get_state().await;
+    let window_drops = worker_snapshot
+        .task_metadata
+        .iter()
+        .filter_map(|(vertex_id, metadata)| {
+            metadata
+                .get(crate::runtime::observability::task_meta::WINDOW_ROWS_DROPPED_LATE)
+                .map(|dropped| (vertex_id, dropped))
+        })
+        .map(|(vertex_id, dropped)| {
+            dropped
+                .parse::<u64>()
+                .map(|dropped| (vertex_id, dropped))
+                .map_err(|e| anyhow::anyhow!("bad window_rows_dropped_late for {vertex_id}: {e}"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    anyhow::ensure!(
+        !window_drops.is_empty(),
+        "no window late-drop accounting in worker snapshot"
+    );
+    let late_dropped: u64 = window_drops.iter().map(|(_, dropped)| *dropped).sum();
+    assert_eq!(late_dropped, 0, "window pipeline dropped late rows");
     worker.signal_tasks_close().await;
     wait_for_status(&worker, StreamTaskStatus::Closed, Duration::from_secs(10)).await;
     worker.close();

--- a/src/tests/inprocess/watermark_streaming.rs
+++ b/src/tests/inprocess/watermark_streaming.rs
@@ -146,7 +146,7 @@ pub(crate) async fn run_watermark_window_pipeline(
         .iter()
         .filter_map(|(vertex_id, metadata)| {
             metadata
-                .get(crate::runtime::observability::task_meta::WINDOW_ROWS_DROPPED_LATE)
+                .get(crate::runtime::operators::window::TASK_METADATA_ROWS_DROPPED_LATE)
                 .map(|dropped| (vertex_id, dropped))
         })
         .map(|(vertex_id, dropped)| {

--- a/src/tests/support/checkpoint/sink_oracle.rs
+++ b/src/tests/support/checkpoint/sink_oracle.rs
@@ -8,7 +8,11 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use crate::runtime::functions::source::datagen_source::{
     DatagenSourceConfig, DatagenSourceFunction,
 };
-use crate::runtime::observability::{task_meta, PipelineSnapshot};
+use crate::runtime::observability::PipelineSnapshot;
+use crate::runtime::operators::source::TASK_METADATA_RECORDS_GENERATED;
+use crate::runtime::operators::window::{
+    TASK_METADATA_ROWS_ACCEPTED, TASK_METADATA_ROWS_DROPPED_LATE,
+};
 use crate::tests::support::cluster_harness::{MasterHandle, RuntimeEnv};
 use crate::storage::InMemoryStorageSnapshot;
 
@@ -259,7 +263,7 @@ fn task_record_counts(snapshot: &PipelineSnapshot) -> Result<Vec<(i32, u64)>> {
     let mut counts = Vec::new();
     for worker in snapshot.worker_states.values() {
         for (vertex_id, meta) in &worker.task_metadata {
-            let Some(records) = meta.get(task_meta::RECORDS_GENERATED) else {
+            let Some(records) = meta.get(TASK_METADATA_RECORDS_GENERATED) else {
                 continue;
             };
             let task_index = task_index_from_vertex_id(vertex_id.as_ref())?;
@@ -273,7 +277,7 @@ fn task_record_counts(snapshot: &PipelineSnapshot) -> Result<Vec<(i32, u64)>> {
     if counts.is_empty() {
         return Err(anyhow!(
             "no task metadata with {} in pipeline snapshot",
-            task_meta::RECORDS_GENERATED
+            TASK_METADATA_RECORDS_GENERATED
         ));
     }
     Ok(counts)
@@ -283,28 +287,28 @@ fn assert_no_window_late_drops(snapshot: &PipelineSnapshot) -> Result<()> {
     let mut window_tasks = Vec::new();
     for worker in snapshot.worker_states.values() {
         for (vertex_id, meta) in &worker.task_metadata {
-            let Some(dropped) = meta.get(task_meta::WINDOW_ROWS_DROPPED_LATE) else {
+            let Some(dropped) = meta.get(TASK_METADATA_ROWS_DROPPED_LATE) else {
                 continue;
             };
             let dropped = dropped.parse::<u64>().map_err(|e| {
                 anyhow!(
                     "bad {} for {vertex_id}: {e}",
-                    task_meta::WINDOW_ROWS_DROPPED_LATE
+                    TASK_METADATA_ROWS_DROPPED_LATE
                 )
             })?;
             let accepted = meta
-                .get(task_meta::WINDOW_ROWS_ACCEPTED)
+                .get(TASK_METADATA_ROWS_ACCEPTED)
                 .ok_or_else(|| {
                     anyhow!(
                         "missing {} for window task {vertex_id}",
-                        task_meta::WINDOW_ROWS_ACCEPTED
+                        TASK_METADATA_ROWS_ACCEPTED
                     )
                 })?
                 .parse::<u64>()
                 .map_err(|e| {
                     anyhow!(
                         "bad {} for {vertex_id}: {e}",
-                        task_meta::WINDOW_ROWS_ACCEPTED
+                        TASK_METADATA_ROWS_ACCEPTED
                     )
                 })?;
             window_tasks.push((vertex_id, accepted, dropped));
@@ -313,7 +317,7 @@ fn assert_no_window_late_drops(snapshot: &PipelineSnapshot) -> Result<()> {
     if window_tasks.is_empty() {
         return Err(anyhow!(
             "no window task metadata with {}",
-            task_meta::WINDOW_ROWS_DROPPED_LATE
+            TASK_METADATA_ROWS_DROPPED_LATE
         ));
     }
     let dropped: u64 = window_tasks.iter().map(|(_, _, dropped)| *dropped).sum();

--- a/src/tests/support/checkpoint/sink_oracle.rs
+++ b/src/tests/support/checkpoint/sink_oracle.rs
@@ -279,6 +279,52 @@ fn task_record_counts(snapshot: &PipelineSnapshot) -> Result<Vec<(i32, u64)>> {
     Ok(counts)
 }
 
+fn assert_no_window_late_drops(snapshot: &PipelineSnapshot) -> Result<()> {
+    let mut window_tasks = Vec::new();
+    for worker in snapshot.worker_states.values() {
+        for (vertex_id, meta) in &worker.task_metadata {
+            let Some(dropped) = meta.get(task_meta::WINDOW_ROWS_DROPPED_LATE) else {
+                continue;
+            };
+            let dropped = dropped.parse::<u64>().map_err(|e| {
+                anyhow!(
+                    "bad {} for {vertex_id}: {e}",
+                    task_meta::WINDOW_ROWS_DROPPED_LATE
+                )
+            })?;
+            let accepted = meta
+                .get(task_meta::WINDOW_ROWS_ACCEPTED)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "missing {} for window task {vertex_id}",
+                        task_meta::WINDOW_ROWS_ACCEPTED
+                    )
+                })?
+                .parse::<u64>()
+                .map_err(|e| {
+                    anyhow!(
+                        "bad {} for {vertex_id}: {e}",
+                        task_meta::WINDOW_ROWS_ACCEPTED
+                    )
+                })?;
+            window_tasks.push((vertex_id, accepted, dropped));
+        }
+    }
+    if window_tasks.is_empty() {
+        return Err(anyhow!(
+            "no window task metadata with {}",
+            task_meta::WINDOW_ROWS_DROPPED_LATE
+        ));
+    }
+    let dropped: u64 = window_tasks.iter().map(|(_, _, dropped)| *dropped).sum();
+    if dropped != 0 {
+        return Err(anyhow!(
+            "window dropped {dropped} late rows: {window_tasks:?}"
+        ));
+    }
+    Ok(())
+}
+
 fn aggregates_match(expected: &WindowAggregateRow, actual: &WindowAggregateRow) -> bool {
     const EPSILON: f64 = 1e-9;
     expected.value.to_bits() == actual.value.to_bits()
@@ -380,6 +426,7 @@ pub(super) async fn assert_sink_matches_offline_datagen(
     let input_rows = materialize_input_rows(&task_counts, workload)?;
 
     if workload == CheckpointWorkload::Window {
+        assert_no_window_late_drops(&snapshot)?;
         let expected = expected_window_rows(input_rows);
         let actual = window_sink_rows(storage)?;
         return assert_window_rows(&expected, &actual, env, total, &task_counts);


### PR DESCRIPTION
## Summary
- add a generic task-local metadata reporter that flows through task and worker snapshots
- publish window accepted and late-dropped row counts through that existing path
- require zero unexpected late drops in checkpoint and watermark correctness tests

## Test plan
- `cargo test --lib runtime::operators::window::tests::smoke::drop_post_frontier_late_events -- --exact` *(running locally)*
- `cargo test --lib runtime::operators::window::tests::semantics::watermark_rejects_late_rows_for_unseen_key -- --exact` *(running locally)*
- `cargo test --lib runtime::tests::checkpoint_tests::local::test_local_single_worker_window_checkpoint_restore -- --exact` *(running locally)*


Made with [Cursor](https://cursor.com)