### PR TITLE
Place watermark assign via plan lineage before KeyBy

### DIFF
--- a/src/api/event_time_placement.rs
+++ b/src/api/event_time_placement.rs
@@ -346,6 +346,11 @@ pub fn apply_auto_watermark_assigns(plan: &LogicalPlan, graph: &mut LogicalGraph
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::logical_graph::LogicalNode;
+    use crate::api::planner::{Planner, PlanningContext};
+    use crate::runtime::operators::operator::OperatorConfig;
+    use crate::runtime::operators::source::source_operator::{SourceConfig, VectorSourceConfig};
+    use crate::runtime::watermark::TimeHint;
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use datafusion::catalog::MemTable;
     use datafusion::prelude::SessionContext;
@@ -383,6 +388,36 @@ mod tests {
         found.expect("expected a Window in plan")
     }
 
+    fn planner_with_events() -> Planner {
+        let mut planner = Planner::new(PlanningContext::new(SessionContext::new()));
+        planner.register_source(
+            "events".to_string(),
+            SourceConfig::VectorSourceConfig(VectorSourceConfig::new(vec![])),
+            events_schema(),
+        );
+        planner
+    }
+
+    fn assign_nodes(graph: &LogicalGraph) -> Vec<&LogicalNode> {
+        graph
+            .get_nodes()
+            .filter(|n| n.watermark_assign.is_some())
+            .collect()
+    }
+
+    fn assert_time_hint_column(node: &LogicalNode, expected: &str) {
+        let hint = &node
+            .watermark_assign
+            .as_ref()
+            .expect("expected watermark_assign")
+            .time_hint;
+        assert!(
+            matches!(hint, TimeHint::ColumnName { name } if name == expected),
+            "expected ColumnName({expected}), got {hint:?} on {}",
+            node.operator_id
+        );
+    }
+
     #[tokio::test]
     async fn lineage_passthrough_column_stops_at_source() {
         let plan = plan_sql(
@@ -390,6 +425,26 @@ mod tests {
              SUM(value) OVER (PARTITION BY key ORDER BY timestamp \
              RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
              FROM events",
+        )
+        .await;
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        assert_eq!(
+            site,
+            AssignSite::Source {
+                table_name: "events".to_string(),
+                column_name: "timestamp".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn lineage_filter_on_path_still_stops_at_source() {
+        let plan = plan_sql(
+            "SELECT timestamp, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY timestamp \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM events WHERE value > 0",
         )
         .await;
         let window = find_window(&plan);
@@ -443,6 +498,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn lineage_rename_above_computed_stops_on_defining_projection() {
+        // Use the unoptimized plan so nested projs are not folded away: peel
+        // `event_time` → `et`, then stop on the computed Projection output `et`.
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
+        ctx.register_table("events", Arc::new(table)).unwrap();
+        let sql = "SELECT event_time, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY event_time \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM ( \
+               SELECT et AS event_time, key, value FROM ( \
+                 SELECT timestamp + INTERVAL '0' MILLISECOND AS et, key, value FROM events \
+               ) \
+             )";
+        let df = ctx.sql(sql).await.unwrap();
+        let plan = df.logical_plan().clone();
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        assert_eq!(
+            site,
+            AssignSite::Projection {
+                column_name: "et".to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn lineage_order_by_non_column_errors() {
+        let plan = plan_sql(
+            "SELECT timestamp, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY timestamp + INTERVAL '0' MILLISECOND \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM events",
+        )
+        .await;
+        let window = find_window(&plan);
+        let err = resolve_event_time_assign_site(&window).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("window ORDER BY must be a column"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
     async fn lineage_join_on_path_errors() {
         let ctx = SessionContext::new();
         let table = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
@@ -462,6 +562,121 @@ mod tests {
         assert!(
             msg.contains("unsupported for auto watermark placement"),
             "unexpected error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_passthrough_attaches_on_source_not_keyby_or_window() {
+        let mut planner = planner_with_events();
+        let graph = planner
+            .sql_to_graph(
+                "SELECT timestamp, key, value, \
+                 SUM(value) OVER (PARTITION BY key ORDER BY timestamp \
+                 RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+                 FROM events",
+            )
+            .unwrap();
+
+        let assigns = assign_nodes(&graph);
+        assert_eq!(assigns.len(), 1, "expected exactly one assign site");
+        assert!(
+            matches!(assigns[0].operator_config, OperatorConfig::SourceConfig(_)),
+            "expected Source assign, got {:?}",
+            assigns[0].operator_config
+        );
+        assert_time_hint_column(assigns[0], "timestamp");
+
+        for node in graph.get_nodes() {
+            if matches!(
+                node.operator_config,
+                OperatorConfig::KeyByConfig(_) | OperatorConfig::WindowConfig(_)
+            ) {
+                assert!(
+                    node.watermark_assign.is_none(),
+                    "KeyBy/Window must not have watermark_assign: {}",
+                    node.operator_id
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_computed_attaches_on_projection_map_not_source() {
+        let mut planner = planner_with_events();
+        let graph = planner
+            .sql_to_graph(
+                "SELECT event_time, key, value, \
+                 SUM(value) OVER (PARTITION BY key ORDER BY event_time \
+                 RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+                 FROM (SELECT timestamp + INTERVAL '0' MILLISECOND AS event_time, key, value FROM events)",
+            )
+            .unwrap();
+
+        let assigns = assign_nodes(&graph);
+        assert_eq!(assigns.len(), 1, "expected exactly one assign site");
+        assert!(
+            matches!(
+                assigns[0].operator_config,
+                OperatorConfig::MapConfig(MapFunction::Projection(_))
+            ),
+            "expected Projection Map assign, got {:?}",
+            assigns[0].operator_config
+        );
+        assert_time_hint_column(assigns[0], "event_time");
+
+        for node in graph.get_nodes() {
+            if matches!(node.operator_config, OperatorConfig::SourceConfig(_)) {
+                assert!(
+                    node.watermark_assign.is_none(),
+                    "Source must not have assign when event-time is computed downstream"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_two_windows_same_event_time_share_one_assign() {
+        let mut planner = planner_with_events();
+        let graph = planner
+            .sql_to_graph(
+                "SELECT timestamp, key, value, \
+                 SUM(value) OVER (PARTITION BY key ORDER BY timestamp \
+                 RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value, \
+                 AVG(value) OVER (PARTITION BY key ORDER BY timestamp \
+                 RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as avg_value \
+                 FROM events",
+            )
+            .unwrap();
+
+        let assigns = assign_nodes(&graph);
+        assert_eq!(
+            assigns.len(),
+            1,
+            "same ORDER BY column should attach once, got {} assign nodes",
+            assigns.len()
+        );
+        assert!(matches!(
+            assigns[0].operator_config,
+            OperatorConfig::SourceConfig(_)
+        ));
+        assert_time_hint_column(assigns[0], "timestamp");
+    }
+
+    #[tokio::test]
+    async fn apply_noop_when_watermarks_disabled() {
+        let plan = plan_sql(
+            "SELECT timestamp, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY timestamp \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM events",
+        )
+        .await;
+        let mut graph = LogicalGraph::new();
+        graph.set_watermarks_enabled(false);
+        apply_auto_watermark_assigns(&plan, &mut graph).unwrap();
+        assert!(
+            assign_nodes(&graph).is_empty(),
+            "disabled watermarks must not attach assigns"
         );
     }
 }

--- a/src/api/event_time_placement.rs
+++ b/src/api/event_time_placement.rs
@@ -1,0 +1,325 @@
+//! Resolve where auto watermark assigners should attach by walking DataFusion
+//! plan lineage from a window's ORDER BY event-time column to its defining site.
+
+use datafusion::common::{Column, DataFusionError, Result};
+use datafusion::logical_expr::{Expr, LogicalPlan, Projection, Window};
+use petgraph::graph::NodeIndex;
+use petgraph::Direction;
+
+use super::logical_graph::LogicalGraph;
+use crate::runtime::operators::operator::OperatorConfig;
+
+/// Plan site where a watermark assigner should be attached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssignSite {
+    /// Column name in the assign site's output schema.
+    pub column_name: String,
+    /// Identity of the defining [`LogicalPlan`] node (`ptr` as usize).
+    pub plan_node_key: usize,
+}
+
+pub fn plan_node_key(plan: &LogicalPlan) -> usize {
+    plan as *const LogicalPlan as usize
+}
+
+fn unwrap_alias(expr: &Expr) -> &Expr {
+    match expr {
+        Expr::Alias(alias) => unwrap_alias(alias.expr.as_ref()),
+        other => other,
+    }
+}
+
+/// Extract the event-time column from the first window ORDER BY expression.
+pub fn event_time_column_from_window(window: &Window) -> Result<Column> {
+    let first = window.window_expr.first().ok_or_else(|| {
+        DataFusionError::Plan("window has no window expressions".to_string())
+    })?;
+
+    let Expr::WindowFunction(wf) = unwrap_alias(first) else {
+        return Err(DataFusionError::Plan(format!(
+            "expected WindowFunction for watermark lineage, got {first:?}"
+        )));
+    };
+
+    let order = wf.params.order_by.first().ok_or_else(|| {
+        DataFusionError::Plan("window ORDER BY is required for auto watermark placement".to_string())
+    })?;
+
+    match unwrap_alias(&order.expr) {
+        Expr::Column(col) => Ok(col.clone()),
+        other => Err(DataFusionError::Plan(format!(
+            "window ORDER BY must be a column for auto watermark placement, got {other:?}"
+        ))),
+    }
+}
+
+fn find_projection_expr<'a>(proj: &'a Projection, col_name: &str) -> Result<&'a Expr> {
+    for (idx, field) in proj.schema.fields().iter().enumerate() {
+        if field.name() == col_name {
+            return proj.expr.get(idx).ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "projection schema/expr mismatch looking for column '{col_name}'"
+                ))
+            });
+        }
+    }
+    for expr in &proj.expr {
+        let (_, name) = expr.qualified_name();
+        if name == col_name {
+            return Ok(expr);
+        }
+    }
+    Err(DataFusionError::Plan(format!(
+        "projection does not define event-time column '{col_name}'"
+    )))
+}
+
+/// Walk backward from `window.input` to the plan node that defines the event-time column.
+pub fn resolve_event_time_assign_site(window: &Window) -> Result<AssignSite> {
+    let mut col = event_time_column_from_window(window)?;
+    let mut current = window.input.as_ref();
+
+    loop {
+        match current {
+            LogicalPlan::Filter(filter) => {
+                current = filter.input.as_ref();
+            }
+            LogicalPlan::SubqueryAlias(alias) => {
+                current = alias.input.as_ref();
+            }
+            LogicalPlan::Sort(sort) => {
+                current = sort.input.as_ref();
+            }
+            LogicalPlan::Limit(limit) => {
+                current = limit.input.as_ref();
+            }
+            LogicalPlan::Repartition(repartition) => {
+                current = repartition.input.as_ref();
+            }
+            LogicalPlan::Distinct(distinct) => {
+                current = distinct.input().as_ref();
+            }
+            LogicalPlan::Projection(proj) => {
+                let expr = find_projection_expr(proj, &col.name)?;
+                match unwrap_alias(expr) {
+                    Expr::Column(inner) => {
+                        col = inner.clone();
+                        current = proj.input.as_ref();
+                    }
+                    _ => {
+                        // Computed (or otherwise non-column) expression — assign here.
+                        return Ok(AssignSite {
+                            column_name: col.name.clone(),
+                            plan_node_key: plan_node_key(current),
+                        });
+                    }
+                }
+            }
+            LogicalPlan::TableScan(_) => {
+                return Ok(AssignSite {
+                    column_name: col.name.clone(),
+                    plan_node_key: plan_node_key(current),
+                });
+            }
+            LogicalPlan::Join(_) | LogicalPlan::Union(_) => {
+                return Err(DataFusionError::Plan(
+                    "unsupported for auto watermark placement: multi-input operator on event-time lineage"
+                        .to_string(),
+                ));
+            }
+            other => {
+                return Err(DataFusionError::Plan(format!(
+                    "unsupported for auto watermark placement on event-time lineage: {}",
+                    other.display()
+                )));
+            }
+        }
+    }
+}
+
+fn reaches(graph: &LogicalGraph, from: NodeIndex, to: NodeIndex) -> bool {
+    if from == to {
+        return true;
+    }
+    let mut visited = std::collections::HashSet::new();
+    let mut stack = vec![from];
+    while let Some(n) = stack.pop() {
+        if !visited.insert(n) {
+            continue;
+        }
+        for neigh in graph.get_neighbors(n, Direction::Outgoing) {
+            if neigh == to {
+                return true;
+            }
+            stack.push(neigh);
+        }
+    }
+    false
+}
+
+/// Assign site must be upstream of the window's KeyBy (fragmenting edge), and must not
+/// land on KeyBy/Window themselves.
+pub fn validate_assign_before_window_keyby(
+    graph: &LogicalGraph,
+    assign_idx: NodeIndex,
+    window_idx: NodeIndex,
+) -> Result<()> {
+    let assign_cfg = &graph.get_node_by_index(assign_idx).operator_config;
+    if matches!(
+        assign_cfg,
+        OperatorConfig::KeyByConfig(_) | OperatorConfig::WindowConfig(_)
+    ) {
+        return Err(DataFusionError::Plan(
+            "event-time watermark assign must not land on KeyBy or Window".to_string(),
+        ));
+    }
+
+    let keyby_idx = graph
+        .get_neighbors(window_idx, Direction::Incoming)
+        .into_iter()
+        .find(|&idx| {
+            matches!(
+                graph.get_node_by_index(idx).operator_config,
+                OperatorConfig::KeyByConfig(_)
+            )
+        })
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "window has no KeyBy predecessor for watermark placement validation".to_string(),
+            )
+        })?;
+
+    if !reaches(graph, assign_idx, keyby_idx) {
+        return Err(DataFusionError::Plan(
+            "event-time assign site must be upstream of the window's KeyBy".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use datafusion::catalog::MemTable;
+    use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+    use datafusion::prelude::SessionContext;
+    use std::sync::Arc;
+
+    fn events_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]))
+    }
+
+    async fn plan_sql(sql: &str) -> LogicalPlan {
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
+        ctx.register_table("events", Arc::new(table)).unwrap();
+        let df = ctx.sql(sql).await.unwrap();
+        df.into_optimized_plan().unwrap()
+    }
+
+    fn find_window(plan: &LogicalPlan) -> Window {
+        let mut found = None;
+        plan.apply(|node| {
+            if let LogicalPlan::Window(w) = node {
+                found = Some(w.clone());
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })
+        .unwrap();
+        found.expect("expected a Window in plan")
+    }
+
+    fn find_plan_by_key<'a>(plan: &'a LogicalPlan, key: usize) -> Option<&'a LogicalPlan> {
+        let mut found = None;
+        plan.apply(|node| {
+            if plan_node_key(node) == key {
+                found = Some(node);
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })
+        .unwrap();
+        found
+    }
+
+    #[tokio::test]
+    async fn lineage_passthrough_column_stops_at_source() {
+        let plan = plan_sql(
+            "SELECT timestamp, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY timestamp \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM events",
+        )
+        .await;
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        assert_eq!(site.column_name, "timestamp");
+        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
+        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+    }
+
+    #[tokio::test]
+    async fn lineage_renamed_column_continues_to_source() {
+        let plan = plan_sql(
+            "SELECT event_time, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY event_time \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM (SELECT timestamp AS event_time, key, value FROM events)",
+        )
+        .await;
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        // After unwrapping the alias, assign on the source under the original column name.
+        assert_eq!(site.column_name, "timestamp");
+        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
+        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+    }
+
+    #[tokio::test]
+    async fn lineage_computed_event_time_stops_on_projection() {
+        let plan = plan_sql(
+            "SELECT event_time, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY event_time \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM (SELECT timestamp + INTERVAL '0' MILLISECOND AS event_time, key, value FROM events)",
+        )
+        .await;
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        assert_eq!(site.column_name, "event_time");
+        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
+        assert!(matches!(site_plan, LogicalPlan::Projection(_)));
+    }
+
+    #[tokio::test]
+    async fn lineage_join_on_path_errors() {
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
+        ctx.register_table("events", Arc::new(table)).unwrap();
+        let table2 = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
+        ctx.register_table("events2", Arc::new(table2)).unwrap();
+
+        let sql = "SELECT e.timestamp, e.key, e.value, \
+             SUM(e.value) OVER (PARTITION BY e.key ORDER BY e.timestamp \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM events e JOIN events2 e2 ON e.key = e2.key";
+        let df = ctx.sql(sql).await.unwrap();
+        let plan = df.into_optimized_plan().unwrap();
+        let window = find_window(&plan);
+        let err = resolve_event_time_assign_site(&window).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unsupported for auto watermark placement"),
+            "unexpected error: {msg}"
+        );
+    }
+}

--- a/src/api/event_time_placement.rs
+++ b/src/api/event_time_placement.rs
@@ -1,25 +1,38 @@
 //! Resolve where auto watermark assigners should attach by walking DataFusion
 //! plan lineage from a window's ORDER BY event-time column to its defining site.
 
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::{Column, DataFusionError, Result};
 use datafusion::logical_expr::{Expr, LogicalPlan, Projection, Window};
+use datafusion::physical_plan::expressions::Column as PhysicalColumn;
 use petgraph::graph::NodeIndex;
 use petgraph::Direction;
 
 use super::logical_graph::LogicalGraph;
+use crate::runtime::functions::map::MapFunction;
 use crate::runtime::operators::operator::OperatorConfig;
 
 /// Plan site where a watermark assigner should be attached.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AssignSite {
-    /// Column name in the assign site's output schema.
-    pub column_name: String,
-    /// Identity of the defining [`LogicalPlan`] node (`ptr` as usize).
-    pub plan_node_key: usize,
+pub enum AssignSite {
+    Source {
+        /// DF table name (lineage / diagnostics; graph match uses unique upstream Source).
+        table_name: String,
+        /// Column name in the source output schema.
+        column_name: String,
+    },
+    /// Projection that defines a computed (non-column) event-time expression.
+    Projection {
+        column_name: String,
+    },
 }
 
-pub fn plan_node_key(plan: &LogicalPlan) -> usize {
-    plan as *const LogicalPlan as usize
+impl AssignSite {
+    pub fn column_name(&self) -> &str {
+        match self {
+            Self::Source { column_name, .. } | Self::Projection { column_name } => column_name,
+        }
+    }
 }
 
 fn unwrap_alias(expr: &Expr) -> &Expr {
@@ -107,18 +120,16 @@ pub fn resolve_event_time_assign_site(window: &Window) -> Result<AssignSite> {
                         current = proj.input.as_ref();
                     }
                     _ => {
-                        // Computed (or otherwise non-column) expression — assign here.
-                        return Ok(AssignSite {
+                        return Ok(AssignSite::Projection {
                             column_name: col.name.clone(),
-                            plan_node_key: plan_node_key(current),
                         });
                     }
                 }
             }
-            LogicalPlan::TableScan(_) => {
-                return Ok(AssignSite {
+            LogicalPlan::TableScan(scan) => {
+                return Ok(AssignSite::Source {
+                    table_name: scan.table_name.table().to_string(),
                     column_name: col.name.clone(),
-                    plan_node_key: plan_node_key(current),
                 });
             }
             LogicalPlan::Join(_) | LogicalPlan::Union(_) => {
@@ -157,6 +168,23 @@ fn reaches(graph: &LogicalGraph, from: NodeIndex, to: NodeIndex) -> bool {
     false
 }
 
+fn window_keyby(graph: &LogicalGraph, window_idx: NodeIndex) -> Result<NodeIndex> {
+    graph
+        .get_neighbors(window_idx, Direction::Incoming)
+        .into_iter()
+        .find(|&idx| {
+            matches!(
+                graph.get_node_by_index(idx).operator_config,
+                OperatorConfig::KeyByConfig(_)
+            )
+        })
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "window has no KeyBy predecessor for watermark placement validation".to_string(),
+            )
+        })
+}
+
 /// Assign site must be upstream of the window's KeyBy (fragmenting edge), and must not
 /// land on KeyBy/Window themselves.
 pub fn validate_assign_before_window_keyby(
@@ -174,25 +202,142 @@ pub fn validate_assign_before_window_keyby(
         ));
     }
 
-    let keyby_idx = graph
-        .get_neighbors(window_idx, Direction::Incoming)
-        .into_iter()
-        .find(|&idx| {
-            matches!(
-                graph.get_node_by_index(idx).operator_config,
-                OperatorConfig::KeyByConfig(_)
-            )
-        })
-        .ok_or_else(|| {
-            DataFusionError::Plan(
-                "window has no KeyBy predecessor for watermark placement validation".to_string(),
-            )
-        })?;
-
+    let keyby_idx = window_keyby(graph, window_idx)?;
     if !reaches(graph, assign_idx, keyby_idx) {
         return Err(DataFusionError::Plan(
             "event-time assign site must be upstream of the window's KeyBy".to_string(),
         ));
+    }
+
+    Ok(())
+}
+
+fn window_order_by_column_name(graph: &LogicalGraph, window_idx: NodeIndex) -> Option<String> {
+    let OperatorConfig::WindowConfig(cfg) = &graph.get_node_by_index(window_idx).operator_config
+    else {
+        return None;
+    };
+    let order = cfg.window_exec.window_expr().first()?.order_by().first()?;
+    order
+        .expr
+        .as_any()
+        .downcast_ref::<PhysicalColumn>()
+        .map(|c| c.name().to_string())
+}
+
+fn projection_defines_computed_column(map: &MapFunction, column_name: &str) -> bool {
+    let MapFunction::Projection(proj) = map else {
+        return false;
+    };
+    for (idx, field) in proj.out_schema().fields().iter().enumerate() {
+        if field.name() != column_name {
+            continue;
+        }
+        let Some(expr) = proj.exprs().get(idx) else {
+            return false;
+        };
+        return !matches!(unwrap_alias(expr), Expr::Column(_));
+    }
+    false
+}
+
+fn find_assign_node(
+    graph: &LogicalGraph,
+    site: &AssignSite,
+    window_idxs: &[NodeIndex],
+) -> Result<NodeIndex> {
+    let keybys = window_idxs
+        .iter()
+        .map(|&w| window_keyby(graph, w))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut candidates = Vec::new();
+    for idx in graph.get_all_node_indices() {
+        if !keybys.iter().all(|&kb| reaches(graph, idx, kb)) {
+            continue;
+        }
+        match (site, &graph.get_node_by_index(idx).operator_config) {
+            (AssignSite::Source { .. }, OperatorConfig::SourceConfig(_)) => {
+                candidates.push(idx);
+            }
+            (AssignSite::Projection { column_name }, OperatorConfig::MapConfig(map))
+                if projection_defines_computed_column(map, column_name) =>
+            {
+                candidates.push(idx);
+            }
+            _ => {}
+        }
+    }
+
+    match candidates.as_slice() {
+        [only] => Ok(*only),
+        [] => Err(DataFusionError::Plan(format!(
+            "no logical node found for watermark assign site {site:?}"
+        ))),
+        _ => Err(DataFusionError::Plan(format!(
+            "ambiguous logical nodes for watermark assign site {site:?}: {} candidates",
+            candidates.len()
+        ))),
+    }
+}
+
+fn attach_assign(graph: &mut LogicalGraph, assign_idx: NodeIndex, column_name: String) -> Result<()> {
+    let cfg = graph.watermark_assign_config_for_column(column_name);
+    let node = graph
+        .get_node_by_index_mut(assign_idx)
+        .expect("assign node index must exist");
+    match &node.watermark_assign {
+        Some(existing) => {
+            if existing.time_hint != cfg.time_hint {
+                return Err(DataFusionError::Plan(format!(
+                    "conflicting watermark assign time hints on {}: {:?} vs {:?}",
+                    node.operator_id, existing.time_hint, cfg.time_hint
+                )));
+            }
+        }
+        None => {
+            node.watermark_assign = Some(cfg);
+        }
+    }
+    Ok(())
+}
+
+/// Attach auto watermark assign configs on the defining Source/Projection nodes for each
+/// window in `plan`. Call after the logical graph has been built from that plan.
+pub fn apply_auto_watermark_assigns(plan: &LogicalPlan, graph: &mut LogicalGraph) -> Result<()> {
+    if !graph.watermarks_enabled() {
+        return Ok(());
+    }
+
+    let mut jobs: Vec<(AssignSite, String)> = Vec::new();
+    plan.apply(|node| {
+        if let LogicalPlan::Window(window) = node {
+            let site = resolve_event_time_assign_site(window)?;
+            let et = event_time_column_from_window(window)?;
+            jobs.push((site, et.name));
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+
+    for (site, window_et_name) in jobs {
+        let window_idxs: Vec<NodeIndex> = graph
+            .get_all_node_indices()
+            .into_iter()
+            .filter(|&idx| {
+                window_order_by_column_name(graph, idx).as_deref() == Some(window_et_name.as_str())
+            })
+            .collect();
+        if window_idxs.is_empty() {
+            return Err(DataFusionError::Plan(format!(
+                "no window operator with ORDER BY column '{window_et_name}' for watermark placement"
+            )));
+        }
+
+        let assign_idx = find_assign_node(graph, &site, &window_idxs)?;
+        for &window_idx in &window_idxs {
+            validate_assign_before_window_keyby(graph, assign_idx, window_idx)?;
+        }
+        attach_assign(graph, assign_idx, site.column_name().to_string())?;
     }
 
     Ok(())
@@ -203,7 +348,6 @@ mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use datafusion::catalog::MemTable;
-    use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
     use datafusion::prelude::SessionContext;
     use std::sync::Arc;
 
@@ -239,18 +383,6 @@ mod tests {
         found.expect("expected a Window in plan")
     }
 
-    fn find_plan_by_key<'a>(plan: &'a LogicalPlan, key: usize) -> Option<&'a LogicalPlan> {
-        let mut found = None;
-        plan.apply(|node| {
-            if plan_node_key(node) == key {
-                found = Some(node);
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })
-        .unwrap();
-        found
-    }
-
     #[tokio::test]
     async fn lineage_passthrough_column_stops_at_source() {
         let plan = plan_sql(
@@ -262,9 +394,13 @@ mod tests {
         .await;
         let window = find_window(&plan);
         let site = resolve_event_time_assign_site(&window).unwrap();
-        assert_eq!(site.column_name, "timestamp");
-        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
-        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+        assert_eq!(
+            site,
+            AssignSite::Source {
+                table_name: "events".to_string(),
+                column_name: "timestamp".to_string(),
+            }
+        );
     }
 
     #[tokio::test]
@@ -278,10 +414,13 @@ mod tests {
         .await;
         let window = find_window(&plan);
         let site = resolve_event_time_assign_site(&window).unwrap();
-        // After unwrapping the alias, assign on the source under the original column name.
-        assert_eq!(site.column_name, "timestamp");
-        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
-        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+        assert_eq!(
+            site,
+            AssignSite::Source {
+                table_name: "events".to_string(),
+                column_name: "timestamp".to_string(),
+            }
+        );
     }
 
     #[tokio::test]
@@ -295,9 +434,12 @@ mod tests {
         .await;
         let window = find_window(&plan);
         let site = resolve_event_time_assign_site(&window).unwrap();
-        assert_eq!(site.column_name, "event_time");
-        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
-        assert!(matches!(site_plan, LogicalPlan::Projection(_)));
+        assert_eq!(
+            site,
+            AssignSite::Projection {
+                column_name: "event_time".to_string(),
+            }
+        );
     }
 
     #[tokio::test]

--- a/src/api/logical_graph.rs
+++ b/src/api/logical_graph.rs
@@ -77,18 +77,31 @@ impl LogicalGraph {
         self.watermarks_enabled = enabled;
     }
 
+    pub fn watermarks_enabled(&self) -> bool {
+        self.watermarks_enabled
+    }
+
     pub(crate) fn set_event_time(&mut self, event_time: EventTimeSpec) {
         self.event_time = event_time;
+        // Refresh ooo/idle on assign configs attached during planning.
+        for node in self.graph.node_weights_mut() {
+            if let Some(cfg) = node.watermark_assign.as_mut() {
+                cfg.out_of_orderness_ms = self.event_time.watermark.out_of_orderness_ms;
+                if let Some(idle) = self.event_time.watermark.idle_timeout_ms {
+                    cfg.idle_timeout_ms = Some(idle);
+                }
+            }
+        }
     }
 
     pub fn event_time(&self) -> &EventTimeSpec {
         &self.event_time
     }
 
-    fn auto_watermark_assign_config(&self) -> WatermarkAssignConfig {
+    pub(crate) fn watermark_assign_config_for_column(&self, column_name: String) -> WatermarkAssignConfig {
         let mut cfg = WatermarkAssignConfig::new(
             self.event_time.watermark.out_of_orderness_ms,
-            Some(TimeHint::WindowOrderByColumn),
+            TimeHint::ColumnName { name: column_name },
         );
         if let Some(idle) = self.event_time.watermark.idle_timeout_ms {
             cfg.idle_timeout_ms = Some(idle);
@@ -181,65 +194,11 @@ impl LogicalGraph {
 
     /// Convert logical graph to execution graph using parallelism from each logical node
     pub fn to_execution_graph(&self) -> ExecutionGraph {
-        // Planner-side heuristic watermark assigner placement:
-        // For now, for each Source, find the closest downstream Window operator(s) and attach a watermark assigner there.
-        // This keeps watermark generation as a StreamTask feature (no dedicated operator) while preserving
-        // downstream min-upstream watermark merge semantics.
+        // Watermark assign placement is decided during planning (event-time lineage) and stored
+        // on LogicalNode.watermark_assign. Execution mapping is a simple copy.
         //
-        // TODO: extend placement for joins/unions (multiple-input operators), where "closest window" is ambiguous
-        // and per-input watermark generation needs careful handling.
-        let mut auto_watermark_assign: HashMap<String, WatermarkAssignConfig> = HashMap::new();
-        if self.watermarks_enabled {
-            let source_nodes: Vec<NodeIndex> = self
-                .graph
-                .node_indices()
-                .filter(|&idx| matches!(self.graph[idx].operator_config, OperatorConfig::SourceConfig(_)))
-                .collect();
-
-            for src in source_nodes {
-            // Layered BFS: stop at first layer that contains any window node(s).
-            let mut visited: HashMap<NodeIndex, ()> = HashMap::new();
-            let mut frontier: Vec<NodeIndex> = vec![src];
-            visited.insert(src, ());
-
-            loop {
-                // Next layer
-                let mut next: Vec<NodeIndex> = Vec::new();
-                for &n in &frontier {
-                    for neigh in self.graph.neighbors_directed(n, Direction::Outgoing) {
-                        if visited.contains_key(&neigh) {
-                            continue;
-                        }
-                        visited.insert(neigh, ());
-                        next.push(neigh);
-                    }
-                }
-
-                if next.is_empty() {
-                    break;
-                }
-
-                let windows_at_layer: Vec<NodeIndex> = next
-                    .iter()
-                    .copied()
-                    .filter(|&idx| matches!(self.graph[idx].operator_config, OperatorConfig::WindowConfig(_)))
-                    .collect();
-                if !windows_at_layer.is_empty() {
-                    let assign = self.auto_watermark_assign_config();
-                    for w in windows_at_layer {
-                        let op_id = self.graph[w].operator_id.clone();
-                        auto_watermark_assign
-                            .entry(op_id)
-                            .or_insert_with(|| assign.clone());
-                    }
-                    break;
-                }
-
-                frontier = next;
-            }
-            }
-        } else {
-            // In Batch mode we expect no watermark assignment at all.
+        // TODO: extend placement for joins/unions (multiple-input operators / per-branch assign).
+        if !self.watermarks_enabled {
             debug_assert!(
                 self.graph.node_weights().all(|n| n.watermark_assign.is_none()),
                 "watermarks_disabled but some logical nodes have watermark_assign configured"
@@ -270,10 +229,7 @@ impl LogicalGraph {
                     i as i32,
                 );
                 let mut execution_vertex = execution_vertex;
-                execution_vertex.watermark_assign = logical_node
-                    .watermark_assign
-                    .clone()
-                    .or_else(|| auto_watermark_assign.get(&logical_node.operator_id).cloned());
+                execution_vertex.watermark_assign = logical_node.watermark_assign.clone();
 
                 execution_graph.add_vertex(execution_vertex);
                 execution_vertex_ids.push(execution_vertex_id);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod logical_graph;
+pub mod event_time_placement;
 pub mod planner;
 #[cfg(test)]
 pub mod logical_optimizer_examples;

--- a/src/api/planner.rs
+++ b/src/api/planner.rs
@@ -20,7 +20,7 @@ use datafusion::logical_expr::{
 use datafusion::physical_plan::aggregates::AggregateExec;
 use datafusion::common::{Result, DataFusionError};
 use datafusion::common::tree_node::TreeNodeRecursion;
-use datafusion::common::tree_node::TreeNodeVisitor;
+use datafusion::common::tree_node::{TreeNode, TreeNodeVisitor};
 use datafusion::prelude::SessionContext;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion::sql::TableReference;
@@ -28,6 +28,9 @@ use datafusion::optimizer::analyzer::type_coercion::TypeCoercion;
 use datafusion::optimizer::analyzer::AnalyzerRule;
 use petgraph::graph::NodeIndex;
 
+use super::event_time_placement::{
+    plan_node_key, resolve_event_time_assign_site, validate_assign_before_window_keyby, AssignSite,
+};
 use super::logical_graph::{LogicalNode, LogicalGraph};
 use crate::api::ExecutionMode;
 use crate::runtime::functions::key_by::key_by_function::{DataFusionKeyFunction};
@@ -111,6 +114,8 @@ pub struct Planner {
     logical_graph: LogicalGraph,
     node_stack: Vec<NodeIndex>,
     context: PlanningContext,
+    /// DF plan node pointer identity → logical graph node (for watermark assign placement).
+    df_plan_to_node: HashMap<usize, NodeIndex>,
 }
 
 #[derive(Clone)]
@@ -165,6 +170,7 @@ impl Planner {
             logical_graph: LogicalGraph::new(),
             node_stack: Vec::new(),
             context,
+            df_plan_to_node: HashMap::new(),
         }
     }
 
@@ -191,11 +197,71 @@ impl Planner {
 
     pub fn logical_plan_to_graph(&mut self, logical_plan: &LogicalPlan) -> Result<LogicalGraph> {
         self.node_stack.clear();
+        self.df_plan_to_node.clear();
 
         let optimized_plan = self.optimize_plan(logical_plan.clone())?;
         optimized_plan.visit_with_subqueries(self)?;
-        
+        self.apply_auto_watermark_assigns(&optimized_plan)?;
+
         Ok(self.logical_graph.clone())
+    }
+
+    fn apply_auto_watermark_assigns(&mut self, plan: &LogicalPlan) -> Result<()> {
+        // Batch mode forbids watermark_assign on StreamTasks.
+        if self.context.execution_mode == ExecutionMode::Batch {
+            return Ok(());
+        }
+        if !self.logical_graph.watermarks_enabled() {
+            return Ok(());
+        }
+
+        let mut sites: Vec<(usize, AssignSite)> = Vec::new();
+        plan.apply(|node| {
+            if let LogicalPlan::Window(window) = node {
+                let site = resolve_event_time_assign_site(window)?;
+                sites.push((plan_node_key(node), site));
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+
+        for (window_plan_key, site) in sites {
+            let assign_idx = *self.df_plan_to_node.get(&site.plan_node_key).ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "no logical node mapped for event-time assign site (column={})",
+                    site.column_name
+                ))
+            })?;
+            let window_idx = *self.df_plan_to_node.get(&window_plan_key).ok_or_else(|| {
+                DataFusionError::Plan(
+                    "no logical node mapped for window during watermark placement".to_string(),
+                )
+            })?;
+
+            validate_assign_before_window_keyby(&self.logical_graph, assign_idx, window_idx)?;
+
+            let cfg = self
+                .logical_graph
+                .watermark_assign_config_for_column(site.column_name.clone());
+            let node = self
+                .logical_graph
+                .get_node_by_index_mut(assign_idx)
+                .expect("assign node index must exist");
+            match &node.watermark_assign {
+                Some(existing) => {
+                    if existing.time_hint != cfg.time_hint {
+                        return Err(DataFusionError::Plan(format!(
+                            "conflicting watermark assign time hints on {}: {:?} vs {:?}",
+                            node.operator_id, existing.time_hint, cfg.time_hint
+                        )));
+                    }
+                }
+                None => {
+                    node.watermark_assign = Some(cfg);
+                }
+            }
+        }
+
+        Ok(())
     }
 
     pub fn sql_to_graph(&mut self, sql: &str) -> Result<LogicalGraph> {
@@ -453,11 +519,15 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
         // Process node and create operator
         match node {
             LogicalPlan::TableScan(table_scan) => {
-                self.create_source_node(table_scan, self.context.parallelism)?
+                self.create_source_node(table_scan, self.context.parallelism)?;
+                let idx = *self.node_stack.last().expect("source node just pushed");
+                self.df_plan_to_node.insert(plan_node_key(node), idx);
             }
             
             LogicalPlan::Projection(projection) => {
-                self.create_projection_node(projection, self.context.parallelism)?
+                self.create_projection_node(projection, self.context.parallelism)?;
+                let idx = *self.node_stack.last().expect("projection node just pushed");
+                self.df_plan_to_node.insert(plan_node_key(node), idx);
             }
             
             LogicalPlan::Filter(filter) => {
@@ -473,6 +543,9 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
             }
             LogicalPlan::Window(window) => {
                 self.handle_window(window, self.context.parallelism)?;
+                // Stack top is KeyBy, then Window (handle_window pushes window then keyby).
+                let window_idx = self.node_stack[self.node_stack.len() - 2];
+                self.df_plan_to_node.insert(plan_node_key(node), window_idx);
             }
             
             // skip subqueries as they simply wrap other plans
@@ -938,6 +1011,21 @@ mod tests {
             (NodeType::KeyBy, NodeType::Window, PartitionType::Hash, 1),
             (NodeType::Window, NodeType::Projection, PartitionType::RoundRobin, 1),
         ]);
+
+        // Event-time lineage: assign on Source (defining site), not Window/KeyBy.
+        assert!(
+            nodes[3].watermark_assign.is_some(),
+            "expected watermark_assign on Source"
+        );
+        assert!(
+            matches!(
+                &nodes[3].watermark_assign.as_ref().unwrap().time_hint,
+                crate::runtime::watermark::TimeHint::ColumnName { name } if name == "event_time"
+            ),
+            "expected ColumnName(event_time) time hint on Source"
+        );
+        assert!(nodes[1].watermark_assign.is_none(), "Window must not have watermark_assign");
+        assert!(nodes[2].watermark_assign.is_none(), "KeyBy must not have watermark_assign");
     }
 
     #[tokio::test]

--- a/src/api/planner.rs
+++ b/src/api/planner.rs
@@ -20,7 +20,7 @@ use datafusion::logical_expr::{
 use datafusion::physical_plan::aggregates::AggregateExec;
 use datafusion::common::{Result, DataFusionError};
 use datafusion::common::tree_node::TreeNodeRecursion;
-use datafusion::common::tree_node::{TreeNode, TreeNodeVisitor};
+use datafusion::common::tree_node::TreeNodeVisitor;
 use datafusion::prelude::SessionContext;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion::sql::TableReference;
@@ -28,9 +28,7 @@ use datafusion::optimizer::analyzer::type_coercion::TypeCoercion;
 use datafusion::optimizer::analyzer::AnalyzerRule;
 use petgraph::graph::NodeIndex;
 
-use super::event_time_placement::{
-    plan_node_key, resolve_event_time_assign_site, validate_assign_before_window_keyby, AssignSite,
-};
+use super::event_time_placement::apply_auto_watermark_assigns;
 use super::logical_graph::{LogicalNode, LogicalGraph};
 use crate::api::ExecutionMode;
 use crate::runtime::functions::key_by::key_by_function::{DataFusionKeyFunction};
@@ -114,8 +112,6 @@ pub struct Planner {
     logical_graph: LogicalGraph,
     node_stack: Vec<NodeIndex>,
     context: PlanningContext,
-    /// DF plan node pointer identity → logical graph node (for watermark assign placement).
-    df_plan_to_node: HashMap<usize, NodeIndex>,
 }
 
 #[derive(Clone)]
@@ -170,7 +166,6 @@ impl Planner {
             logical_graph: LogicalGraph::new(),
             node_stack: Vec::new(),
             context,
-            df_plan_to_node: HashMap::new(),
         }
     }
 
@@ -197,71 +192,15 @@ impl Planner {
 
     pub fn logical_plan_to_graph(&mut self, logical_plan: &LogicalPlan) -> Result<LogicalGraph> {
         self.node_stack.clear();
-        self.df_plan_to_node.clear();
 
         let optimized_plan = self.optimize_plan(logical_plan.clone())?;
         optimized_plan.visit_with_subqueries(self)?;
-        self.apply_auto_watermark_assigns(&optimized_plan)?;
+        // Batch mode forbids watermark_assign on StreamTasks.
+        if self.context.execution_mode != ExecutionMode::Batch {
+            apply_auto_watermark_assigns(&optimized_plan, &mut self.logical_graph)?;
+        }
 
         Ok(self.logical_graph.clone())
-    }
-
-    fn apply_auto_watermark_assigns(&mut self, plan: &LogicalPlan) -> Result<()> {
-        // Batch mode forbids watermark_assign on StreamTasks.
-        if self.context.execution_mode == ExecutionMode::Batch {
-            return Ok(());
-        }
-        if !self.logical_graph.watermarks_enabled() {
-            return Ok(());
-        }
-
-        let mut sites: Vec<(usize, AssignSite)> = Vec::new();
-        plan.apply(|node| {
-            if let LogicalPlan::Window(window) = node {
-                let site = resolve_event_time_assign_site(window)?;
-                sites.push((plan_node_key(node), site));
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })?;
-
-        for (window_plan_key, site) in sites {
-            let assign_idx = *self.df_plan_to_node.get(&site.plan_node_key).ok_or_else(|| {
-                DataFusionError::Plan(format!(
-                    "no logical node mapped for event-time assign site (column={})",
-                    site.column_name
-                ))
-            })?;
-            let window_idx = *self.df_plan_to_node.get(&window_plan_key).ok_or_else(|| {
-                DataFusionError::Plan(
-                    "no logical node mapped for window during watermark placement".to_string(),
-                )
-            })?;
-
-            validate_assign_before_window_keyby(&self.logical_graph, assign_idx, window_idx)?;
-
-            let cfg = self
-                .logical_graph
-                .watermark_assign_config_for_column(site.column_name.clone());
-            let node = self
-                .logical_graph
-                .get_node_by_index_mut(assign_idx)
-                .expect("assign node index must exist");
-            match &node.watermark_assign {
-                Some(existing) => {
-                    if existing.time_hint != cfg.time_hint {
-                        return Err(DataFusionError::Plan(format!(
-                            "conflicting watermark assign time hints on {}: {:?} vs {:?}",
-                            node.operator_id, existing.time_hint, cfg.time_hint
-                        )));
-                    }
-                }
-                None => {
-                    node.watermark_assign = Some(cfg);
-                }
-            }
-        }
-
-        Ok(())
     }
 
     pub fn sql_to_graph(&mut self, sql: &str) -> Result<LogicalGraph> {
@@ -519,15 +458,11 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
         // Process node and create operator
         match node {
             LogicalPlan::TableScan(table_scan) => {
-                self.create_source_node(table_scan, self.context.parallelism)?;
-                let idx = *self.node_stack.last().expect("source node just pushed");
-                self.df_plan_to_node.insert(plan_node_key(node), idx);
+                self.create_source_node(table_scan, self.context.parallelism)?
             }
             
             LogicalPlan::Projection(projection) => {
-                self.create_projection_node(projection, self.context.parallelism)?;
-                let idx = *self.node_stack.last().expect("projection node just pushed");
-                self.df_plan_to_node.insert(plan_node_key(node), idx);
+                self.create_projection_node(projection, self.context.parallelism)?
             }
             
             LogicalPlan::Filter(filter) => {
@@ -543,9 +478,6 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
             }
             LogicalPlan::Window(window) => {
                 self.handle_window(window, self.context.parallelism)?;
-                // Stack top is KeyBy, then Window (handle_window pushes window then keyby).
-                let window_idx = self.node_stack[self.node_stack.len() - 2];
-                self.df_plan_to_node.insert(plan_node_key(node), window_idx);
             }
             
             // skip subqueries as they simply wrap other plans

--- a/src/runtime/functions/map/projection_function.rs
+++ b/src/runtime/functions/map/projection_function.rs
@@ -57,6 +57,10 @@ impl ProjectionFunction {
     pub fn out_schema(&self) -> DFSchemaRef {
         self.out_schema.clone()
     }
+
+    pub fn exprs(&self) -> &[Expr] {
+        &self.exprs
+    }
 }
 
 #[async_trait]

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -322,7 +322,6 @@ impl StreamTask {
     pub(crate) fn create_preprocessed_input_stream(
         input_stream: MessageStream,
         vertex_id: VertexId,
-        operator_config: OperatorConfig,
         watermark_assign: Option<WatermarkAssignConfig>,
         upstream_vertices: Vec<String>,
         upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
@@ -336,7 +335,6 @@ impl StreamTask {
             let mut input_stream = input_stream;
             let mut watermark_manager = WatermarkManager::new(
                 watermark_assign,
-                Some(&operator_config),
                 upstream_vertices.clone(),
                 upstream_watermarks.clone(),
                 current_watermark.clone(),
@@ -586,7 +584,6 @@ impl StreamTask {
                 .get_vertex(&vertex_id)
                 .expect("vertex should exist in execution graph");
             let watermark_assign = vertex_meta.watermark_assign.clone();
-            let vertex_operator_config = vertex_meta.operator_config.clone();
 
             // Runtime invariant: watermark assigners must not run in Batch mode.
             // Batch pipelines rely on source completion to emit a terminal MAX_WATERMARK_VALUE.
@@ -605,7 +602,6 @@ impl StreamTask {
             let mut source_watermark_manager = if is_source {
                 Some(WatermarkManager::new(
                     watermark_assign.clone(),
-                    Some(&vertex_operator_config),
                     upstream_vertices.clone(),
                     upstream_watermarks.clone(),
                     current_watermark.clone(),
@@ -626,7 +622,6 @@ impl StreamTask {
                 let preprocessed_stream = Self::create_preprocessed_input_stream(
                     input_stream,
                     vertex_id.clone(),
-                    vertex_operator_config.clone(),
                     watermark_assign.clone(),
                     upstream_vertices.clone(),
                     upstream_watermarks.clone(),

--- a/src/runtime/watermark/confg.rs
+++ b/src/runtime/watermark/confg.rs
@@ -1,14 +1,14 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WatermarkAssignConfig {
     pub out_of_orderness_ms: u64,
-    pub time_hint: Option<TimeHint>,
+    pub time_hint: TimeHint,
     pub idle_timeout_ms: Option<u64>,
 }
 
 impl WatermarkAssignConfig {
     pub const DEFAULT_IDLE_TIMEOUT_MS: u64 = 1_000;
 
-    pub fn new(out_of_orderness_ms: u64, time_hint: Option<TimeHint>) -> Self {
+    pub fn new(out_of_orderness_ms: u64, time_hint: TimeHint) -> Self {
         Self {
             out_of_orderness_ms,
             time_hint,
@@ -19,8 +19,5 @@ impl WatermarkAssignConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TimeHint {
-    WindowOrderByColumn,
     ColumnName { name: String },
-    // TODO: auto-resolve for non-window operators (timestamp-like column heuristics).
 }
-

--- a/src/runtime/watermark/manager.rs
+++ b/src/runtime/watermark/manager.rs
@@ -8,17 +8,8 @@ use arrow::record_batch::RecordBatch;
 use tokio::sync::Mutex;
 
 use crate::common::message::{Message, WatermarkMessage};
-use crate::runtime::operators::operator::OperatorConfig;
-
-use datafusion::physical_plan::expressions::Column;
 
 use super::confg::{TimeHint, WatermarkAssignConfig};
-
-#[derive(Debug, Clone)]
-enum TsColumnSpec {
-    Index(usize),
-    ColumnName(String),
-}
 
 #[derive(Debug, Default, Clone)]
 struct UpstreamWatermarkProgress {
@@ -28,66 +19,33 @@ struct UpstreamWatermarkProgress {
 
 /// Stateful event-time watermark generator.
 ///
-/// Progress is tracked **per upstream vertex id** so we can attach this generator to a downstream
-/// task (e.g. Window) while still simulating independent upstream watermark production.
+/// Progress is tracked **per upstream vertex id** (sources use the task's own id; map/preprocess
+/// uses the message upstream id).
 #[derive(Debug)]
 pub struct WatermarkAssignerState {
     out_of_orderness_ms: u64,
-    ts_column: TsColumnSpec,
+    ts_column_name: String,
     per_upstream: HashMap<String, UpstreamWatermarkProgress>,
 }
 
 impl WatermarkAssignerState {
-    pub fn new(cfg: WatermarkAssignConfig, operator_config: Option<&OperatorConfig>) -> Self {
-        let ts_column = match cfg.time_hint {
-            Some(TimeHint::WindowOrderByColumn) => TsColumnSpec::Index(
-                Self::derive_window_ts_column_index(
-                    operator_config.expect("WindowOrderByColumn requires operator_config"),
-                ),
-            ),
-            Some(TimeHint::ColumnName { name }) => TsColumnSpec::ColumnName(name),
-            None => {
-                // Auto-resolve only for Window vertices.
-                TsColumnSpec::Index(Self::derive_window_ts_column_index(
-                    operator_config.expect("Auto-resolve requires operator_config"),
-                ))
-            }
-        };
-
+    pub fn new(cfg: WatermarkAssignConfig) -> Self {
+        let TimeHint::ColumnName { name } = cfg.time_hint;
         Self {
             out_of_orderness_ms: cfg.out_of_orderness_ms,
-            ts_column,
+            ts_column_name: name,
             per_upstream: HashMap::new(),
         }
     }
 
-    fn derive_window_ts_column_index(operator_config: &OperatorConfig) -> usize {
-        let OperatorConfig::WindowConfig(window_cfg) = operator_config else {
-            panic!("WatermarkAssign auto-resolve requires Window vertex or explicit time hint");
-        };
-        window_cfg.window_exec.window_expr()[0]
-            .order_by()[0]
-            .expr
-            .as_any()
-            .downcast_ref::<Column>()
-            .expect("Expected Column expression in Window ORDER BY")
-            .index()
-    }
-
     fn resolve_ts_column_index(&self, batch: &RecordBatch) -> usize {
-        match &self.ts_column {
-            TsColumnSpec::Index(idx) => *idx,
-            TsColumnSpec::ColumnName(name) => batch
-                .schema()
-                .index_of(name)
-                .unwrap_or_else(|_| {
-                    panic!(
-                        "WatermarkAssign failed: missing column '{}' in schema {:?}",
-                        name,
-                        batch.schema()
-                    )
-                }),
-        }
+        batch.schema().index_of(&self.ts_column_name).unwrap_or_else(|_| {
+            panic!(
+                "WatermarkAssign failed: missing column '{}' in schema {:?}",
+                self.ts_column_name,
+                batch.schema()
+            )
+        })
     }
 
     fn batch_max_ts_ms(&self, batch: &RecordBatch, ts_column_index: usize) -> Option<u64> {
@@ -180,13 +138,12 @@ pub struct WatermarkManager {
 impl WatermarkManager {
     pub fn new(
         watermark_assign: Option<WatermarkAssignConfig>,
-        operator_config: Option<&OperatorConfig>,
         upstream_vertices: Vec<String>,
         upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
         current_watermark: Arc<AtomicU64>,
     ) -> Self {
         let idle_timeout_ms = watermark_assign.as_ref().and_then(|cfg| cfg.idle_timeout_ms);
-        let assigner = watermark_assign.map(|cfg| WatermarkAssignerState::new(cfg, operator_config));
+        let assigner = watermark_assign.map(WatermarkAssignerState::new);
         let last_seen_processing_time = upstream_vertices
             .iter()
             .map(|u| (u.clone(), Instant::now()))
@@ -339,12 +296,12 @@ mod tests {
 
         let cfg = WatermarkAssignConfig {
             out_of_orderness_ms: 0,
-            time_hint: Some(TimeHint::ColumnName {
+            time_hint: TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
             idle_timeout_ms: Some(WatermarkAssignConfig::DEFAULT_IDLE_TIMEOUT_MS),
         };
-        let mut assigner = WatermarkAssignerState::new(cfg, None);
+        let mut assigner = WatermarkAssignerState::new(cfg);
 
         let wm1 = assigner.on_data_message("upA", &msg).unwrap();
         assert_eq!(wm1.metadata.upstream_vertex_id.as_deref(), Some("upA"));
@@ -386,17 +343,14 @@ mod tests {
 
         let cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string()],
             Arc::new(Mutex::new(HashMap::new())),
@@ -460,17 +414,14 @@ mod tests {
         let input = Box::pin(stream::iter(vec![m0, m1]));
         let cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string(), "u1".to_string()],
             Arc::new(Mutex::new(HashMap::new())),
@@ -523,18 +474,15 @@ mod tests {
 
         let mut cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
         cfg.idle_timeout_ms = Some(1);
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string(), "u1".to_string()],
             Arc::new(Mutex::new(HashMap::new())),
@@ -580,18 +528,15 @@ mod tests {
 
         let mut cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
         cfg.idle_timeout_ms = None;
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string(), "u1".to_string()],
             Arc::new(Mutex::new(HashMap::new())),

--- a/src/tests/inprocess/watermark_streaming.rs
+++ b/src/tests/inprocess/watermark_streaming.rs
@@ -118,7 +118,7 @@ pub(crate) async fn run_watermark_window_pipeline(
     exec_graph.configure_channels(None, None);
     let vertex_ids = exec_graph.get_vertices().keys().cloned().collect();
 
-    // Sanity: ensure we actually built a window operator (planner-side watermark placement should attach to it).
+    // Sanity: window exists; watermark assign is on Source (pre-KeyBy), not Window.
     assert!(
         exec_graph
             .get_vertices()
@@ -126,6 +126,26 @@ pub(crate) async fn run_watermark_window_pipeline(
             .any(|v| matches!(v.operator_config, OperatorConfig::WindowConfig(_))),
         "expected execution graph to contain a Window operator"
     );
+    let assign_vertices: Vec<_> = exec_graph
+        .get_vertices()
+        .values()
+        .filter(|v| v.watermark_assign.is_some())
+        .collect();
+    assert!(
+        !assign_vertices.is_empty(),
+        "expected watermark_assign on at least one vertex"
+    );
+    for v in &assign_vertices {
+        assert!(
+            matches!(v.operator_config, OperatorConfig::SourceConfig(_)),
+            "watermark_assign should be on Source, got {:?}",
+            v.operator_config
+        );
+        assert!(
+            !matches!(v.operator_config, OperatorConfig::WindowConfig(_)),
+            "Window must not have watermark_assign"
+        );
+    }
 
     let mut worker = Worker::from_config(WorkerConfig::new(
         "wm-e2e-worker".to_string(),


### PR DESCRIPTION
## Summary
- Resolve window ORDER BY event-time column lineage in the DF plan and attach `watermark_assign` (`TimeHint::ColumnName`) on the defining Source/Projection, before KeyBy.
- Remove closest-window BFS placement and Window-side assign/derive paths so Window only min-merges upstream watermarks.
- Fixes [#169](https://github.com/volga-project/volga/issues/169): keyed fragments no longer advance global WM and late-drop sibling keys from the same batch.
- Raise inmem window checkpoint inline limit to 8 MiB (WM fix retains more state) and log checkpoint size on each inmem snapshot.

## How assign placement works
1. Find windows in the DF plan that need event-time watermarks.
2. Read the window `ORDER BY` column — that is the event-time column (must be a real column).
3. Walk backward through the plan to where that column is **defined**:
   - Filter / rename alias (`timestamp AS event_time`) → keep walking with the inner column.
   - Computed expression (e.g. `timestamp + INTERVAL '0' MILLISECOND AS event_time`) → **stop at that Projection** (it creates the column the assigner will read).
   - Table scan → stop at that **Source**.
   - Join / multi-input → unsupported for auto placement for now.
4. Attach `watermark_assign` (`ColumnName` + ooo/idle) on that Source/Projection in the Volga graph.
5. Validate the assign site is **upstream of the window’s KeyBy** so WM is generated on the full (pre-split) batch.
6. Window has no assigner — it only min-merges upstream WMs.