### PR TITLE
Add configurable inproc/kube stress machines for CI

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -10,15 +10,32 @@ on:
   workflow_dispatch:
     inputs:
       profile:
-        description: "Test profile (default=unit+inprocess; all=default+docker+kube)"
+        description: "Test profile (default=unit+inprocess; all=default+docker+kube; kube-stress / inproc-stress)"
         type: choice
         options:
           - default
           - docker
           - kube
           - all
-          - stress
+          - kube-stress
+          - inproc-stress
         default: default
+      stress_test:
+        description: "Exact test name for inproc-stress (ignored otherwise)"
+        type: string
+        default: test_local_multi_worker_window_checkpoint_restore
+      stress_machines:
+        description: "CI runners (machines) for kube-stress / inproc-stress"
+        type: string
+        default: "3"
+      stress_shards_per_machine:
+        description: "Parallel stress processes per machine (kube default 1 = one Kind cluster)"
+        type: string
+        default: "1"
+      stress_runs_per_shard:
+        description: "Iterations per shard for kube-stress / inproc-stress"
+        type: string
+        default: "10"
 
 concurrency:
   # PRs cancel superseded runs; scheduled stress must not cancel itself (jobs can exceed 1h).
@@ -137,14 +154,65 @@ jobs:
       - if: always()
         run: scripts/kube-test-env destroy
 
+  # Resolve machines × shards-per-machine for stress jobs.
+  # machine = GitHub runner (isolation); shard = parallel process on that runner
+  # (kube: usually 1 = one Kind cluster; inproc: usually 1 to avoid interference).
+  stress-config:
+    if: >
+      github.event_name == 'schedule' ||
+      inputs.profile == 'kube-stress' ||
+      inputs.profile == 'inproc-stress'
+    runs-on: ubuntu-latest
+    outputs:
+      machine_ids: ${{ steps.config.outputs.machine_ids }}
+      shards_per_machine: ${{ steps.config.outputs.shards_per_machine }}
+      runs_per_shard: ${{ steps.config.outputs.runs_per_shard }}
+    steps:
+      - id: config
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            machines=3
+            shards=1
+            runs=10
+          else
+            machines="${{ inputs.stress_machines }}"
+            shards="${{ inputs.stress_shards_per_machine }}"
+            runs="${{ inputs.stress_runs_per_shard }}"
+          fi
+          for name in machines shards runs; do
+            val="${!name}"
+            if [[ ! "$val" =~ ^[1-9][0-9]*$ ]]; then
+              echo "$name must be a positive integer, got: $val" >&2
+              exit 2
+            fi
+          done
+          if (( machines > 16 )); then
+            echo "stress_machines max is 16, got: $machines" >&2
+            exit 2
+          fi
+          machine_ids="$(python3 -c "import json; print(json.dumps(list(range(1, int('${machines}') + 1))))")"
+          echo "machines=$machines shards_per_machine=$shards runs_per_shard=$runs"
+          echo "machine_ids=$machine_ids"
+          {
+            echo "machine_ids=$machine_ids"
+            echo "shards_per_machine=$shards"
+            echo "runs_per_shard=$runs"
+          } >> "$GITHUB_OUTPUT"
+
   kube-stress:
-    if: github.event_name == 'schedule' || inputs.profile == 'stress'
+    needs: stress-config
+    if: >
+      always() &&
+      needs.stress-config.result == 'success' &&
+      (github.event_name == 'schedule' || inputs.profile == 'kube-stress')
     runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        machine: ${{ fromJSON(needs.stress-config.outputs.machine_ids) }}
     env:
       CARGO_INCREMENTAL: "0"
       VOLGA_DOCKER_CACHE: gha
@@ -170,11 +238,77 @@ jobs:
       - uses: helm/kind-action@v1
         with:
           install_only: true
-      - run: scripts/test stress --env kube --all --runs-per-shard 10 --shards 1 --fresh-cluster
+      - name: Run kube stress
+        run: |
+          set -euo pipefail
+          shards="${{ needs.stress-config.outputs.shards_per_machine }}"
+          runs="${{ needs.stress-config.outputs.runs_per_shard }}"
+          echo "kube-stress machine=${{ matrix.machine }} shards_per_machine=$shards runs_per_shard=$runs"
+          scripts/test stress --env kube --all \
+            --runs-per-shard "$runs" \
+            --shards "$shards" \
+            --fresh-cluster
       - if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: kube-stress-logs-shard-${{ matrix.shard }}
+          name: kube-stress-logs-machine-${{ matrix.machine }}
+          path: target/stress/
+          if-no-files-found: warn
+          retention-days: 14
+
+  # Inprocess stress with the same machine × shard knobs (machine = runner isolation).
+  inproc-stress:
+    needs: stress-config
+    if: >
+      always() &&
+      needs.stress-config.result == 'success' &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.profile == 'inproc-stress'
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        machine: ${{ fromJSON(needs.stress-config.outputs.machine_ids) }}
+    env:
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            pkg-config \
+            protobuf-compiler \
+            libprotobuf-dev \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            libsasl2-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Run inproc stress
+        run: |
+          set -euo pipefail
+          test_name="${{ inputs.stress_test }}"
+          shards="${{ needs.stress-config.outputs.shards_per_machine }}"
+          runs="${{ needs.stress-config.outputs.runs_per_shard }}"
+          if [[ -z "$test_name" ]]; then
+            echo "stress_test input is required for inproc-stress" >&2
+            exit 2
+          fi
+          echo "inproc-stress machine=${{ matrix.machine }} test=$test_name shards_per_machine=$shards runs_per_shard=$runs"
+          scripts/test stress --env local \
+            --test "$test_name" \
+            --runs-per-shard "$runs" \
+            --shards "$shards"
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: inproc-stress-logs-machine-${{ matrix.machine }}
           path: target/stress/
           if-no-files-found: warn
           retention-days: 14

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,8 +31,21 @@ CI runs `default` as the required job, plus parallel non-blocking `docker` and
 ### One-off CI runs (`workflow_dispatch`)
 
 GitHub → **Actions** → **Rust tests** → **Run workflow**: pick branch +
-`profile` (`default` / `unit` / `inprocess` / `docker` / `kube` / `all` /
-`stress`).
+`profile` (`default` / `docker` / `kube` / `all` / `kube-stress` /
+`inproc-stress`).
+
+Stress knobs (shared by `kube-stress` / `inproc-stress`):
+
+| Input | Default | Meaning |
+| --- | --- | --- |
+| `stress_machines` | `3` | GitHub runners (machine isolation) |
+| `stress_shards_per_machine` | `1` | Parallel stress processes per runner |
+| `stress_runs_per_shard` | `10` | Iterations per process |
+| `stress_test` | (inproc default) | Exact test name; `inproc-stress` only |
+
+Schedule uses 3 machines × 1 shard × 10 runs (kube). Prefer
+`stress_shards_per_machine=1` so parallelism comes from machines, not
+co-tenancy on one runner.
 
 Or from the CLI (same inputs):
 
@@ -43,11 +56,25 @@ gh workflow run rust-tests.yml --ref "$(git branch --show-current)" -f profile=d
 # Kube-only
 gh workflow run rust-tests.yml --ref "$(git branch --show-current)" -f profile=kube
 
-# On-demand kube stress (3 shards, same as the schedule)
-gh workflow run rust-tests.yml --ref "$(git branch --show-current)" -f profile=stress
+# On-demand kube stress (same shape as the schedule)
+gh workflow run rust-tests.yml --ref "$(git branch --show-current)" \
+  -f profile=kube-stress \
+  -f stress_machines=3 \
+  -f stress_shards_per_machine=1 \
+  -f stress_runs_per_shard=10
+
+# On-demand inprocess stress for one test (4 isolated runners)
+gh workflow run rust-tests.yml --ref "$(git branch --show-current)" \
+  -f profile=inproc-stress \
+  -f stress_test=test_local_multi_worker_window_checkpoint_restore \
+  -f stress_machines=4 \
+  -f stress_shards_per_machine=1 \
+  -f stress_runs_per_shard=10
 ```
 
-`stress` skips the normal test/docker/kube jobs and only runs `kube-stress`.
+`kube-stress` / `inproc-stress` skip the normal test/docker/kube jobs.
+`inproc-stress` runs `scripts/test stress --env local` for `stress_test`.
+Logs upload per machine from `target/stress/`.
 `docker` / `kube` run just that env job. `unit` / `inprocess` / `default` run
 the required `test` job with that profile (and may still start sibling
 docker/kube jobs unless you pick an env-only profile).
@@ -104,7 +131,7 @@ scripts/test inprocess --filter 'test(test_local_single_worker_window_checkpoint
 The stress runner repeats the **kube** suite (or selected kube tests) across
 parallel shards. It writes one log per shard under `target/stress/` and stops
 scheduling new iterations after the first failure. Prefer `--env kube` (Kind);
-CI schedule and on-demand `profile=stress` use the same path.
+CI schedule and on-demand `profile=kube-stress` use the same path.
 
 ```bash
 # Full kube profile, fresh Kind cluster each iteration.


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` profiles `kube-stress` / `inproc-stress` with knobs for machines × shards-per-machine × runs
- Document the CI stress inputs in `scripts/README.md`

## Test plan
- [ ] Dispatch `inproc-stress` with 2 machines × 1 shard × 1 run on a known test
- [ ] Confirm schedule still runs kube-stress (3×1×10)


Made with [Cursor](https://cursor.com)