### PR TITLE
Disable interval checkpoints during StopSources drain

### DIFF
--- a/scripts/stress-test
+++ b/scripts/stress-test
@@ -159,6 +159,10 @@ done
 
 echo "Stress logs: $LOG_DIR"
 if [[ "$failed" -ne 0 ]]; then
-  rg -n "Error: |=== $ENVIRONMENT shard .*: fail ===" "$LOG_DIR" || true
+  if command -v rg >/dev/null 2>&1; then
+    rg -n "Error: |=== $ENVIRONMENT shard .*: fail ===" "$LOG_DIR" || true
+  else
+    grep -REn "Error: |=== $ENVIRONMENT shard .*: fail ===" "$LOG_DIR" || true
+  fi
 fi
 exit "$failed"

--- a/src/common/grpc.rs
+++ b/src/common/grpc.rs
@@ -1,0 +1,5 @@
+/// Max gRPC message size for control-plane and transport RPCs.
+///
+/// Must stay above the in-memory window checkpoint inline limit (8 MiB) so
+/// checkpoint/restore payloads are not rejected by tonic's 4 MiB default.
+pub const GRPC_MAX_MESSAGE_BYTES: usize = 12 * 1024 * 1024;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod grpc;
 pub mod message;
 pub mod ports;
 #[cfg(test)]
@@ -5,6 +6,8 @@ pub mod test_utils;
 pub mod key;
 pub mod types;
 pub mod failure;
+
+pub use grpc::GRPC_MAX_MESSAGE_BYTES;
 
 pub use message::*;
 pub use key::Key;

--- a/src/runtime/master/attempt/execute.rs
+++ b/src/runtime/master/attempt/execute.rs
@@ -60,11 +60,16 @@ impl ExecutionAttempt {
                     return Ok(self.await_failure_window_and_recover(failure).await);
                 }
                 _ = optional_tick(&mut checkpoint_tick) => {
-                    if let Err(error) = self.begin_checkpoint().await {
-                        println!(
-                            "[MASTER] Interval checkpoint skipped attempt={}: {}",
-                            self.id, error
-                        );
+                    match self.begin_checkpoint().await {
+                        Ok(_) => {}
+                        // Expected after StopSources; do not spam.
+                        Err(error) if error == "sources stopped for drain" => {}
+                        Err(error) => {
+                            println!(
+                                "[MASTER] Interval checkpoint skipped attempt={}: {}",
+                                self.id, error
+                            );
+                        }
                     }
                 }
                 state_poll = async {
@@ -130,6 +135,7 @@ impl ExecutionAttempt {
                 CheckpointStartError::NoCheckpointableTasks => {
                     "no checkpointable tasks".to_string()
                 }
+                CheckpointStartError::Disabled => "sources stopped for drain".to_string(),
             })?;
         println!(
             "[MASTER] Triggering checkpoint {} attempt={}",

--- a/src/runtime/master/checkpoint/mod.rs
+++ b/src/runtime/master/checkpoint/mod.rs
@@ -20,6 +20,8 @@ pub use store::{create_checkpoint_store, CheckpointStore, InMemoryCheckpointStor
 pub enum CheckpointStartError {
     AlreadyInFlight { checkpoint_id: u64 },
     NoCheckpointableTasks,
+    /// Sources were stopped for drain; new checkpoints must not start.
+    Disabled,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,6 +55,8 @@ pub struct Checkpoints {
     protocol: CheckpointProtocol,
     store: Option<Arc<dyn CheckpointStore>>,
     pending: HashMap<u64, HashMap<TaskKey, SerializedCheckpoint>>,
+    /// Cleared on `StopSources` so interval ticks cannot open a CP on a draining graph.
+    enabled: bool,
 }
 
 impl Default for Checkpoints {
@@ -65,6 +69,7 @@ impl Default for Checkpoints {
             protocol: CheckpointProtocol::default(),
             store: None,
             pending: HashMap::new(),
+            enabled: true,
         }
     }
 }
@@ -85,9 +90,17 @@ impl Checkpoints {
         self.store = Some(store);
         self.protocol = CheckpointProtocol::default();
         self.pending.clear();
+        self.enabled = true;
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
     }
 
     pub fn start(&mut self) -> Result<u64, CheckpointStartError> {
+        if !self.enabled {
+            return Err(CheckpointStartError::Disabled);
+        }
         self.protocol
             .start(&self.expected_acks, &self.expected_aligns)
     }
@@ -282,6 +295,18 @@ mod tests {
         assert!(cps.load(id).await.is_err());
         assert_eq!(cps.abort_in_flight().await.unwrap(), Some(id));
         assert!(cps.load(id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn disabled_rejects_start() {
+        let mut cps = Checkpoints::default();
+        let acks: HashSet<_> = [task("a", 0)].into_iter().collect();
+        let aligns = acks.clone();
+        cps.configure(pipeline(), acks, aligns, 1, store());
+        cps.set_enabled(false);
+        assert_eq!(cps.start(), Err(CheckpointStartError::Disabled));
+        cps.set_enabled(true);
+        assert!(cps.start().is_ok());
     }
 
     #[tokio::test]

--- a/src/runtime/master/lifecycle.rs
+++ b/src/runtime/master/lifecycle.rs
@@ -31,6 +31,7 @@ impl MasterLifecycle {
                 })
                 .await;
             self.state.set_current_attempt_id(execution_attempt_id);
+            self.state.enable_checkpoints().await;
             let mut attempt = ExecutionAttempt::new(
                 execution_attempt_id,
                 restore_checkpoint_id,

--- a/src/runtime/master/mod.rs
+++ b/src/runtime/master/mod.rs
@@ -106,6 +106,11 @@ impl Master {
             .current_execution_worker_endpoints()
             .await
             .ok_or_else(|| "no workers on current execution attempt".to_string())?;
+        // Disable interval CPs before stopping sources so a tick cannot open a
+        // barrier on an already-draining graph (acks/aligns stay at 0 forever).
+        self.state
+            .disable_checkpoints_for_drain(execution_attempt_id)
+            .await?;
         let futures = workers.iter().map(|(worker_id, addr)| {
             let worker_id = worker_id.clone();
             let addr = addr.clone();
@@ -152,6 +157,9 @@ impl Master {
                 } => format!("already in flight checkpoint_id={checkpoint_id}"),
                 crate::runtime::master::checkpoint::CheckpointStartError::NoCheckpointableTasks => {
                     "no checkpointable tasks".to_string()
+                }
+                crate::runtime::master::checkpoint::CheckpointStartError::Disabled => {
+                    "sources stopped for drain".to_string()
                 }
             })
     }

--- a/src/runtime/master/server.rs
+++ b/src/runtime/master/server.rs
@@ -50,7 +50,9 @@ impl MasterServer {
     pub async fn start(&mut self, addr: &str) -> anyhow::Result<()> {
         let addr = addr.parse()?;
         let service =
-            master_service::master_service_server::MasterServiceServer::new(self.service.clone());
+            master_service::master_service_server::MasterServiceServer::new(self.service.clone())
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[MASTER_SERVER] Starting MasterService server on {}", addr);
 

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -280,6 +280,37 @@ impl MasterState {
         self.current_attempt_id.load(Ordering::SeqCst)
     }
 
+    pub(super) async fn enable_checkpoints(&self) {
+        self.checkpoints.lock().await.set_enabled(true);
+    }
+
+    /// Stop taking new checkpoints and drop any in-flight one (pipeline is draining).
+    pub(super) async fn disable_checkpoints_for_drain(
+        &self,
+        attempt_id: u64,
+    ) -> Result<Option<u64>, String> {
+        let mut checkpoints = self.checkpoints.lock().await;
+        checkpoints.set_enabled(false);
+        let checkpoint_id = checkpoints
+            .abort_in_flight()
+            .await
+            .map_err(|error| format!("failed to remove aborted checkpoint: {error}"))?;
+        drop(checkpoints);
+        if let Some(checkpoint_id) = checkpoint_id {
+            self.record_lifecycle_event(LifecycleEvent::CheckpointFailed {
+                checkpoint_id,
+                attempt_id,
+                detail: "aborted: sources stopped for drain".to_string(),
+            })
+            .await;
+            println!(
+                "[MASTER] Checkpoint {} aborted: sources stopped for drain attempt={}",
+                checkpoint_id, attempt_id
+            );
+        }
+        Ok(checkpoint_id)
+    }
+
     pub(super) async fn begin_checkpoint(
         &self,
         attempt_id: u64,

--- a/src/runtime/master/worker_client.rs
+++ b/src/runtime/master/worker_client.rs
@@ -114,7 +114,11 @@ pub(super) async fn connect_worker_client(
     endpoint
         .connect()
         .await
-        .map(WorkerServiceClient::new)
+        .map(|channel| {
+            WorkerServiceClient::new(channel)
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        })
         .map_err(|e| format!("connect to {addr} failed: {e}"))
 }
 

--- a/src/runtime/operators/window/README.md
+++ b/src/runtime/operators/window/README.md
@@ -155,7 +155,7 @@ partitioning, publication, fencing, caching, and cleanup. They must preserve:
 uses one read lock as the WRO snapshot boundary, and embeds complete namespace
 snapshots, including durable triggers, in checkpoint data. Its live state
 remains process-local and is not a cross-worker backend. It is intended only
-for development and tests: inline checkpoint snapshots are limited to 3 MiB to
+for development and tests: inline checkpoint snapshots are limited to 8 MiB to
 stay below the gRPC control-plane message limit.
 
 ## Checkpoint and restore

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -22,7 +22,7 @@ use crate::runtime::operators::window::store::{
     KeyState, PartitionKey, StateNamespace, TileMap, WindowData,
 };
 
-const MAX_INLINE_CHECKPOINT_BYTES: usize = 3 * 1024 * 1024;
+const MAX_INLINE_CHECKPOINT_BYTES: usize = 8 * 1024 * 1024;
 
 fn validate_checkpoint_size(snapshot: &[u8]) -> Result<()> {
     anyhow::ensure!(
@@ -61,7 +61,7 @@ struct InMemState {
     triggers: BTreeSet<WindowTrigger>,
 }
 
-/// Development/test reference backend with inline checkpoints limited to 3 MiB.
+/// Development/test reference backend with inline checkpoints limited to 8 MiB.
 /// One read lock is the WRO snapshot boundary.
 #[derive(Debug, Clone, Default)]
 pub struct InMemWindowStore {
@@ -276,6 +276,13 @@ impl WindowOperatorStore for InMemWindowStore {
                 .collect(),
         };
         let snapshot = bincode::serialize(&checkpoint)?;
+        println!(
+            "[WINDOW][INMEM] checkpoint size={} bytes (limit={} bytes, partitions={}, triggers={})",
+            snapshot.len(),
+            MAX_INLINE_CHECKPOINT_BYTES,
+            checkpoint.partitions.len(),
+            checkpoint.triggers.len(),
+        );
         validate_checkpoint_size(&snapshot)?;
         Ok(WindowBackendSnapshot::InMemory { snapshot })
     }

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -547,6 +547,11 @@ impl StreamTask {
                 Some(
                     MasterServiceClient::connect(endpoint)
                         .await
+                        .map(|client| {
+                            client
+                                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        })
                         .map_err(|e| anyhow::anyhow!("Failed to connect to master service: {}", e))?,
                 )
             } else {

--- a/src/runtime/worker_server.rs
+++ b/src/runtime/worker_server.rs
@@ -504,7 +504,9 @@ impl WorkerServer {
         let addr = addr.parse()?;
         let service = worker_service::worker_service_server::WorkerServiceServer::new(
             self.service.clone()
-        );
+        )
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[WORKER_SERVER] Starting WorkerService server on {}", addr);
         
@@ -550,7 +552,10 @@ impl WorkerServer {
             match endpoint.clone().connect().await {
                 Ok(channel) => match tokio::time::timeout(
                     rpc_timeout,
-                    MasterServiceClient::new(channel).register_worker(tonic::Request::new(req)),
+                    MasterServiceClient::new(channel)
+                        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .register_worker(tonic::Request::new(req)),
                 )
                 .await
                 {

--- a/src/storage/in_memory_storage_grpc_client.rs
+++ b/src/storage/in_memory_storage_grpc_client.rs
@@ -40,8 +40,8 @@ impl InMemoryStorageClient {
                 Ok(client) => {
                     println!("[IN_MEMORY_STORAGE_CLIENT] Successfully connected to {} on attempt {}", addr, attempt + 1);
                     let client = client
-                        .max_decoding_message_size(12*1024*1024)
-                        .max_encoding_message_size(12*1024*1024); // 12 MB
+                        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
                     
                     return Ok(Self { client });
                 }

--- a/src/storage/in_memory_storage_grpc_server.rs
+++ b/src/storage/in_memory_storage_grpc_server.rs
@@ -216,7 +216,9 @@ impl InMemoryStorageServer {
         let addr = addr.parse()?;
         let service = in_memory_storage_service::in_memory_storage_service_server::InMemoryStorageServiceServer::new(
             self.service.clone()
-        );
+        )
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[IN_MEMORY_STORAGE_SERVER] Starting InMemoryStorageService server on {}", addr);
         
@@ -225,7 +227,7 @@ impl InMemoryStorageServer {
         
         let server_handle = tokio::spawn(async move {
             match tonic::transport::Server::builder()
-                .max_frame_size(Some(12 * 1024 * 1024)) // 12MB
+                .max_frame_size(Some(crate::common::GRPC_MAX_MESSAGE_BYTES as u32))
                 .add_service(service)
                 .serve_with_shutdown(addr, async {
                     shutdown_receiver.await.ok();

--- a/src/tests/inprocess/transport/grpc_streaming.rs
+++ b/src/tests/inprocess/transport/grpc_streaming.rs
@@ -20,7 +20,9 @@ pub async fn start_server(
     println!("[SERVER] Starting gRPC server on {}", addr);
     let addr = addr.parse()?;
     let service = MessageStreamServiceImpl::new(tx);
-    let svc = MessageStreamServiceServer::new(service);
+    let svc = MessageStreamServiceServer::new(service)
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
     println!("[SERVER] gRPC server listening on {}", addr);
     let router = Server::builder().add_service(svc);

--- a/src/transport/grpc/grpc_streaming_service.rs
+++ b/src/transport/grpc/grpc_streaming_service.rs
@@ -1,6 +1,7 @@
 use tonic::{Request, Response, Status};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
+use crate::common::grpc::GRPC_MAX_MESSAGE_BYTES;
 use crate::common::message::Message;
 use crate::runtime::consts::{
     runtime_consts, TRANSPORT_GRPC_CONNECT_MAX_RETRIES, TRANSPORT_GRPC_CONNECT_RETRY_DELAY,
@@ -81,6 +82,9 @@ impl MessageStreamClient {
         for attempt in 0..=max_retries {
             match MessageStreamServiceClient::connect(addr.clone()).await {
                 Ok(client) => {
+                    let client = client
+                        .max_decoding_message_size(GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(GRPC_MAX_MESSAGE_BYTES);
                     println!("[GRPC_CLIENT] Successfully connected to {} after {} attempts", addr, attempt + 1);
                     return Ok(Self { client });
                 }

--- a/src/transport/transport_backend.rs
+++ b/src/transport/transport_backend.rs
@@ -193,7 +193,9 @@ impl TransportBackend {
                 .parse()
                 .expect("[GRPC_BACKEND] invalid listen address");
             let service = MessageStreamServiceImpl::new(server_tx);
-            let svc = MessageStreamServiceServer::new(service);
+            let svc = MessageStreamServiceServer::new(service)
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
             println!("[GRPC_BACKEND] Starting gRPC server on {}", addr);
 


### PR DESCRIPTION
## Summary
- On `StopSources`, disable new interval checkpoints and abort any in-flight CP so drain can finish (`acks=0/N` hang)
- Re-enable checkpoints when a new execution attempt starts
- Make `scripts/stress-test` tolerate missing `rg`

Depends on #181.

## Test plan
- [ ] `scripts/test stress --env local --test test_local_multi_worker_window_checkpoint_restore --runs-per-shard 10 --shards 4`
- [ ] Confirm no hang with `acks=0/N` after `StopSources`