### PR TITLE
Place watermark assign via event-time plan lineage

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -10,15 +10,32 @@ on:
   workflow_dispatch:
     inputs:
       profile:
-        description: "Test profile (default=unit+inprocess; all=default+docker+kube)"
+        description: "Test profile (default=unit+inprocess; all=default+docker+kube; kube-stress / inproc-stress)"
         type: choice
         options:
           - default
           - docker
           - kube
           - all
-          - stress
+          - kube-stress
+          - inproc-stress
         default: default
+      stress_test:
+        description: "Exact test name for inproc-stress (ignored otherwise)"
+        type: string
+        default: test_local_multi_worker_window_checkpoint_restore
+      stress_machines:
+        description: "CI runners (machines) for kube-stress / inproc-stress"
+        type: string
+        default: "3"
+      stress_shards_per_machine:
+        description: "Parallel stress processes per machine (kube default 1 = one Kind cluster)"
+        type: string
+        default: "1"
+      stress_runs_per_shard:
+        description: "Iterations per shard for kube-stress / inproc-stress"
+        type: string
+        default: "10"
 
 concurrency:
   # PRs cancel superseded runs; scheduled stress must not cancel itself (jobs can exceed 1h).
@@ -137,14 +154,65 @@ jobs:
       - if: always()
         run: scripts/kube-test-env destroy
 
+  # Resolve machines × shards-per-machine for stress jobs.
+  # machine = GitHub runner (isolation); shard = parallel process on that runner
+  # (kube: usually 1 = one Kind cluster; inproc: usually 1 to avoid interference).
+  stress-config:
+    if: >
+      github.event_name == 'schedule' ||
+      inputs.profile == 'kube-stress' ||
+      inputs.profile == 'inproc-stress'
+    runs-on: ubuntu-latest
+    outputs:
+      machine_ids: ${{ steps.config.outputs.machine_ids }}
+      shards_per_machine: ${{ steps.config.outputs.shards_per_machine }}
+      runs_per_shard: ${{ steps.config.outputs.runs_per_shard }}
+    steps:
+      - id: config
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            machines=3
+            shards=1
+            runs=10
+          else
+            machines="${{ inputs.stress_machines }}"
+            shards="${{ inputs.stress_shards_per_machine }}"
+            runs="${{ inputs.stress_runs_per_shard }}"
+          fi
+          for name in machines shards runs; do
+            val="${!name}"
+            if [[ ! "$val" =~ ^[1-9][0-9]*$ ]]; then
+              echo "$name must be a positive integer, got: $val" >&2
+              exit 2
+            fi
+          done
+          if (( machines > 16 )); then
+            echo "stress_machines max is 16, got: $machines" >&2
+            exit 2
+          fi
+          machine_ids="$(python3 -c "import json; print(json.dumps(list(range(1, int('${machines}') + 1))))")"
+          echo "machines=$machines shards_per_machine=$shards runs_per_shard=$runs"
+          echo "machine_ids=$machine_ids"
+          {
+            echo "machine_ids=$machine_ids"
+            echo "shards_per_machine=$shards"
+            echo "runs_per_shard=$runs"
+          } >> "$GITHUB_OUTPUT"
+
   kube-stress:
-    if: github.event_name == 'schedule' || inputs.profile == 'stress'
+    needs: stress-config
+    if: >
+      always() &&
+      needs.stress-config.result == 'success' &&
+      (github.event_name == 'schedule' || inputs.profile == 'kube-stress')
     runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        machine: ${{ fromJSON(needs.stress-config.outputs.machine_ids) }}
     env:
       CARGO_INCREMENTAL: "0"
       VOLGA_DOCKER_CACHE: gha
@@ -170,11 +238,77 @@ jobs:
       - uses: helm/kind-action@v1
         with:
           install_only: true
-      - run: scripts/test stress --env kube --all --runs-per-shard 10 --shards 1 --fresh-cluster
+      - name: Run kube stress
+        run: |
+          set -euo pipefail
+          shards="${{ needs.stress-config.outputs.shards_per_machine }}"
+          runs="${{ needs.stress-config.outputs.runs_per_shard }}"
+          echo "kube-stress machine=${{ matrix.machine }} shards_per_machine=$shards runs_per_shard=$runs"
+          scripts/test stress --env kube --all \
+            --runs-per-shard "$runs" \
+            --shards "$shards" \
+            --fresh-cluster
       - if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: kube-stress-logs-shard-${{ matrix.shard }}
+          name: kube-stress-logs-machine-${{ matrix.machine }}
+          path: target/stress/
+          if-no-files-found: warn
+          retention-days: 14
+
+  # Inprocess stress with the same machine × shard knobs (machine = runner isolation).
+  inproc-stress:
+    needs: stress-config
+    if: >
+      always() &&
+      needs.stress-config.result == 'success' &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.profile == 'inproc-stress'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ${{ fromJSON(needs.stress-config.outputs.machine_ids) }}
+    env:
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            pkg-config \
+            protobuf-compiler \
+            libprotobuf-dev \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            libsasl2-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Run inproc stress
+        run: |
+          set -euo pipefail
+          test_name="${{ inputs.stress_test }}"
+          shards="${{ needs.stress-config.outputs.shards_per_machine }}"
+          runs="${{ needs.stress-config.outputs.runs_per_shard }}"
+          if [[ -z "$test_name" ]]; then
+            echo "stress_test input is required for inproc-stress" >&2
+            exit 2
+          fi
+          echo "inproc-stress machine=${{ matrix.machine }} test=$test_name shards_per_machine=$shards runs_per_shard=$runs"
+          scripts/test stress --env local \
+            --test "$test_name" \
+            --runs-per-shard "$runs" \
+            --shards "$shards"
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: inproc-stress-logs-machine-${{ matrix.machine }}
           path: target/stress/
           if-no-files-found: warn
           retention-days: 14

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,8 +31,21 @@ CI runs `default` as the required job, plus parallel non-blocking `docker` and
 ### One-off CI runs (`workflow_dispatch`)
 
 GitHub → **Actions** → **Rust tests** → **Run workflow**: pick branch +
-`profile` (`default` / `unit` / `inprocess` / `docker` / `kube` / `all` /
-`stress`).
+`profile` (`default` / `docker` / `kube` / `all` / `kube-stress` /
+`inproc-stress`).
+
+Stress knobs (shared by `kube-stress` / `inproc-stress`):
+
+| Input | Default | Meaning |
+| --- | --- | --- |
+| `stress_machines` | `3` | GitHub runners (machine isolation) |
+| `stress_shards_per_machine` | `1` | Parallel stress processes per runner |
+| `stress_runs_per_shard` | `10` | Iterations per process |
+| `stress_test` | (inproc default) | Exact test name; `inproc-stress` only |
+
+Schedule uses 3 machines × 1 shard × 10 runs (kube). Prefer
+`stress_shards_per_machine=1` so parallelism comes from machines, not
+co-tenancy on one runner.
 
 Or from the CLI (same inputs):
 
@@ -43,11 +56,25 @@ gh workflow run rust-tests.yml --ref "$(git branch --show-current)" -f profile=d
 # Kube-only
 gh workflow run rust-tests.yml --ref "$(git branch --show-current)" -f profile=kube
 
-# On-demand kube stress (3 shards, same as the schedule)
-gh workflow run rust-tests.yml --ref "$(git branch --show-current)" -f profile=stress
+# On-demand kube stress (same shape as the schedule)
+gh workflow run rust-tests.yml --ref "$(git branch --show-current)" \
+  -f profile=kube-stress \
+  -f stress_machines=3 \
+  -f stress_shards_per_machine=1 \
+  -f stress_runs_per_shard=10
+
+# On-demand inprocess stress for one test (4 isolated runners)
+gh workflow run rust-tests.yml --ref "$(git branch --show-current)" \
+  -f profile=inproc-stress \
+  -f stress_test=test_local_multi_worker_window_checkpoint_restore \
+  -f stress_machines=4 \
+  -f stress_shards_per_machine=1 \
+  -f stress_runs_per_shard=10
 ```
 
-`stress` skips the normal test/docker/kube jobs and only runs `kube-stress`.
+`kube-stress` / `inproc-stress` skip the normal test/docker/kube jobs.
+`inproc-stress` runs `scripts/test stress --env local` for `stress_test`.
+Logs upload per machine from `target/stress/`.
 `docker` / `kube` run just that env job. `unit` / `inprocess` / `default` run
 the required `test` job with that profile (and may still start sibling
 docker/kube jobs unless you pick an env-only profile).
@@ -104,7 +131,7 @@ scripts/test inprocess --filter 'test(test_local_single_worker_window_checkpoint
 The stress runner repeats the **kube** suite (or selected kube tests) across
 parallel shards. It writes one log per shard under `target/stress/` and stops
 scheduling new iterations after the first failure. Prefer `--env kube` (Kind);
-CI schedule and on-demand `profile=stress` use the same path.
+CI schedule and on-demand `profile=kube-stress` use the same path.
 
 ```bash
 # Full kube profile, fresh Kind cluster each iteration.

--- a/scripts/stress-test
+++ b/scripts/stress-test
@@ -159,6 +159,10 @@ done
 
 echo "Stress logs: $LOG_DIR"
 if [[ "$failed" -ne 0 ]]; then
-  rg -n "Error: |=== $ENVIRONMENT shard .*: fail ===" "$LOG_DIR" || true
+  if command -v rg >/dev/null 2>&1; then
+    rg -n "Error: |=== $ENVIRONMENT shard .*: fail ===" "$LOG_DIR" || true
+  else
+    grep -REn "Error: |=== $ENVIRONMENT shard .*: fail ===" "$LOG_DIR" || true
+  fi
 fi
 exit "$failed"

--- a/src/api/event_time_placement.rs
+++ b/src/api/event_time_placement.rs
@@ -1,0 +1,325 @@
+//! Resolve where auto watermark assigners should attach by walking DataFusion
+//! plan lineage from a window's ORDER BY event-time column to its defining site.
+
+use datafusion::common::{Column, DataFusionError, Result};
+use datafusion::logical_expr::{Expr, LogicalPlan, Projection, Window};
+use petgraph::graph::NodeIndex;
+use petgraph::Direction;
+
+use super::logical_graph::LogicalGraph;
+use crate::runtime::operators::operator::OperatorConfig;
+
+/// Plan site where a watermark assigner should be attached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssignSite {
+    /// Column name in the assign site's output schema.
+    pub column_name: String,
+    /// Identity of the defining [`LogicalPlan`] node (`ptr` as usize).
+    pub plan_node_key: usize,
+}
+
+pub fn plan_node_key(plan: &LogicalPlan) -> usize {
+    plan as *const LogicalPlan as usize
+}
+
+fn unwrap_alias(expr: &Expr) -> &Expr {
+    match expr {
+        Expr::Alias(alias) => unwrap_alias(alias.expr.as_ref()),
+        other => other,
+    }
+}
+
+/// Extract the event-time column from the first window ORDER BY expression.
+pub fn event_time_column_from_window(window: &Window) -> Result<Column> {
+    let first = window.window_expr.first().ok_or_else(|| {
+        DataFusionError::Plan("window has no window expressions".to_string())
+    })?;
+
+    let Expr::WindowFunction(wf) = unwrap_alias(first) else {
+        return Err(DataFusionError::Plan(format!(
+            "expected WindowFunction for watermark lineage, got {first:?}"
+        )));
+    };
+
+    let order = wf.params.order_by.first().ok_or_else(|| {
+        DataFusionError::Plan("window ORDER BY is required for auto watermark placement".to_string())
+    })?;
+
+    match unwrap_alias(&order.expr) {
+        Expr::Column(col) => Ok(col.clone()),
+        other => Err(DataFusionError::Plan(format!(
+            "window ORDER BY must be a column for auto watermark placement, got {other:?}"
+        ))),
+    }
+}
+
+fn find_projection_expr<'a>(proj: &'a Projection, col_name: &str) -> Result<&'a Expr> {
+    for (idx, field) in proj.schema.fields().iter().enumerate() {
+        if field.name() == col_name {
+            return proj.expr.get(idx).ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "projection schema/expr mismatch looking for column '{col_name}'"
+                ))
+            });
+        }
+    }
+    for expr in &proj.expr {
+        let (_, name) = expr.qualified_name();
+        if name == col_name {
+            return Ok(expr);
+        }
+    }
+    Err(DataFusionError::Plan(format!(
+        "projection does not define event-time column '{col_name}'"
+    )))
+}
+
+/// Walk backward from `window.input` to the plan node that defines the event-time column.
+pub fn resolve_event_time_assign_site(window: &Window) -> Result<AssignSite> {
+    let mut col = event_time_column_from_window(window)?;
+    let mut current = window.input.as_ref();
+
+    loop {
+        match current {
+            LogicalPlan::Filter(filter) => {
+                current = filter.input.as_ref();
+            }
+            LogicalPlan::SubqueryAlias(alias) => {
+                current = alias.input.as_ref();
+            }
+            LogicalPlan::Sort(sort) => {
+                current = sort.input.as_ref();
+            }
+            LogicalPlan::Limit(limit) => {
+                current = limit.input.as_ref();
+            }
+            LogicalPlan::Repartition(repartition) => {
+                current = repartition.input.as_ref();
+            }
+            LogicalPlan::Distinct(distinct) => {
+                current = distinct.input().as_ref();
+            }
+            LogicalPlan::Projection(proj) => {
+                let expr = find_projection_expr(proj, &col.name)?;
+                match unwrap_alias(expr) {
+                    Expr::Column(inner) => {
+                        col = inner.clone();
+                        current = proj.input.as_ref();
+                    }
+                    _ => {
+                        // Computed (or otherwise non-column) expression — assign here.
+                        return Ok(AssignSite {
+                            column_name: col.name.clone(),
+                            plan_node_key: plan_node_key(current),
+                        });
+                    }
+                }
+            }
+            LogicalPlan::TableScan(_) => {
+                return Ok(AssignSite {
+                    column_name: col.name.clone(),
+                    plan_node_key: plan_node_key(current),
+                });
+            }
+            LogicalPlan::Join(_) | LogicalPlan::Union(_) => {
+                return Err(DataFusionError::Plan(
+                    "unsupported for auto watermark placement: multi-input operator on event-time lineage"
+                        .to_string(),
+                ));
+            }
+            other => {
+                return Err(DataFusionError::Plan(format!(
+                    "unsupported for auto watermark placement on event-time lineage: {}",
+                    other.display()
+                )));
+            }
+        }
+    }
+}
+
+fn reaches(graph: &LogicalGraph, from: NodeIndex, to: NodeIndex) -> bool {
+    if from == to {
+        return true;
+    }
+    let mut visited = std::collections::HashSet::new();
+    let mut stack = vec![from];
+    while let Some(n) = stack.pop() {
+        if !visited.insert(n) {
+            continue;
+        }
+        for neigh in graph.get_neighbors(n, Direction::Outgoing) {
+            if neigh == to {
+                return true;
+            }
+            stack.push(neigh);
+        }
+    }
+    false
+}
+
+/// Assign site must be upstream of the window's KeyBy (fragmenting edge), and must not
+/// land on KeyBy/Window themselves.
+pub fn validate_assign_before_window_keyby(
+    graph: &LogicalGraph,
+    assign_idx: NodeIndex,
+    window_idx: NodeIndex,
+) -> Result<()> {
+    let assign_cfg = &graph.get_node_by_index(assign_idx).operator_config;
+    if matches!(
+        assign_cfg,
+        OperatorConfig::KeyByConfig(_) | OperatorConfig::WindowConfig(_)
+    ) {
+        return Err(DataFusionError::Plan(
+            "event-time watermark assign must not land on KeyBy or Window".to_string(),
+        ));
+    }
+
+    let keyby_idx = graph
+        .get_neighbors(window_idx, Direction::Incoming)
+        .into_iter()
+        .find(|&idx| {
+            matches!(
+                graph.get_node_by_index(idx).operator_config,
+                OperatorConfig::KeyByConfig(_)
+            )
+        })
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "window has no KeyBy predecessor for watermark placement validation".to_string(),
+            )
+        })?;
+
+    if !reaches(graph, assign_idx, keyby_idx) {
+        return Err(DataFusionError::Plan(
+            "event-time assign site must be upstream of the window's KeyBy".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use datafusion::catalog::MemTable;
+    use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+    use datafusion::prelude::SessionContext;
+    use std::sync::Arc;
+
+    fn events_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]))
+    }
+
+    async fn plan_sql(sql: &str) -> LogicalPlan {
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
+        ctx.register_table("events", Arc::new(table)).unwrap();
+        let df = ctx.sql(sql).await.unwrap();
+        df.into_optimized_plan().unwrap()
+    }
+
+    fn find_window(plan: &LogicalPlan) -> Window {
+        let mut found = None;
+        plan.apply(|node| {
+            if let LogicalPlan::Window(w) = node {
+                found = Some(w.clone());
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })
+        .unwrap();
+        found.expect("expected a Window in plan")
+    }
+
+    fn find_plan_by_key<'a>(plan: &'a LogicalPlan, key: usize) -> Option<&'a LogicalPlan> {
+        let mut found = None;
+        plan.apply(|node| {
+            if plan_node_key(node) == key {
+                found = Some(node);
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })
+        .unwrap();
+        found
+    }
+
+    #[tokio::test]
+    async fn lineage_passthrough_column_stops_at_source() {
+        let plan = plan_sql(
+            "SELECT timestamp, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY timestamp \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM events",
+        )
+        .await;
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        assert_eq!(site.column_name, "timestamp");
+        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
+        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+    }
+
+    #[tokio::test]
+    async fn lineage_renamed_column_continues_to_source() {
+        let plan = plan_sql(
+            "SELECT event_time, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY event_time \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM (SELECT timestamp AS event_time, key, value FROM events)",
+        )
+        .await;
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        // After unwrapping the alias, assign on the source under the original column name.
+        assert_eq!(site.column_name, "timestamp");
+        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
+        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+    }
+
+    #[tokio::test]
+    async fn lineage_computed_event_time_stops_on_projection() {
+        let plan = plan_sql(
+            "SELECT event_time, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY event_time \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM (SELECT timestamp + INTERVAL '0' MILLISECOND AS event_time, key, value FROM events)",
+        )
+        .await;
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        assert_eq!(site.column_name, "event_time");
+        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
+        assert!(matches!(site_plan, LogicalPlan::Projection(_)));
+    }
+
+    #[tokio::test]
+    async fn lineage_join_on_path_errors() {
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
+        ctx.register_table("events", Arc::new(table)).unwrap();
+        let table2 = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
+        ctx.register_table("events2", Arc::new(table2)).unwrap();
+
+        let sql = "SELECT e.timestamp, e.key, e.value, \
+             SUM(e.value) OVER (PARTITION BY e.key ORDER BY e.timestamp \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM events e JOIN events2 e2 ON e.key = e2.key";
+        let df = ctx.sql(sql).await.unwrap();
+        let plan = df.into_optimized_plan().unwrap();
+        let window = find_window(&plan);
+        let err = resolve_event_time_assign_site(&window).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unsupported for auto watermark placement"),
+            "unexpected error: {msg}"
+        );
+    }
+}

--- a/src/api/event_time_placement.rs
+++ b/src/api/event_time_placement.rs
@@ -1,25 +1,38 @@
 //! Resolve where auto watermark assigners should attach by walking DataFusion
 //! plan lineage from a window's ORDER BY event-time column to its defining site.
 
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::{Column, DataFusionError, Result};
 use datafusion::logical_expr::{Expr, LogicalPlan, Projection, Window};
+use datafusion::physical_plan::expressions::Column as PhysicalColumn;
 use petgraph::graph::NodeIndex;
 use petgraph::Direction;
 
 use super::logical_graph::LogicalGraph;
+use crate::runtime::functions::map::MapFunction;
 use crate::runtime::operators::operator::OperatorConfig;
 
 /// Plan site where a watermark assigner should be attached.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AssignSite {
-    /// Column name in the assign site's output schema.
-    pub column_name: String,
-    /// Identity of the defining [`LogicalPlan`] node (`ptr` as usize).
-    pub plan_node_key: usize,
+pub enum AssignSite {
+    Source {
+        /// DF table name (lineage / diagnostics; graph match uses unique upstream Source).
+        table_name: String,
+        /// Column name in the source output schema.
+        column_name: String,
+    },
+    /// Projection that defines a computed (non-column) event-time expression.
+    Projection {
+        column_name: String,
+    },
 }
 
-pub fn plan_node_key(plan: &LogicalPlan) -> usize {
-    plan as *const LogicalPlan as usize
+impl AssignSite {
+    pub fn column_name(&self) -> &str {
+        match self {
+            Self::Source { column_name, .. } | Self::Projection { column_name } => column_name,
+        }
+    }
 }
 
 fn unwrap_alias(expr: &Expr) -> &Expr {
@@ -107,18 +120,16 @@ pub fn resolve_event_time_assign_site(window: &Window) -> Result<AssignSite> {
                         current = proj.input.as_ref();
                     }
                     _ => {
-                        // Computed (or otherwise non-column) expression — assign here.
-                        return Ok(AssignSite {
+                        return Ok(AssignSite::Projection {
                             column_name: col.name.clone(),
-                            plan_node_key: plan_node_key(current),
                         });
                     }
                 }
             }
-            LogicalPlan::TableScan(_) => {
-                return Ok(AssignSite {
+            LogicalPlan::TableScan(scan) => {
+                return Ok(AssignSite::Source {
+                    table_name: scan.table_name.table().to_string(),
                     column_name: col.name.clone(),
-                    plan_node_key: plan_node_key(current),
                 });
             }
             LogicalPlan::Join(_) | LogicalPlan::Union(_) => {
@@ -157,6 +168,23 @@ fn reaches(graph: &LogicalGraph, from: NodeIndex, to: NodeIndex) -> bool {
     false
 }
 
+fn window_keyby(graph: &LogicalGraph, window_idx: NodeIndex) -> Result<NodeIndex> {
+    graph
+        .get_neighbors(window_idx, Direction::Incoming)
+        .into_iter()
+        .find(|&idx| {
+            matches!(
+                graph.get_node_by_index(idx).operator_config,
+                OperatorConfig::KeyByConfig(_)
+            )
+        })
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "window has no KeyBy predecessor for watermark placement validation".to_string(),
+            )
+        })
+}
+
 /// Assign site must be upstream of the window's KeyBy (fragmenting edge), and must not
 /// land on KeyBy/Window themselves.
 pub fn validate_assign_before_window_keyby(
@@ -174,25 +202,142 @@ pub fn validate_assign_before_window_keyby(
         ));
     }
 
-    let keyby_idx = graph
-        .get_neighbors(window_idx, Direction::Incoming)
-        .into_iter()
-        .find(|&idx| {
-            matches!(
-                graph.get_node_by_index(idx).operator_config,
-                OperatorConfig::KeyByConfig(_)
-            )
-        })
-        .ok_or_else(|| {
-            DataFusionError::Plan(
-                "window has no KeyBy predecessor for watermark placement validation".to_string(),
-            )
-        })?;
-
+    let keyby_idx = window_keyby(graph, window_idx)?;
     if !reaches(graph, assign_idx, keyby_idx) {
         return Err(DataFusionError::Plan(
             "event-time assign site must be upstream of the window's KeyBy".to_string(),
         ));
+    }
+
+    Ok(())
+}
+
+fn window_order_by_column_name(graph: &LogicalGraph, window_idx: NodeIndex) -> Option<String> {
+    let OperatorConfig::WindowConfig(cfg) = &graph.get_node_by_index(window_idx).operator_config
+    else {
+        return None;
+    };
+    let order = cfg.window_exec.window_expr().first()?.order_by().first()?;
+    order
+        .expr
+        .as_any()
+        .downcast_ref::<PhysicalColumn>()
+        .map(|c| c.name().to_string())
+}
+
+fn projection_defines_computed_column(map: &MapFunction, column_name: &str) -> bool {
+    let MapFunction::Projection(proj) = map else {
+        return false;
+    };
+    for (idx, field) in proj.out_schema().fields().iter().enumerate() {
+        if field.name() != column_name {
+            continue;
+        }
+        let Some(expr) = proj.exprs().get(idx) else {
+            return false;
+        };
+        return !matches!(unwrap_alias(expr), Expr::Column(_));
+    }
+    false
+}
+
+fn find_assign_node(
+    graph: &LogicalGraph,
+    site: &AssignSite,
+    window_idxs: &[NodeIndex],
+) -> Result<NodeIndex> {
+    let keybys = window_idxs
+        .iter()
+        .map(|&w| window_keyby(graph, w))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut candidates = Vec::new();
+    for idx in graph.get_all_node_indices() {
+        if !keybys.iter().all(|&kb| reaches(graph, idx, kb)) {
+            continue;
+        }
+        match (site, &graph.get_node_by_index(idx).operator_config) {
+            (AssignSite::Source { .. }, OperatorConfig::SourceConfig(_)) => {
+                candidates.push(idx);
+            }
+            (AssignSite::Projection { column_name }, OperatorConfig::MapConfig(map))
+                if projection_defines_computed_column(map, column_name) =>
+            {
+                candidates.push(idx);
+            }
+            _ => {}
+        }
+    }
+
+    match candidates.as_slice() {
+        [only] => Ok(*only),
+        [] => Err(DataFusionError::Plan(format!(
+            "no logical node found for watermark assign site {site:?}"
+        ))),
+        _ => Err(DataFusionError::Plan(format!(
+            "ambiguous logical nodes for watermark assign site {site:?}: {} candidates",
+            candidates.len()
+        ))),
+    }
+}
+
+fn attach_assign(graph: &mut LogicalGraph, assign_idx: NodeIndex, column_name: String) -> Result<()> {
+    let cfg = graph.watermark_assign_config_for_column(column_name);
+    let node = graph
+        .get_node_by_index_mut(assign_idx)
+        .expect("assign node index must exist");
+    match &node.watermark_assign {
+        Some(existing) => {
+            if existing.time_hint != cfg.time_hint {
+                return Err(DataFusionError::Plan(format!(
+                    "conflicting watermark assign time hints on {}: {:?} vs {:?}",
+                    node.operator_id, existing.time_hint, cfg.time_hint
+                )));
+            }
+        }
+        None => {
+            node.watermark_assign = Some(cfg);
+        }
+    }
+    Ok(())
+}
+
+/// Attach auto watermark assign configs on the defining Source/Projection nodes for each
+/// window in `plan`. Call after the logical graph has been built from that plan.
+pub fn apply_auto_watermark_assigns(plan: &LogicalPlan, graph: &mut LogicalGraph) -> Result<()> {
+    if !graph.watermarks_enabled() {
+        return Ok(());
+    }
+
+    let mut jobs: Vec<(AssignSite, String)> = Vec::new();
+    plan.apply(|node| {
+        if let LogicalPlan::Window(window) = node {
+            let site = resolve_event_time_assign_site(window)?;
+            let et = event_time_column_from_window(window)?;
+            jobs.push((site, et.name));
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+
+    for (site, window_et_name) in jobs {
+        let window_idxs: Vec<NodeIndex> = graph
+            .get_all_node_indices()
+            .into_iter()
+            .filter(|&idx| {
+                window_order_by_column_name(graph, idx).as_deref() == Some(window_et_name.as_str())
+            })
+            .collect();
+        if window_idxs.is_empty() {
+            return Err(DataFusionError::Plan(format!(
+                "no window operator with ORDER BY column '{window_et_name}' for watermark placement"
+            )));
+        }
+
+        let assign_idx = find_assign_node(graph, &site, &window_idxs)?;
+        for &window_idx in &window_idxs {
+            validate_assign_before_window_keyby(graph, assign_idx, window_idx)?;
+        }
+        attach_assign(graph, assign_idx, site.column_name().to_string())?;
     }
 
     Ok(())
@@ -203,7 +348,6 @@ mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use datafusion::catalog::MemTable;
-    use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
     use datafusion::prelude::SessionContext;
     use std::sync::Arc;
 
@@ -239,18 +383,6 @@ mod tests {
         found.expect("expected a Window in plan")
     }
 
-    fn find_plan_by_key<'a>(plan: &'a LogicalPlan, key: usize) -> Option<&'a LogicalPlan> {
-        let mut found = None;
-        plan.apply(|node| {
-            if plan_node_key(node) == key {
-                found = Some(node);
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })
-        .unwrap();
-        found
-    }
-
     #[tokio::test]
     async fn lineage_passthrough_column_stops_at_source() {
         let plan = plan_sql(
@@ -262,9 +394,13 @@ mod tests {
         .await;
         let window = find_window(&plan);
         let site = resolve_event_time_assign_site(&window).unwrap();
-        assert_eq!(site.column_name, "timestamp");
-        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
-        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+        assert_eq!(
+            site,
+            AssignSite::Source {
+                table_name: "events".to_string(),
+                column_name: "timestamp".to_string(),
+            }
+        );
     }
 
     #[tokio::test]
@@ -278,10 +414,13 @@ mod tests {
         .await;
         let window = find_window(&plan);
         let site = resolve_event_time_assign_site(&window).unwrap();
-        // After unwrapping the alias, assign on the source under the original column name.
-        assert_eq!(site.column_name, "timestamp");
-        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
-        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+        assert_eq!(
+            site,
+            AssignSite::Source {
+                table_name: "events".to_string(),
+                column_name: "timestamp".to_string(),
+            }
+        );
     }
 
     #[tokio::test]
@@ -295,9 +434,12 @@ mod tests {
         .await;
         let window = find_window(&plan);
         let site = resolve_event_time_assign_site(&window).unwrap();
-        assert_eq!(site.column_name, "event_time");
-        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
-        assert!(matches!(site_plan, LogicalPlan::Projection(_)));
+        assert_eq!(
+            site,
+            AssignSite::Projection {
+                column_name: "event_time".to_string(),
+            }
+        );
     }
 
     #[tokio::test]

--- a/src/api/logical_graph.rs
+++ b/src/api/logical_graph.rs
@@ -77,18 +77,31 @@ impl LogicalGraph {
         self.watermarks_enabled = enabled;
     }
 
+    pub fn watermarks_enabled(&self) -> bool {
+        self.watermarks_enabled
+    }
+
     pub(crate) fn set_event_time(&mut self, event_time: EventTimeSpec) {
         self.event_time = event_time;
+        // Refresh ooo/idle on assign configs attached during planning.
+        for node in self.graph.node_weights_mut() {
+            if let Some(cfg) = node.watermark_assign.as_mut() {
+                cfg.out_of_orderness_ms = self.event_time.watermark.out_of_orderness_ms;
+                if let Some(idle) = self.event_time.watermark.idle_timeout_ms {
+                    cfg.idle_timeout_ms = Some(idle);
+                }
+            }
+        }
     }
 
     pub fn event_time(&self) -> &EventTimeSpec {
         &self.event_time
     }
 
-    fn auto_watermark_assign_config(&self) -> WatermarkAssignConfig {
+    pub(crate) fn watermark_assign_config_for_column(&self, column_name: String) -> WatermarkAssignConfig {
         let mut cfg = WatermarkAssignConfig::new(
             self.event_time.watermark.out_of_orderness_ms,
-            Some(TimeHint::WindowOrderByColumn),
+            TimeHint::ColumnName { name: column_name },
         );
         if let Some(idle) = self.event_time.watermark.idle_timeout_ms {
             cfg.idle_timeout_ms = Some(idle);
@@ -181,65 +194,11 @@ impl LogicalGraph {
 
     /// Convert logical graph to execution graph using parallelism from each logical node
     pub fn to_execution_graph(&self) -> ExecutionGraph {
-        // Planner-side heuristic watermark assigner placement:
-        // For now, for each Source, find the closest downstream Window operator(s) and attach a watermark assigner there.
-        // This keeps watermark generation as a StreamTask feature (no dedicated operator) while preserving
-        // downstream min-upstream watermark merge semantics.
+        // Watermark assign placement is decided during planning (event-time lineage) and stored
+        // on LogicalNode.watermark_assign. Execution mapping is a simple copy.
         //
-        // TODO: extend placement for joins/unions (multiple-input operators), where "closest window" is ambiguous
-        // and per-input watermark generation needs careful handling.
-        let mut auto_watermark_assign: HashMap<String, WatermarkAssignConfig> = HashMap::new();
-        if self.watermarks_enabled {
-            let source_nodes: Vec<NodeIndex> = self
-                .graph
-                .node_indices()
-                .filter(|&idx| matches!(self.graph[idx].operator_config, OperatorConfig::SourceConfig(_)))
-                .collect();
-
-            for src in source_nodes {
-            // Layered BFS: stop at first layer that contains any window node(s).
-            let mut visited: HashMap<NodeIndex, ()> = HashMap::new();
-            let mut frontier: Vec<NodeIndex> = vec![src];
-            visited.insert(src, ());
-
-            loop {
-                // Next layer
-                let mut next: Vec<NodeIndex> = Vec::new();
-                for &n in &frontier {
-                    for neigh in self.graph.neighbors_directed(n, Direction::Outgoing) {
-                        if visited.contains_key(&neigh) {
-                            continue;
-                        }
-                        visited.insert(neigh, ());
-                        next.push(neigh);
-                    }
-                }
-
-                if next.is_empty() {
-                    break;
-                }
-
-                let windows_at_layer: Vec<NodeIndex> = next
-                    .iter()
-                    .copied()
-                    .filter(|&idx| matches!(self.graph[idx].operator_config, OperatorConfig::WindowConfig(_)))
-                    .collect();
-                if !windows_at_layer.is_empty() {
-                    let assign = self.auto_watermark_assign_config();
-                    for w in windows_at_layer {
-                        let op_id = self.graph[w].operator_id.clone();
-                        auto_watermark_assign
-                            .entry(op_id)
-                            .or_insert_with(|| assign.clone());
-                    }
-                    break;
-                }
-
-                frontier = next;
-            }
-            }
-        } else {
-            // In Batch mode we expect no watermark assignment at all.
+        // TODO: extend placement for joins/unions (multiple-input operators / per-branch assign).
+        if !self.watermarks_enabled {
             debug_assert!(
                 self.graph.node_weights().all(|n| n.watermark_assign.is_none()),
                 "watermarks_disabled but some logical nodes have watermark_assign configured"
@@ -270,10 +229,7 @@ impl LogicalGraph {
                     i as i32,
                 );
                 let mut execution_vertex = execution_vertex;
-                execution_vertex.watermark_assign = logical_node
-                    .watermark_assign
-                    .clone()
-                    .or_else(|| auto_watermark_assign.get(&logical_node.operator_id).cloned());
+                execution_vertex.watermark_assign = logical_node.watermark_assign.clone();
 
                 execution_graph.add_vertex(execution_vertex);
                 execution_vertex_ids.push(execution_vertex_id);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod logical_graph;
+pub mod event_time_placement;
 pub mod planner;
 #[cfg(test)]
 pub mod logical_optimizer_examples;

--- a/src/api/planner.rs
+++ b/src/api/planner.rs
@@ -20,7 +20,7 @@ use datafusion::logical_expr::{
 use datafusion::physical_plan::aggregates::AggregateExec;
 use datafusion::common::{Result, DataFusionError};
 use datafusion::common::tree_node::TreeNodeRecursion;
-use datafusion::common::tree_node::TreeNodeVisitor;
+use datafusion::common::tree_node::{TreeNode, TreeNodeVisitor};
 use datafusion::prelude::SessionContext;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion::sql::TableReference;
@@ -28,6 +28,9 @@ use datafusion::optimizer::analyzer::type_coercion::TypeCoercion;
 use datafusion::optimizer::analyzer::AnalyzerRule;
 use petgraph::graph::NodeIndex;
 
+use super::event_time_placement::{
+    plan_node_key, resolve_event_time_assign_site, validate_assign_before_window_keyby, AssignSite,
+};
 use super::logical_graph::{LogicalNode, LogicalGraph};
 use crate::api::ExecutionMode;
 use crate::runtime::functions::key_by::key_by_function::{DataFusionKeyFunction};
@@ -111,6 +114,8 @@ pub struct Planner {
     logical_graph: LogicalGraph,
     node_stack: Vec<NodeIndex>,
     context: PlanningContext,
+    /// DF plan node pointer identity → logical graph node (for watermark assign placement).
+    df_plan_to_node: HashMap<usize, NodeIndex>,
 }
 
 #[derive(Clone)]
@@ -165,6 +170,7 @@ impl Planner {
             logical_graph: LogicalGraph::new(),
             node_stack: Vec::new(),
             context,
+            df_plan_to_node: HashMap::new(),
         }
     }
 
@@ -191,11 +197,71 @@ impl Planner {
 
     pub fn logical_plan_to_graph(&mut self, logical_plan: &LogicalPlan) -> Result<LogicalGraph> {
         self.node_stack.clear();
+        self.df_plan_to_node.clear();
 
         let optimized_plan = self.optimize_plan(logical_plan.clone())?;
         optimized_plan.visit_with_subqueries(self)?;
-        
+        self.apply_auto_watermark_assigns(&optimized_plan)?;
+
         Ok(self.logical_graph.clone())
+    }
+
+    fn apply_auto_watermark_assigns(&mut self, plan: &LogicalPlan) -> Result<()> {
+        // Batch mode forbids watermark_assign on StreamTasks.
+        if self.context.execution_mode == ExecutionMode::Batch {
+            return Ok(());
+        }
+        if !self.logical_graph.watermarks_enabled() {
+            return Ok(());
+        }
+
+        let mut sites: Vec<(usize, AssignSite)> = Vec::new();
+        plan.apply(|node| {
+            if let LogicalPlan::Window(window) = node {
+                let site = resolve_event_time_assign_site(window)?;
+                sites.push((plan_node_key(node), site));
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+
+        for (window_plan_key, site) in sites {
+            let assign_idx = *self.df_plan_to_node.get(&site.plan_node_key).ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "no logical node mapped for event-time assign site (column={})",
+                    site.column_name
+                ))
+            })?;
+            let window_idx = *self.df_plan_to_node.get(&window_plan_key).ok_or_else(|| {
+                DataFusionError::Plan(
+                    "no logical node mapped for window during watermark placement".to_string(),
+                )
+            })?;
+
+            validate_assign_before_window_keyby(&self.logical_graph, assign_idx, window_idx)?;
+
+            let cfg = self
+                .logical_graph
+                .watermark_assign_config_for_column(site.column_name.clone());
+            let node = self
+                .logical_graph
+                .get_node_by_index_mut(assign_idx)
+                .expect("assign node index must exist");
+            match &node.watermark_assign {
+                Some(existing) => {
+                    if existing.time_hint != cfg.time_hint {
+                        return Err(DataFusionError::Plan(format!(
+                            "conflicting watermark assign time hints on {}: {:?} vs {:?}",
+                            node.operator_id, existing.time_hint, cfg.time_hint
+                        )));
+                    }
+                }
+                None => {
+                    node.watermark_assign = Some(cfg);
+                }
+            }
+        }
+
+        Ok(())
     }
 
     pub fn sql_to_graph(&mut self, sql: &str) -> Result<LogicalGraph> {
@@ -453,11 +519,15 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
         // Process node and create operator
         match node {
             LogicalPlan::TableScan(table_scan) => {
-                self.create_source_node(table_scan, self.context.parallelism)?
+                self.create_source_node(table_scan, self.context.parallelism)?;
+                let idx = *self.node_stack.last().expect("source node just pushed");
+                self.df_plan_to_node.insert(plan_node_key(node), idx);
             }
             
             LogicalPlan::Projection(projection) => {
-                self.create_projection_node(projection, self.context.parallelism)?
+                self.create_projection_node(projection, self.context.parallelism)?;
+                let idx = *self.node_stack.last().expect("projection node just pushed");
+                self.df_plan_to_node.insert(plan_node_key(node), idx);
             }
             
             LogicalPlan::Filter(filter) => {
@@ -473,6 +543,9 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
             }
             LogicalPlan::Window(window) => {
                 self.handle_window(window, self.context.parallelism)?;
+                // Stack top is KeyBy, then Window (handle_window pushes window then keyby).
+                let window_idx = self.node_stack[self.node_stack.len() - 2];
+                self.df_plan_to_node.insert(plan_node_key(node), window_idx);
             }
             
             // skip subqueries as they simply wrap other plans
@@ -938,6 +1011,21 @@ mod tests {
             (NodeType::KeyBy, NodeType::Window, PartitionType::Hash, 1),
             (NodeType::Window, NodeType::Projection, PartitionType::RoundRobin, 1),
         ]);
+
+        // Event-time lineage: assign on Source (defining site), not Window/KeyBy.
+        assert!(
+            nodes[3].watermark_assign.is_some(),
+            "expected watermark_assign on Source"
+        );
+        assert!(
+            matches!(
+                &nodes[3].watermark_assign.as_ref().unwrap().time_hint,
+                crate::runtime::watermark::TimeHint::ColumnName { name } if name == "event_time"
+            ),
+            "expected ColumnName(event_time) time hint on Source"
+        );
+        assert!(nodes[1].watermark_assign.is_none(), "Window must not have watermark_assign");
+        assert!(nodes[2].watermark_assign.is_none(), "KeyBy must not have watermark_assign");
     }
 
     #[tokio::test]

--- a/src/api/planner.rs
+++ b/src/api/planner.rs
@@ -20,7 +20,7 @@ use datafusion::logical_expr::{
 use datafusion::physical_plan::aggregates::AggregateExec;
 use datafusion::common::{Result, DataFusionError};
 use datafusion::common::tree_node::TreeNodeRecursion;
-use datafusion::common::tree_node::{TreeNode, TreeNodeVisitor};
+use datafusion::common::tree_node::TreeNodeVisitor;
 use datafusion::prelude::SessionContext;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion::sql::TableReference;
@@ -28,9 +28,7 @@ use datafusion::optimizer::analyzer::type_coercion::TypeCoercion;
 use datafusion::optimizer::analyzer::AnalyzerRule;
 use petgraph::graph::NodeIndex;
 
-use super::event_time_placement::{
-    plan_node_key, resolve_event_time_assign_site, validate_assign_before_window_keyby, AssignSite,
-};
+use super::event_time_placement::apply_auto_watermark_assigns;
 use super::logical_graph::{LogicalNode, LogicalGraph};
 use crate::api::ExecutionMode;
 use crate::runtime::functions::key_by::key_by_function::{DataFusionKeyFunction};
@@ -114,8 +112,6 @@ pub struct Planner {
     logical_graph: LogicalGraph,
     node_stack: Vec<NodeIndex>,
     context: PlanningContext,
-    /// DF plan node pointer identity → logical graph node (for watermark assign placement).
-    df_plan_to_node: HashMap<usize, NodeIndex>,
 }
 
 #[derive(Clone)]
@@ -170,7 +166,6 @@ impl Planner {
             logical_graph: LogicalGraph::new(),
             node_stack: Vec::new(),
             context,
-            df_plan_to_node: HashMap::new(),
         }
     }
 
@@ -197,71 +192,15 @@ impl Planner {
 
     pub fn logical_plan_to_graph(&mut self, logical_plan: &LogicalPlan) -> Result<LogicalGraph> {
         self.node_stack.clear();
-        self.df_plan_to_node.clear();
 
         let optimized_plan = self.optimize_plan(logical_plan.clone())?;
         optimized_plan.visit_with_subqueries(self)?;
-        self.apply_auto_watermark_assigns(&optimized_plan)?;
+        // Batch mode forbids watermark_assign on StreamTasks.
+        if self.context.execution_mode != ExecutionMode::Batch {
+            apply_auto_watermark_assigns(&optimized_plan, &mut self.logical_graph)?;
+        }
 
         Ok(self.logical_graph.clone())
-    }
-
-    fn apply_auto_watermark_assigns(&mut self, plan: &LogicalPlan) -> Result<()> {
-        // Batch mode forbids watermark_assign on StreamTasks.
-        if self.context.execution_mode == ExecutionMode::Batch {
-            return Ok(());
-        }
-        if !self.logical_graph.watermarks_enabled() {
-            return Ok(());
-        }
-
-        let mut sites: Vec<(usize, AssignSite)> = Vec::new();
-        plan.apply(|node| {
-            if let LogicalPlan::Window(window) = node {
-                let site = resolve_event_time_assign_site(window)?;
-                sites.push((plan_node_key(node), site));
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })?;
-
-        for (window_plan_key, site) in sites {
-            let assign_idx = *self.df_plan_to_node.get(&site.plan_node_key).ok_or_else(|| {
-                DataFusionError::Plan(format!(
-                    "no logical node mapped for event-time assign site (column={})",
-                    site.column_name
-                ))
-            })?;
-            let window_idx = *self.df_plan_to_node.get(&window_plan_key).ok_or_else(|| {
-                DataFusionError::Plan(
-                    "no logical node mapped for window during watermark placement".to_string(),
-                )
-            })?;
-
-            validate_assign_before_window_keyby(&self.logical_graph, assign_idx, window_idx)?;
-
-            let cfg = self
-                .logical_graph
-                .watermark_assign_config_for_column(site.column_name.clone());
-            let node = self
-                .logical_graph
-                .get_node_by_index_mut(assign_idx)
-                .expect("assign node index must exist");
-            match &node.watermark_assign {
-                Some(existing) => {
-                    if existing.time_hint != cfg.time_hint {
-                        return Err(DataFusionError::Plan(format!(
-                            "conflicting watermark assign time hints on {}: {:?} vs {:?}",
-                            node.operator_id, existing.time_hint, cfg.time_hint
-                        )));
-                    }
-                }
-                None => {
-                    node.watermark_assign = Some(cfg);
-                }
-            }
-        }
-
-        Ok(())
     }
 
     pub fn sql_to_graph(&mut self, sql: &str) -> Result<LogicalGraph> {
@@ -519,15 +458,11 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
         // Process node and create operator
         match node {
             LogicalPlan::TableScan(table_scan) => {
-                self.create_source_node(table_scan, self.context.parallelism)?;
-                let idx = *self.node_stack.last().expect("source node just pushed");
-                self.df_plan_to_node.insert(plan_node_key(node), idx);
+                self.create_source_node(table_scan, self.context.parallelism)?
             }
             
             LogicalPlan::Projection(projection) => {
-                self.create_projection_node(projection, self.context.parallelism)?;
-                let idx = *self.node_stack.last().expect("projection node just pushed");
-                self.df_plan_to_node.insert(plan_node_key(node), idx);
+                self.create_projection_node(projection, self.context.parallelism)?
             }
             
             LogicalPlan::Filter(filter) => {
@@ -543,9 +478,6 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
             }
             LogicalPlan::Window(window) => {
                 self.handle_window(window, self.context.parallelism)?;
-                // Stack top is KeyBy, then Window (handle_window pushes window then keyby).
-                let window_idx = self.node_stack[self.node_stack.len() - 2];
-                self.df_plan_to_node.insert(plan_node_key(node), window_idx);
             }
             
             // skip subqueries as they simply wrap other plans

--- a/src/common/grpc.rs
+++ b/src/common/grpc.rs
@@ -1,0 +1,5 @@
+/// Max gRPC message size for control-plane and transport RPCs.
+///
+/// Must stay above the in-memory window checkpoint inline limit (8 MiB) so
+/// checkpoint/restore payloads are not rejected by tonic's 4 MiB default.
+pub const GRPC_MAX_MESSAGE_BYTES: usize = 12 * 1024 * 1024;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod grpc;
 pub mod message;
 pub mod ports;
 #[cfg(test)]
@@ -5,6 +6,8 @@ pub mod test_utils;
 pub mod key;
 pub mod types;
 pub mod failure;
+
+pub use grpc::GRPC_MAX_MESSAGE_BYTES;
 
 pub use message::*;
 pub use key::Key;

--- a/src/runtime/functions/map/projection_function.rs
+++ b/src/runtime/functions/map/projection_function.rs
@@ -57,6 +57,10 @@ impl ProjectionFunction {
     pub fn out_schema(&self) -> DFSchemaRef {
         self.out_schema.clone()
     }
+
+    pub fn exprs(&self) -> &[Expr] {
+        &self.exprs
+    }
 }
 
 #[async_trait]

--- a/src/runtime/master/attempt/execute.rs
+++ b/src/runtime/master/attempt/execute.rs
@@ -48,6 +48,7 @@ impl ExecutionAttempt {
         let checkpoint_interval = runtime_consts().duration(MASTER_CHECKPOINT_INTERVAL);
         let checkpoint_timeout = runtime_consts().duration(MASTER_CHECKPOINT_TIMEOUT);
         let mut checkpoint_tick = optional_interval(checkpoint_interval);
+        let mut last_in_flight_skip_log = Instant::now() - Duration::from_secs(60);
 
         loop {
             tokio::select! {
@@ -61,10 +62,19 @@ impl ExecutionAttempt {
                 }
                 _ = optional_tick(&mut checkpoint_tick) => {
                     if let Err(error) = self.begin_checkpoint().await {
-                        println!(
-                            "[MASTER] Interval checkpoint skipped attempt={}: {}",
-                            self.id, error
-                        );
+                        // Throttle: interval ticks spam while a CP is stuck; include progress.
+                        if last_in_flight_skip_log.elapsed() >= Duration::from_secs(2) {
+                            last_in_flight_skip_log = Instant::now();
+                            let progress = self
+                                .state
+                                .in_flight_checkpoint_progress()
+                                .await
+                                .unwrap_or_else(|| "no in-flight progress".to_string());
+                            println!(
+                                "[MASTER] Interval checkpoint skipped attempt={}: {} ({})",
+                                self.id, error, progress
+                            );
+                        }
                     }
                 }
                 state_poll = async {
@@ -88,11 +98,16 @@ impl ExecutionAttempt {
                         .in_flight_checkpoint_timed_out(checkpoint_timeout)
                         .await
                     {
+                        let progress = self
+                            .state
+                            .in_flight_checkpoint_progress()
+                            .await
+                            .unwrap_or_default();
                         self.abort_in_flight(format!("checkpoint {checkpoint_id} timed out"))
                             .await;
                         println!(
-                            "[MASTER] Checkpoint timeout attempt={} checkpoint_id={}",
-                            self.id, checkpoint_id
+                            "[MASTER] Checkpoint timeout attempt={} checkpoint_id={} {}",
+                            self.id, checkpoint_id, progress
                         );
                         return Ok(AttemptOutcome::Recover(HashSet::new()));
                     }

--- a/src/runtime/master/attempt/execute.rs
+++ b/src/runtime/master/attempt/execute.rs
@@ -61,19 +61,24 @@ impl ExecutionAttempt {
                     return Ok(self.await_failure_window_and_recover(failure).await);
                 }
                 _ = optional_tick(&mut checkpoint_tick) => {
-                    if let Err(error) = self.begin_checkpoint().await {
-                        // Throttle: interval ticks spam while a CP is stuck; include progress.
-                        if last_in_flight_skip_log.elapsed() >= Duration::from_secs(2) {
-                            last_in_flight_skip_log = Instant::now();
-                            let progress = self
-                                .state
-                                .in_flight_checkpoint_progress()
-                                .await
-                                .unwrap_or_else(|| "no in-flight progress".to_string());
-                            println!(
-                                "[MASTER] Interval checkpoint skipped attempt={}: {} ({})",
-                                self.id, error, progress
-                            );
+                    match self.begin_checkpoint().await {
+                        Ok(_) => {}
+                        // Expected after StopSources; do not spam.
+                        Err(error) if error == "sources stopped for drain" => {}
+                        Err(error) => {
+                            // Throttle: interval ticks spam while a CP is stuck; include progress.
+                            if last_in_flight_skip_log.elapsed() >= Duration::from_secs(2) {
+                                last_in_flight_skip_log = Instant::now();
+                                let progress = self
+                                    .state
+                                    .in_flight_checkpoint_progress()
+                                    .await
+                                    .unwrap_or_else(|| "no in-flight progress".to_string());
+                                println!(
+                                    "[MASTER] Interval checkpoint skipped attempt={}: {} ({})",
+                                    self.id, error, progress
+                                );
+                            }
                         }
                     }
                 }
@@ -145,6 +150,7 @@ impl ExecutionAttempt {
                 CheckpointStartError::NoCheckpointableTasks => {
                     "no checkpointable tasks".to_string()
                 }
+                CheckpointStartError::Disabled => "sources stopped for drain".to_string(),
             })?;
         println!(
             "[MASTER] Triggering checkpoint {} attempt={}",

--- a/src/runtime/master/checkpoint/mod.rs
+++ b/src/runtime/master/checkpoint/mod.rs
@@ -20,6 +20,8 @@ pub use store::{create_checkpoint_store, CheckpointStore, InMemoryCheckpointStor
 pub enum CheckpointStartError {
     AlreadyInFlight { checkpoint_id: u64 },
     NoCheckpointableTasks,
+    /// Sources were stopped for drain; new checkpoints must not start.
+    Disabled,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,6 +55,8 @@ pub struct Checkpoints {
     protocol: CheckpointProtocol,
     store: Option<Arc<dyn CheckpointStore>>,
     pending: HashMap<u64, HashMap<TaskKey, SerializedCheckpoint>>,
+    /// Cleared on `StopSources` so interval ticks cannot open a CP on a draining graph.
+    enabled: bool,
 }
 
 impl Default for Checkpoints {
@@ -65,6 +69,7 @@ impl Default for Checkpoints {
             protocol: CheckpointProtocol::default(),
             store: None,
             pending: HashMap::new(),
+            enabled: true,
         }
     }
 }
@@ -85,9 +90,17 @@ impl Checkpoints {
         self.store = Some(store);
         self.protocol = CheckpointProtocol::default();
         self.pending.clear();
+        self.enabled = true;
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
     }
 
     pub fn start(&mut self) -> Result<u64, CheckpointStartError> {
+        if !self.enabled {
+            return Err(CheckpointStartError::Disabled);
+        }
         self.protocol
             .start(&self.expected_acks, &self.expected_aligns)
     }
@@ -319,6 +332,18 @@ mod tests {
         assert!(cps.load(id).await.is_err());
         assert_eq!(cps.abort_in_flight().await.unwrap(), Some(id));
         assert!(cps.load(id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn disabled_rejects_start() {
+        let mut cps = Checkpoints::default();
+        let acks: HashSet<_> = [task("a", 0)].into_iter().collect();
+        let aligns = acks.clone();
+        cps.configure(pipeline(), acks, aligns, 1, store());
+        cps.set_enabled(false);
+        assert_eq!(cps.start(), Err(CheckpointStartError::Disabled));
+        cps.set_enabled(true);
+        assert!(cps.start().is_ok());
     }
 
     #[tokio::test]

--- a/src/runtime/master/checkpoint/mod.rs
+++ b/src/runtime/master/checkpoint/mod.rs
@@ -108,6 +108,11 @@ impl Checkpoints {
         self.protocol.in_flight_timed_out(timeout)
     }
 
+    pub fn in_flight_progress_summary(&self) -> Option<String> {
+        self.protocol
+            .in_flight_progress_summary(&self.expected_acks, &self.expected_aligns)
+    }
+
     pub fn latest_complete(&self) -> Option<u64> {
         self.protocol.latest_complete()
     }
@@ -141,11 +146,27 @@ impl Checkpoints {
             &self.expected_acks,
             &self.expected_aligns,
         );
-        if !matches!(outcome, CheckpointAckOutcome::Rejected(_)) {
+        if matches!(outcome, CheckpointAckOutcome::Rejected(_)) {
+            println!(
+                "[MASTER][CHECKPOINT] state_ack rejected task={}/{} checkpoint_id={} outcome={:?}",
+                task.vertex_id, task.task_index, checkpoint_id, outcome
+            );
+        } else {
             self.pending
                 .entry(checkpoint_id)
                 .or_default()
-                .insert(task, checkpoint);
+                .insert(task.clone(), checkpoint);
+            if matches!(outcome, CheckpointAckOutcome::Completed) {
+                println!(
+                    "[MASTER][CHECKPOINT] state_ack task={}/{} completed checkpoint_id={}",
+                    task.vertex_id, task.task_index, checkpoint_id
+                );
+            } else if let Some(summary) = self.in_flight_progress_summary() {
+                println!(
+                    "[MASTER][CHECKPOINT] state_ack task={}/{} pending {}",
+                    task.vertex_id, task.task_index, summary
+                );
+            }
         }
         self.finish_if_completed(checkpoint_id, outcome).await
     }
@@ -158,10 +179,26 @@ impl Checkpoints {
     ) -> anyhow::Result<CheckpointAckOutcome> {
         let outcome = self.protocol.align(
             checkpoint_id,
-            task,
+            task.clone(),
             &self.expected_acks,
             &self.expected_aligns,
         );
+        if matches!(outcome, CheckpointAckOutcome::Rejected(_)) {
+            println!(
+                "[MASTER][CHECKPOINT] barrier_align rejected task={}/{} checkpoint_id={} outcome={:?}",
+                task.vertex_id, task.task_index, checkpoint_id, outcome
+            );
+        } else if matches!(outcome, CheckpointAckOutcome::Completed) {
+            println!(
+                "[MASTER][CHECKPOINT] barrier_align task={}/{} completed checkpoint_id={}",
+                task.vertex_id, task.task_index, checkpoint_id
+            );
+        } else if let Some(summary) = self.in_flight_progress_summary() {
+            println!(
+                "[MASTER][CHECKPOINT] barrier_align task={}/{} pending {}",
+                task.vertex_id, task.task_index, summary
+            );
+        }
         self.finish_if_completed(checkpoint_id, outcome).await
     }
 

--- a/src/runtime/master/checkpoint/protocol.rs
+++ b/src/runtime/master/checkpoint/protocol.rs
@@ -22,6 +22,26 @@ pub(super) struct CheckpointProtocol {
     completed: BTreeSet<u64>,
 }
 
+fn format_task_key(task: &TaskKey) -> String {
+    format!("{}/{}", task.vertex_id, task.task_index)
+}
+
+fn format_missing_tasks(expected: &HashSet<TaskKey>, have: &HashSet<TaskKey>) -> String {
+    const MAX_SHOW: usize = 8;
+    let mut missing: Vec<String> = expected
+        .difference(have)
+        .map(format_task_key)
+        .collect();
+    missing.sort();
+    let total = missing.len();
+    if total > MAX_SHOW {
+        missing.truncate(MAX_SHOW);
+        format!("{},…(+{})", missing.join(","), total - MAX_SHOW)
+    } else {
+        missing.join(",")
+    }
+}
+
 impl CheckpointProtocol {
     pub(super) fn in_flight_id(&self) -> Option<u64> {
         self.in_flight.as_ref().map(|c| c.checkpoint_id)
@@ -34,6 +54,28 @@ impl CheckpointProtocol {
         } else {
             None
         }
+    }
+
+    /// Human-readable in-flight ack/align progress for diagnostics.
+    pub(super) fn in_flight_progress_summary(
+        &self,
+        expected_acks: &HashSet<TaskKey>,
+        expected_aligns: &HashSet<TaskKey>,
+    ) -> Option<String> {
+        let in_flight = self.in_flight.as_ref()?;
+        let missing_acks = format_missing_tasks(expected_acks, &in_flight.acks);
+        let missing_aligns = format_missing_tasks(expected_aligns, &in_flight.aligns);
+        Some(format!(
+            "checkpoint_id={} elapsed={:?} acks={}/{} missing_acks=[{}] aligns={}/{} missing_aligns=[{}]",
+            in_flight.checkpoint_id,
+            in_flight.started_at.elapsed(),
+            in_flight.acks.len(),
+            expected_acks.len(),
+            missing_acks,
+            in_flight.aligns.len(),
+            expected_aligns.len(),
+            missing_aligns,
+        ))
     }
 
     pub(super) fn start(

--- a/src/runtime/master/lifecycle.rs
+++ b/src/runtime/master/lifecycle.rs
@@ -31,6 +31,7 @@ impl MasterLifecycle {
                 })
                 .await;
             self.state.set_current_attempt_id(execution_attempt_id);
+            self.state.enable_checkpoints().await;
             let mut attempt = ExecutionAttempt::new(
                 execution_attempt_id,
                 restore_checkpoint_id,

--- a/src/runtime/master/mod.rs
+++ b/src/runtime/master/mod.rs
@@ -106,6 +106,11 @@ impl Master {
             .current_execution_worker_endpoints()
             .await
             .ok_or_else(|| "no workers on current execution attempt".to_string())?;
+        // Disable interval CPs before stopping sources so a tick cannot open a
+        // barrier on an already-draining graph (acks/aligns stay at 0 forever).
+        self.state
+            .disable_checkpoints_for_drain(execution_attempt_id)
+            .await?;
         let futures = workers.iter().map(|(worker_id, addr)| {
             let worker_id = worker_id.clone();
             let addr = addr.clone();
@@ -152,6 +157,9 @@ impl Master {
                 } => format!("already in flight checkpoint_id={checkpoint_id}"),
                 crate::runtime::master::checkpoint::CheckpointStartError::NoCheckpointableTasks => {
                     "no checkpointable tasks".to_string()
+                }
+                crate::runtime::master::checkpoint::CheckpointStartError::Disabled => {
+                    "sources stopped for drain".to_string()
                 }
             })
     }

--- a/src/runtime/master/server.rs
+++ b/src/runtime/master/server.rs
@@ -50,7 +50,9 @@ impl MasterServer {
     pub async fn start(&mut self, addr: &str) -> anyhow::Result<()> {
         let addr = addr.parse()?;
         let service =
-            master_service::master_service_server::MasterServiceServer::new(self.service.clone());
+            master_service::master_service_server::MasterServiceServer::new(self.service.clone())
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[MASTER_SERVER] Starting MasterService server on {}", addr);
 

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -280,6 +280,37 @@ impl MasterState {
         self.current_attempt_id.load(Ordering::SeqCst)
     }
 
+    pub(super) async fn enable_checkpoints(&self) {
+        self.checkpoints.lock().await.set_enabled(true);
+    }
+
+    /// Stop taking new checkpoints and drop any in-flight one (pipeline is draining).
+    pub(super) async fn disable_checkpoints_for_drain(
+        &self,
+        attempt_id: u64,
+    ) -> Result<Option<u64>, String> {
+        let mut checkpoints = self.checkpoints.lock().await;
+        checkpoints.set_enabled(false);
+        let checkpoint_id = checkpoints
+            .abort_in_flight()
+            .await
+            .map_err(|error| format!("failed to remove aborted checkpoint: {error}"))?;
+        drop(checkpoints);
+        if let Some(checkpoint_id) = checkpoint_id {
+            self.record_lifecycle_event(LifecycleEvent::CheckpointFailed {
+                checkpoint_id,
+                attempt_id,
+                detail: "aborted: sources stopped for drain".to_string(),
+            })
+            .await;
+            println!(
+                "[MASTER] Checkpoint {} aborted: sources stopped for drain attempt={}",
+                checkpoint_id, attempt_id
+            );
+        }
+        Ok(checkpoint_id)
+    }
+
     pub(super) async fn begin_checkpoint(
         &self,
         attempt_id: u64,

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -323,6 +323,10 @@ impl MasterState {
             .in_flight_timed_out(timeout)
     }
 
+    pub(super) async fn in_flight_checkpoint_progress(&self) -> Option<String> {
+        self.checkpoints.lock().await.in_flight_progress_summary()
+    }
+
     /// Journal barrier progress and count it toward completion (with state acks).
     /// Drops stale attempts and unknown ids; rejects are soft so tasks are not failed.
     pub(super) async fn report_checkpoint_propagation(
@@ -341,6 +345,15 @@ impl MasterState {
             let mut cps = self.checkpoints.lock().await;
             // Only in-flight CPs accept barrier progress (Completed implies align already done).
             if cps.in_flight_id() != Some(checkpoint_id) {
+                println!(
+                    "[MASTER][CHECKPOINT] ignore barrier progress checkpoint_id={} in_flight={:?} task={}/{} phase={:?} attempt={}",
+                    checkpoint_id,
+                    cps.in_flight_id(),
+                    task.vertex_id,
+                    task.task_index,
+                    phase,
+                    execution_attempt_id
+                );
                 return Ok(());
             }
             cps.note_barrier_progress(checkpoint_id, task.clone())

--- a/src/runtime/master/worker_client.rs
+++ b/src/runtime/master/worker_client.rs
@@ -114,7 +114,11 @@ pub(super) async fn connect_worker_client(
     endpoint
         .connect()
         .await
-        .map(WorkerServiceClient::new)
+        .map(|channel| {
+            WorkerServiceClient::new(channel)
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        })
         .map_err(|e| format!("connect to {addr} failed: {e}"))
 }
 

--- a/src/runtime/operators/window/README.md
+++ b/src/runtime/operators/window/README.md
@@ -155,7 +155,7 @@ partitioning, publication, fencing, caching, and cleanup. They must preserve:
 uses one read lock as the WRO snapshot boundary, and embeds complete namespace
 snapshots, including durable triggers, in checkpoint data. Its live state
 remains process-local and is not a cross-worker backend. It is intended only
-for development and tests: inline checkpoint snapshots are limited to 3 MiB to
+for development and tests: inline checkpoint snapshots are limited to 8 MiB to
 stay below the gRPC control-plane message limit.
 
 ## Checkpoint and restore

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -22,7 +22,7 @@ use crate::runtime::operators::window::store::{
     KeyState, PartitionKey, StateNamespace, TileMap, WindowData,
 };
 
-const MAX_INLINE_CHECKPOINT_BYTES: usize = 3 * 1024 * 1024;
+const MAX_INLINE_CHECKPOINT_BYTES: usize = 8 * 1024 * 1024;
 
 fn validate_checkpoint_size(snapshot: &[u8]) -> Result<()> {
     anyhow::ensure!(
@@ -61,7 +61,7 @@ struct InMemState {
     triggers: BTreeSet<WindowTrigger>,
 }
 
-/// Development/test reference backend with inline checkpoints limited to 3 MiB.
+/// Development/test reference backend with inline checkpoints limited to 8 MiB.
 /// One read lock is the WRO snapshot boundary.
 #[derive(Debug, Clone, Default)]
 pub struct InMemWindowStore {
@@ -276,6 +276,13 @@ impl WindowOperatorStore for InMemWindowStore {
                 .collect(),
         };
         let snapshot = bincode::serialize(&checkpoint)?;
+        println!(
+            "[WINDOW][INMEM] checkpoint size={} bytes (limit={} bytes, partitions={}, triggers={})",
+            snapshot.len(),
+            MAX_INLINE_CHECKPOINT_BYTES,
+            checkpoint.partitions.len(),
+            checkpoint.triggers.len(),
+        );
         validate_checkpoint_size(&snapshot)?;
         Ok(WindowBackendSnapshot::InMemory { snapshot })
     }

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -556,6 +556,11 @@ impl StreamTask {
                 Some(
                     MasterServiceClient::connect(endpoint)
                         .await
+                        .map(|client| {
+                            client
+                                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        })
                         .map_err(|e| anyhow::anyhow!("Failed to connect to master service: {}", e))?,
                 )
             } else {

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -322,7 +322,6 @@ impl StreamTask {
     pub(crate) fn create_preprocessed_input_stream(
         input_stream: MessageStream,
         vertex_id: VertexId,
-        operator_config: OperatorConfig,
         watermark_assign: Option<WatermarkAssignConfig>,
         upstream_vertices: Vec<String>,
         upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
@@ -336,7 +335,6 @@ impl StreamTask {
             let mut input_stream = input_stream;
             let mut watermark_manager = WatermarkManager::new(
                 watermark_assign,
-                Some(&operator_config),
                 upstream_vertices.clone(),
                 upstream_watermarks.clone(),
                 current_watermark.clone(),
@@ -586,7 +584,6 @@ impl StreamTask {
                 .get_vertex(&vertex_id)
                 .expect("vertex should exist in execution graph");
             let watermark_assign = vertex_meta.watermark_assign.clone();
-            let vertex_operator_config = vertex_meta.operator_config.clone();
 
             // Runtime invariant: watermark assigners must not run in Batch mode.
             // Batch pipelines rely on source completion to emit a terminal MAX_WATERMARK_VALUE.
@@ -605,7 +602,6 @@ impl StreamTask {
             let mut source_watermark_manager = if is_source {
                 Some(WatermarkManager::new(
                     watermark_assign.clone(),
-                    Some(&vertex_operator_config),
                     upstream_vertices.clone(),
                     upstream_watermarks.clone(),
                     current_watermark.clone(),
@@ -626,7 +622,6 @@ impl StreamTask {
                 let preprocessed_stream = Self::create_preprocessed_input_stream(
                     input_stream,
                     vertex_id.clone(),
-                    vertex_operator_config.clone(),
                     watermark_assign.clone(),
                     upstream_vertices.clone(),
                     upstream_watermarks.clone(),

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -93,13 +93,24 @@ impl CheckpointAligner {
         }
 
         self.reader_control.block_upstream(&upstream_vertex_id);
-        self.seen_upstreams.insert(upstream_vertex_id);
+        self.seen_upstreams.insert(upstream_vertex_id.clone());
 
         if self.seen_upstreams.len() == self.upstream_count {
+            println!(
+                "[CHECKPOINT] aligned checkpoint_id={} upstreams={}/{}",
+                checkpoint_id, self.upstream_count, self.upstream_count
+            );
             self.current_checkpoint = None;
             self.seen_upstreams.clear();
             return Ok(Some(checkpoint_id));
         }
+        println!(
+            "[CHECKPOINT] aligning checkpoint_id={} from={} seen={}/{}",
+            checkpoint_id,
+            upstream_vertex_id,
+            self.seen_upstreams.len(),
+            self.upstream_count
+        );
         Ok(None)
     }
 

--- a/src/runtime/watermark/confg.rs
+++ b/src/runtime/watermark/confg.rs
@@ -1,14 +1,14 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WatermarkAssignConfig {
     pub out_of_orderness_ms: u64,
-    pub time_hint: Option<TimeHint>,
+    pub time_hint: TimeHint,
     pub idle_timeout_ms: Option<u64>,
 }
 
 impl WatermarkAssignConfig {
     pub const DEFAULT_IDLE_TIMEOUT_MS: u64 = 1_000;
 
-    pub fn new(out_of_orderness_ms: u64, time_hint: Option<TimeHint>) -> Self {
+    pub fn new(out_of_orderness_ms: u64, time_hint: TimeHint) -> Self {
         Self {
             out_of_orderness_ms,
             time_hint,
@@ -19,8 +19,5 @@ impl WatermarkAssignConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TimeHint {
-    WindowOrderByColumn,
     ColumnName { name: String },
-    // TODO: auto-resolve for non-window operators (timestamp-like column heuristics).
 }
-

--- a/src/runtime/watermark/manager.rs
+++ b/src/runtime/watermark/manager.rs
@@ -8,17 +8,8 @@ use arrow::record_batch::RecordBatch;
 use tokio::sync::Mutex;
 
 use crate::common::message::{Message, WatermarkMessage};
-use crate::runtime::operators::operator::OperatorConfig;
-
-use datafusion::physical_plan::expressions::Column;
 
 use super::confg::{TimeHint, WatermarkAssignConfig};
-
-#[derive(Debug, Clone)]
-enum TsColumnSpec {
-    Index(usize),
-    ColumnName(String),
-}
 
 #[derive(Debug, Default, Clone)]
 struct UpstreamWatermarkProgress {
@@ -28,66 +19,33 @@ struct UpstreamWatermarkProgress {
 
 /// Stateful event-time watermark generator.
 ///
-/// Progress is tracked **per upstream vertex id** so we can attach this generator to a downstream
-/// task (e.g. Window) while still simulating independent upstream watermark production.
+/// Progress is tracked **per upstream vertex id** (sources use the task's own id; map/preprocess
+/// uses the message upstream id).
 #[derive(Debug)]
 pub struct WatermarkAssignerState {
     out_of_orderness_ms: u64,
-    ts_column: TsColumnSpec,
+    ts_column_name: String,
     per_upstream: HashMap<String, UpstreamWatermarkProgress>,
 }
 
 impl WatermarkAssignerState {
-    pub fn new(cfg: WatermarkAssignConfig, operator_config: Option<&OperatorConfig>) -> Self {
-        let ts_column = match cfg.time_hint {
-            Some(TimeHint::WindowOrderByColumn) => TsColumnSpec::Index(
-                Self::derive_window_ts_column_index(
-                    operator_config.expect("WindowOrderByColumn requires operator_config"),
-                ),
-            ),
-            Some(TimeHint::ColumnName { name }) => TsColumnSpec::ColumnName(name),
-            None => {
-                // Auto-resolve only for Window vertices.
-                TsColumnSpec::Index(Self::derive_window_ts_column_index(
-                    operator_config.expect("Auto-resolve requires operator_config"),
-                ))
-            }
-        };
-
+    pub fn new(cfg: WatermarkAssignConfig) -> Self {
+        let TimeHint::ColumnName { name } = cfg.time_hint;
         Self {
             out_of_orderness_ms: cfg.out_of_orderness_ms,
-            ts_column,
+            ts_column_name: name,
             per_upstream: HashMap::new(),
         }
     }
 
-    fn derive_window_ts_column_index(operator_config: &OperatorConfig) -> usize {
-        let OperatorConfig::WindowConfig(window_cfg) = operator_config else {
-            panic!("WatermarkAssign auto-resolve requires Window vertex or explicit time hint");
-        };
-        window_cfg.window_exec.window_expr()[0]
-            .order_by()[0]
-            .expr
-            .as_any()
-            .downcast_ref::<Column>()
-            .expect("Expected Column expression in Window ORDER BY")
-            .index()
-    }
-
     fn resolve_ts_column_index(&self, batch: &RecordBatch) -> usize {
-        match &self.ts_column {
-            TsColumnSpec::Index(idx) => *idx,
-            TsColumnSpec::ColumnName(name) => batch
-                .schema()
-                .index_of(name)
-                .unwrap_or_else(|_| {
-                    panic!(
-                        "WatermarkAssign failed: missing column '{}' in schema {:?}",
-                        name,
-                        batch.schema()
-                    )
-                }),
-        }
+        batch.schema().index_of(&self.ts_column_name).unwrap_or_else(|_| {
+            panic!(
+                "WatermarkAssign failed: missing column '{}' in schema {:?}",
+                self.ts_column_name,
+                batch.schema()
+            )
+        })
     }
 
     fn batch_max_ts_ms(&self, batch: &RecordBatch, ts_column_index: usize) -> Option<u64> {
@@ -180,13 +138,12 @@ pub struct WatermarkManager {
 impl WatermarkManager {
     pub fn new(
         watermark_assign: Option<WatermarkAssignConfig>,
-        operator_config: Option<&OperatorConfig>,
         upstream_vertices: Vec<String>,
         upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
         current_watermark: Arc<AtomicU64>,
     ) -> Self {
         let idle_timeout_ms = watermark_assign.as_ref().and_then(|cfg| cfg.idle_timeout_ms);
-        let assigner = watermark_assign.map(|cfg| WatermarkAssignerState::new(cfg, operator_config));
+        let assigner = watermark_assign.map(WatermarkAssignerState::new);
         let last_seen_processing_time = upstream_vertices
             .iter()
             .map(|u| (u.clone(), Instant::now()))
@@ -339,12 +296,12 @@ mod tests {
 
         let cfg = WatermarkAssignConfig {
             out_of_orderness_ms: 0,
-            time_hint: Some(TimeHint::ColumnName {
+            time_hint: TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
             idle_timeout_ms: Some(WatermarkAssignConfig::DEFAULT_IDLE_TIMEOUT_MS),
         };
-        let mut assigner = WatermarkAssignerState::new(cfg, None);
+        let mut assigner = WatermarkAssignerState::new(cfg);
 
         let wm1 = assigner.on_data_message("upA", &msg).unwrap();
         assert_eq!(wm1.metadata.upstream_vertex_id.as_deref(), Some("upA"));
@@ -386,17 +343,14 @@ mod tests {
 
         let cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string()],
             Arc::new(Mutex::new(HashMap::new())),
@@ -460,17 +414,14 @@ mod tests {
         let input = Box::pin(stream::iter(vec![m0, m1]));
         let cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string(), "u1".to_string()],
             Arc::new(Mutex::new(HashMap::new())),
@@ -523,18 +474,15 @@ mod tests {
 
         let mut cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
         cfg.idle_timeout_ms = Some(1);
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string(), "u1".to_string()],
             Arc::new(Mutex::new(HashMap::new())),
@@ -580,18 +528,15 @@ mod tests {
 
         let mut cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
         cfg.idle_timeout_ms = None;
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string(), "u1".to_string()],
             Arc::new(Mutex::new(HashMap::new())),

--- a/src/runtime/worker_server.rs
+++ b/src/runtime/worker_server.rs
@@ -504,7 +504,9 @@ impl WorkerServer {
         let addr = addr.parse()?;
         let service = worker_service::worker_service_server::WorkerServiceServer::new(
             self.service.clone()
-        );
+        )
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[WORKER_SERVER] Starting WorkerService server on {}", addr);
         
@@ -550,7 +552,10 @@ impl WorkerServer {
             match endpoint.clone().connect().await {
                 Ok(channel) => match tokio::time::timeout(
                     rpc_timeout,
-                    MasterServiceClient::new(channel).register_worker(tonic::Request::new(req)),
+                    MasterServiceClient::new(channel)
+                        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .register_worker(tonic::Request::new(req)),
                 )
                 .await
                 {

--- a/src/storage/in_memory_storage_grpc_client.rs
+++ b/src/storage/in_memory_storage_grpc_client.rs
@@ -40,8 +40,8 @@ impl InMemoryStorageClient {
                 Ok(client) => {
                     println!("[IN_MEMORY_STORAGE_CLIENT] Successfully connected to {} on attempt {}", addr, attempt + 1);
                     let client = client
-                        .max_decoding_message_size(12*1024*1024)
-                        .max_encoding_message_size(12*1024*1024); // 12 MB
+                        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
                     
                     return Ok(Self { client });
                 }

--- a/src/storage/in_memory_storage_grpc_server.rs
+++ b/src/storage/in_memory_storage_grpc_server.rs
@@ -216,7 +216,9 @@ impl InMemoryStorageServer {
         let addr = addr.parse()?;
         let service = in_memory_storage_service::in_memory_storage_service_server::InMemoryStorageServiceServer::new(
             self.service.clone()
-        );
+        )
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[IN_MEMORY_STORAGE_SERVER] Starting InMemoryStorageService server on {}", addr);
         
@@ -225,7 +227,7 @@ impl InMemoryStorageServer {
         
         let server_handle = tokio::spawn(async move {
             match tonic::transport::Server::builder()
-                .max_frame_size(Some(12 * 1024 * 1024)) // 12MB
+                .max_frame_size(Some(crate::common::GRPC_MAX_MESSAGE_BYTES as u32))
                 .add_service(service)
                 .serve_with_shutdown(addr, async {
                     shutdown_receiver.await.ok();

--- a/src/tests/inprocess/transport/grpc_streaming.rs
+++ b/src/tests/inprocess/transport/grpc_streaming.rs
@@ -20,7 +20,9 @@ pub async fn start_server(
     println!("[SERVER] Starting gRPC server on {}", addr);
     let addr = addr.parse()?;
     let service = MessageStreamServiceImpl::new(tx);
-    let svc = MessageStreamServiceServer::new(service);
+    let svc = MessageStreamServiceServer::new(service)
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
     println!("[SERVER] gRPC server listening on {}", addr);
     let router = Server::builder().add_service(svc);

--- a/src/tests/inprocess/watermark_streaming.rs
+++ b/src/tests/inprocess/watermark_streaming.rs
@@ -118,7 +118,7 @@ pub(crate) async fn run_watermark_window_pipeline(
     exec_graph.configure_channels(None, None);
     let vertex_ids = exec_graph.get_vertices().keys().cloned().collect();
 
-    // Sanity: ensure we actually built a window operator (planner-side watermark placement should attach to it).
+    // Sanity: window exists; watermark assign is on Source (pre-KeyBy), not Window.
     assert!(
         exec_graph
             .get_vertices()
@@ -126,6 +126,26 @@ pub(crate) async fn run_watermark_window_pipeline(
             .any(|v| matches!(v.operator_config, OperatorConfig::WindowConfig(_))),
         "expected execution graph to contain a Window operator"
     );
+    let assign_vertices: Vec<_> = exec_graph
+        .get_vertices()
+        .values()
+        .filter(|v| v.watermark_assign.is_some())
+        .collect();
+    assert!(
+        !assign_vertices.is_empty(),
+        "expected watermark_assign on at least one vertex"
+    );
+    for v in &assign_vertices {
+        assert!(
+            matches!(v.operator_config, OperatorConfig::SourceConfig(_)),
+            "watermark_assign should be on Source, got {:?}",
+            v.operator_config
+        );
+        assert!(
+            !matches!(v.operator_config, OperatorConfig::WindowConfig(_)),
+            "Window must not have watermark_assign"
+        );
+    }
 
     let mut worker = Worker::from_config(WorkerConfig::new(
         "wm-e2e-worker".to_string(),

--- a/src/transport/grpc/grpc_streaming_service.rs
+++ b/src/transport/grpc/grpc_streaming_service.rs
@@ -1,6 +1,7 @@
 use tonic::{Request, Response, Status};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
+use crate::common::grpc::GRPC_MAX_MESSAGE_BYTES;
 use crate::common::message::Message;
 use crate::runtime::consts::{
     runtime_consts, TRANSPORT_GRPC_CONNECT_MAX_RETRIES, TRANSPORT_GRPC_CONNECT_RETRY_DELAY,
@@ -81,6 +82,9 @@ impl MessageStreamClient {
         for attempt in 0..=max_retries {
             match MessageStreamServiceClient::connect(addr.clone()).await {
                 Ok(client) => {
+                    let client = client
+                        .max_decoding_message_size(GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(GRPC_MAX_MESSAGE_BYTES);
                     println!("[GRPC_CLIENT] Successfully connected to {} after {} attempts", addr, attempt + 1);
                     return Ok(Self { client });
                 }

--- a/src/transport/transport_backend.rs
+++ b/src/transport/transport_backend.rs
@@ -193,7 +193,9 @@ impl TransportBackend {
                 .parse()
                 .expect("[GRPC_BACKEND] invalid listen address");
             let service = MessageStreamServiceImpl::new(server_tx);
-            let svc = MessageStreamServiceServer::new(service);
+            let svc = MessageStreamServiceServer::new(service)
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
             println!("[GRPC_BACKEND] Starting gRPC server on {}", addr);
 


### PR DESCRIPTION
## Summary
- Resolve window ORDER BY event-time column lineage in the DF plan and attach `watermark_assign` (`TimeHint::ColumnName`) on the defining Source/Projection, before KeyBy.
- Remove closest-window BFS placement and Window-side assign/derive paths so Window only min-merges upstream watermarks.
- Fixes [#169](https://github.com/volga-project/volga/issues/169): keyed fragments no longer advance global WM and late-drop sibling keys from the same batch.
- Raise inmem window checkpoint inline limit to 8 MiB (WM fix retains more state) and log checkpoint size on each inmem snapshot.

## How assign placement works
1. Find windows in the DF plan that need event-time watermarks.
2. Read the window `ORDER BY` column — that is the event-time column (must be a real column).
3. Walk backward through the plan to where that column is **defined**:
   - Filter / rename alias (`timestamp AS event_time`) → keep walking with the inner column.
   - Computed expression (e.g. `timestamp + INTERVAL '0' MILLISECOND AS event_time`) → **stop at that Projection** (it creates the column the assigner will read).
   - Table scan → stop at that **Source**.
   - Join / multi-input → unsupported for auto placement for now.
4. Attach `watermark_assign` (`ColumnName` + ooo/idle) on that Source/Projection in the Volga graph.
5. Validate the assign site is **upstream of the window’s KeyBy** so WM is generated on the full (pre-split) batch.
6. Window has no assigner — it only min-merges upstream WMs.

## Test plan
- [x] Lineage unit tests (source / rename / computed / join error)
- [x] Planner window placement asserts (assign on Source, absent on Window/KeyBy)
- [x] Watermark streaming e2e late-drop == 0
- [x] `test_local_single_worker_window_checkpoint_restore` + multi-worker
- [x] Local stress 10× both window restore tests
- [ ] CI green after 8 MiB inmem limit bump