### PR TITLE
Fix PipelineFinished hang after StopSources drain

### DIFF
--- a/config/runtime_consts.kube_test.json
+++ b/config/runtime_consts.kube_test.json
@@ -10,6 +10,7 @@
   "master.heartbeat_send_interval": "1s",
   "master.worker_connect_timeout": "2s",
   "master.state_poll_interval": "2s",
+  "master.state_poll_timeout": "10s",
   "master.reset_worker_timeout": "5s",
   "master.registry_wait_tick": "500ms",
   "master.checkpoint_interval": "2s",

--- a/config/runtime_consts.local_test.json
+++ b/config/runtime_consts.local_test.json
@@ -10,6 +10,7 @@
   "master.heartbeat_send_interval": "100ms",
   "master.worker_connect_timeout": "200ms",
   "master.state_poll_interval": "100ms",
+  "master.state_poll_timeout": "2s",
   "master.reset_worker_timeout": "2s",
   "master.registry_wait_tick": "50ms",
   "master.checkpoint_interval": "500ms",

--- a/config/runtime_consts.prod.json
+++ b/config/runtime_consts.prod.json
@@ -10,6 +10,7 @@
   "master.heartbeat_send_interval": "1s",
   "master.worker_connect_timeout": "2s",
   "master.state_poll_interval": "2s",
+  "master.state_poll_timeout": "10s",
   "master.reset_worker_timeout": "5s",
   "master.registry_wait_tick": "500ms",
   "master.checkpoint_interval": "30s",

--- a/scripts/stress-test
+++ b/scripts/stress-test
@@ -159,6 +159,10 @@ done
 
 echo "Stress logs: $LOG_DIR"
 if [[ "$failed" -ne 0 ]]; then
-  rg -n "Error: |=== $ENVIRONMENT shard .*: fail ===" "$LOG_DIR" || true
+  if command -v rg >/dev/null 2>&1; then
+    rg -n "Error: |=== $ENVIRONMENT shard .*: fail ===" "$LOG_DIR" || true
+  else
+    grep -REn "Error: |=== $ENVIRONMENT shard .*: fail ===" "$LOG_DIR" || true
+  fi
 fi
 exit "$failed"

--- a/src/api/event_time_placement.rs
+++ b/src/api/event_time_placement.rs
@@ -1,0 +1,325 @@
+//! Resolve where auto watermark assigners should attach by walking DataFusion
+//! plan lineage from a window's ORDER BY event-time column to its defining site.
+
+use datafusion::common::{Column, DataFusionError, Result};
+use datafusion::logical_expr::{Expr, LogicalPlan, Projection, Window};
+use petgraph::graph::NodeIndex;
+use petgraph::Direction;
+
+use super::logical_graph::LogicalGraph;
+use crate::runtime::operators::operator::OperatorConfig;
+
+/// Plan site where a watermark assigner should be attached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssignSite {
+    /// Column name in the assign site's output schema.
+    pub column_name: String,
+    /// Identity of the defining [`LogicalPlan`] node (`ptr` as usize).
+    pub plan_node_key: usize,
+}
+
+pub fn plan_node_key(plan: &LogicalPlan) -> usize {
+    plan as *const LogicalPlan as usize
+}
+
+fn unwrap_alias(expr: &Expr) -> &Expr {
+    match expr {
+        Expr::Alias(alias) => unwrap_alias(alias.expr.as_ref()),
+        other => other,
+    }
+}
+
+/// Extract the event-time column from the first window ORDER BY expression.
+pub fn event_time_column_from_window(window: &Window) -> Result<Column> {
+    let first = window.window_expr.first().ok_or_else(|| {
+        DataFusionError::Plan("window has no window expressions".to_string())
+    })?;
+
+    let Expr::WindowFunction(wf) = unwrap_alias(first) else {
+        return Err(DataFusionError::Plan(format!(
+            "expected WindowFunction for watermark lineage, got {first:?}"
+        )));
+    };
+
+    let order = wf.params.order_by.first().ok_or_else(|| {
+        DataFusionError::Plan("window ORDER BY is required for auto watermark placement".to_string())
+    })?;
+
+    match unwrap_alias(&order.expr) {
+        Expr::Column(col) => Ok(col.clone()),
+        other => Err(DataFusionError::Plan(format!(
+            "window ORDER BY must be a column for auto watermark placement, got {other:?}"
+        ))),
+    }
+}
+
+fn find_projection_expr<'a>(proj: &'a Projection, col_name: &str) -> Result<&'a Expr> {
+    for (idx, field) in proj.schema.fields().iter().enumerate() {
+        if field.name() == col_name {
+            return proj.expr.get(idx).ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "projection schema/expr mismatch looking for column '{col_name}'"
+                ))
+            });
+        }
+    }
+    for expr in &proj.expr {
+        let (_, name) = expr.qualified_name();
+        if name == col_name {
+            return Ok(expr);
+        }
+    }
+    Err(DataFusionError::Plan(format!(
+        "projection does not define event-time column '{col_name}'"
+    )))
+}
+
+/// Walk backward from `window.input` to the plan node that defines the event-time column.
+pub fn resolve_event_time_assign_site(window: &Window) -> Result<AssignSite> {
+    let mut col = event_time_column_from_window(window)?;
+    let mut current = window.input.as_ref();
+
+    loop {
+        match current {
+            LogicalPlan::Filter(filter) => {
+                current = filter.input.as_ref();
+            }
+            LogicalPlan::SubqueryAlias(alias) => {
+                current = alias.input.as_ref();
+            }
+            LogicalPlan::Sort(sort) => {
+                current = sort.input.as_ref();
+            }
+            LogicalPlan::Limit(limit) => {
+                current = limit.input.as_ref();
+            }
+            LogicalPlan::Repartition(repartition) => {
+                current = repartition.input.as_ref();
+            }
+            LogicalPlan::Distinct(distinct) => {
+                current = distinct.input().as_ref();
+            }
+            LogicalPlan::Projection(proj) => {
+                let expr = find_projection_expr(proj, &col.name)?;
+                match unwrap_alias(expr) {
+                    Expr::Column(inner) => {
+                        col = inner.clone();
+                        current = proj.input.as_ref();
+                    }
+                    _ => {
+                        // Computed (or otherwise non-column) expression — assign here.
+                        return Ok(AssignSite {
+                            column_name: col.name.clone(),
+                            plan_node_key: plan_node_key(current),
+                        });
+                    }
+                }
+            }
+            LogicalPlan::TableScan(_) => {
+                return Ok(AssignSite {
+                    column_name: col.name.clone(),
+                    plan_node_key: plan_node_key(current),
+                });
+            }
+            LogicalPlan::Join(_) | LogicalPlan::Union(_) => {
+                return Err(DataFusionError::Plan(
+                    "unsupported for auto watermark placement: multi-input operator on event-time lineage"
+                        .to_string(),
+                ));
+            }
+            other => {
+                return Err(DataFusionError::Plan(format!(
+                    "unsupported for auto watermark placement on event-time lineage: {}",
+                    other.display()
+                )));
+            }
+        }
+    }
+}
+
+fn reaches(graph: &LogicalGraph, from: NodeIndex, to: NodeIndex) -> bool {
+    if from == to {
+        return true;
+    }
+    let mut visited = std::collections::HashSet::new();
+    let mut stack = vec![from];
+    while let Some(n) = stack.pop() {
+        if !visited.insert(n) {
+            continue;
+        }
+        for neigh in graph.get_neighbors(n, Direction::Outgoing) {
+            if neigh == to {
+                return true;
+            }
+            stack.push(neigh);
+        }
+    }
+    false
+}
+
+/// Assign site must be upstream of the window's KeyBy (fragmenting edge), and must not
+/// land on KeyBy/Window themselves.
+pub fn validate_assign_before_window_keyby(
+    graph: &LogicalGraph,
+    assign_idx: NodeIndex,
+    window_idx: NodeIndex,
+) -> Result<()> {
+    let assign_cfg = &graph.get_node_by_index(assign_idx).operator_config;
+    if matches!(
+        assign_cfg,
+        OperatorConfig::KeyByConfig(_) | OperatorConfig::WindowConfig(_)
+    ) {
+        return Err(DataFusionError::Plan(
+            "event-time watermark assign must not land on KeyBy or Window".to_string(),
+        ));
+    }
+
+    let keyby_idx = graph
+        .get_neighbors(window_idx, Direction::Incoming)
+        .into_iter()
+        .find(|&idx| {
+            matches!(
+                graph.get_node_by_index(idx).operator_config,
+                OperatorConfig::KeyByConfig(_)
+            )
+        })
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "window has no KeyBy predecessor for watermark placement validation".to_string(),
+            )
+        })?;
+
+    if !reaches(graph, assign_idx, keyby_idx) {
+        return Err(DataFusionError::Plan(
+            "event-time assign site must be upstream of the window's KeyBy".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use datafusion::catalog::MemTable;
+    use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+    use datafusion::prelude::SessionContext;
+    use std::sync::Arc;
+
+    fn events_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                false,
+            ),
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]))
+    }
+
+    async fn plan_sql(sql: &str) -> LogicalPlan {
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
+        ctx.register_table("events", Arc::new(table)).unwrap();
+        let df = ctx.sql(sql).await.unwrap();
+        df.into_optimized_plan().unwrap()
+    }
+
+    fn find_window(plan: &LogicalPlan) -> Window {
+        let mut found = None;
+        plan.apply(|node| {
+            if let LogicalPlan::Window(w) = node {
+                found = Some(w.clone());
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })
+        .unwrap();
+        found.expect("expected a Window in plan")
+    }
+
+    fn find_plan_by_key<'a>(plan: &'a LogicalPlan, key: usize) -> Option<&'a LogicalPlan> {
+        let mut found = None;
+        plan.apply(|node| {
+            if plan_node_key(node) == key {
+                found = Some(node);
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })
+        .unwrap();
+        found
+    }
+
+    #[tokio::test]
+    async fn lineage_passthrough_column_stops_at_source() {
+        let plan = plan_sql(
+            "SELECT timestamp, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY timestamp \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM events",
+        )
+        .await;
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        assert_eq!(site.column_name, "timestamp");
+        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
+        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+    }
+
+    #[tokio::test]
+    async fn lineage_renamed_column_continues_to_source() {
+        let plan = plan_sql(
+            "SELECT event_time, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY event_time \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM (SELECT timestamp AS event_time, key, value FROM events)",
+        )
+        .await;
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        // After unwrapping the alias, assign on the source under the original column name.
+        assert_eq!(site.column_name, "timestamp");
+        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
+        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+    }
+
+    #[tokio::test]
+    async fn lineage_computed_event_time_stops_on_projection() {
+        let plan = plan_sql(
+            "SELECT event_time, key, value, \
+             SUM(value) OVER (PARTITION BY key ORDER BY event_time \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM (SELECT timestamp + INTERVAL '0' MILLISECOND AS event_time, key, value FROM events)",
+        )
+        .await;
+        let window = find_window(&plan);
+        let site = resolve_event_time_assign_site(&window).unwrap();
+        assert_eq!(site.column_name, "event_time");
+        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
+        assert!(matches!(site_plan, LogicalPlan::Projection(_)));
+    }
+
+    #[tokio::test]
+    async fn lineage_join_on_path_errors() {
+        let ctx = SessionContext::new();
+        let table = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
+        ctx.register_table("events", Arc::new(table)).unwrap();
+        let table2 = MemTable::try_new(events_schema(), vec![vec![]]).unwrap();
+        ctx.register_table("events2", Arc::new(table2)).unwrap();
+
+        let sql = "SELECT e.timestamp, e.key, e.value, \
+             SUM(e.value) OVER (PARTITION BY e.key ORDER BY e.timestamp \
+             RANGE BETWEEN INTERVAL '1000' MILLISECOND PRECEDING AND CURRENT ROW) as sum_value \
+             FROM events e JOIN events2 e2 ON e.key = e2.key";
+        let df = ctx.sql(sql).await.unwrap();
+        let plan = df.into_optimized_plan().unwrap();
+        let window = find_window(&plan);
+        let err = resolve_event_time_assign_site(&window).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unsupported for auto watermark placement"),
+            "unexpected error: {msg}"
+        );
+    }
+}

--- a/src/api/event_time_placement.rs
+++ b/src/api/event_time_placement.rs
@@ -1,25 +1,38 @@
 //! Resolve where auto watermark assigners should attach by walking DataFusion
 //! plan lineage from a window's ORDER BY event-time column to its defining site.
 
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::{Column, DataFusionError, Result};
 use datafusion::logical_expr::{Expr, LogicalPlan, Projection, Window};
+use datafusion::physical_plan::expressions::Column as PhysicalColumn;
 use petgraph::graph::NodeIndex;
 use petgraph::Direction;
 
 use super::logical_graph::LogicalGraph;
+use crate::runtime::functions::map::MapFunction;
 use crate::runtime::operators::operator::OperatorConfig;
 
 /// Plan site where a watermark assigner should be attached.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AssignSite {
-    /// Column name in the assign site's output schema.
-    pub column_name: String,
-    /// Identity of the defining [`LogicalPlan`] node (`ptr` as usize).
-    pub plan_node_key: usize,
+pub enum AssignSite {
+    Source {
+        /// DF table name (lineage / diagnostics; graph match uses unique upstream Source).
+        table_name: String,
+        /// Column name in the source output schema.
+        column_name: String,
+    },
+    /// Projection that defines a computed (non-column) event-time expression.
+    Projection {
+        column_name: String,
+    },
 }
 
-pub fn plan_node_key(plan: &LogicalPlan) -> usize {
-    plan as *const LogicalPlan as usize
+impl AssignSite {
+    pub fn column_name(&self) -> &str {
+        match self {
+            Self::Source { column_name, .. } | Self::Projection { column_name } => column_name,
+        }
+    }
 }
 
 fn unwrap_alias(expr: &Expr) -> &Expr {
@@ -107,18 +120,16 @@ pub fn resolve_event_time_assign_site(window: &Window) -> Result<AssignSite> {
                         current = proj.input.as_ref();
                     }
                     _ => {
-                        // Computed (or otherwise non-column) expression — assign here.
-                        return Ok(AssignSite {
+                        return Ok(AssignSite::Projection {
                             column_name: col.name.clone(),
-                            plan_node_key: plan_node_key(current),
                         });
                     }
                 }
             }
-            LogicalPlan::TableScan(_) => {
-                return Ok(AssignSite {
+            LogicalPlan::TableScan(scan) => {
+                return Ok(AssignSite::Source {
+                    table_name: scan.table_name.table().to_string(),
                     column_name: col.name.clone(),
-                    plan_node_key: plan_node_key(current),
                 });
             }
             LogicalPlan::Join(_) | LogicalPlan::Union(_) => {
@@ -157,6 +168,23 @@ fn reaches(graph: &LogicalGraph, from: NodeIndex, to: NodeIndex) -> bool {
     false
 }
 
+fn window_keyby(graph: &LogicalGraph, window_idx: NodeIndex) -> Result<NodeIndex> {
+    graph
+        .get_neighbors(window_idx, Direction::Incoming)
+        .into_iter()
+        .find(|&idx| {
+            matches!(
+                graph.get_node_by_index(idx).operator_config,
+                OperatorConfig::KeyByConfig(_)
+            )
+        })
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "window has no KeyBy predecessor for watermark placement validation".to_string(),
+            )
+        })
+}
+
 /// Assign site must be upstream of the window's KeyBy (fragmenting edge), and must not
 /// land on KeyBy/Window themselves.
 pub fn validate_assign_before_window_keyby(
@@ -174,25 +202,142 @@ pub fn validate_assign_before_window_keyby(
         ));
     }
 
-    let keyby_idx = graph
-        .get_neighbors(window_idx, Direction::Incoming)
-        .into_iter()
-        .find(|&idx| {
-            matches!(
-                graph.get_node_by_index(idx).operator_config,
-                OperatorConfig::KeyByConfig(_)
-            )
-        })
-        .ok_or_else(|| {
-            DataFusionError::Plan(
-                "window has no KeyBy predecessor for watermark placement validation".to_string(),
-            )
-        })?;
-
+    let keyby_idx = window_keyby(graph, window_idx)?;
     if !reaches(graph, assign_idx, keyby_idx) {
         return Err(DataFusionError::Plan(
             "event-time assign site must be upstream of the window's KeyBy".to_string(),
         ));
+    }
+
+    Ok(())
+}
+
+fn window_order_by_column_name(graph: &LogicalGraph, window_idx: NodeIndex) -> Option<String> {
+    let OperatorConfig::WindowConfig(cfg) = &graph.get_node_by_index(window_idx).operator_config
+    else {
+        return None;
+    };
+    let order = cfg.window_exec.window_expr().first()?.order_by().first()?;
+    order
+        .expr
+        .as_any()
+        .downcast_ref::<PhysicalColumn>()
+        .map(|c| c.name().to_string())
+}
+
+fn projection_defines_computed_column(map: &MapFunction, column_name: &str) -> bool {
+    let MapFunction::Projection(proj) = map else {
+        return false;
+    };
+    for (idx, field) in proj.out_schema().fields().iter().enumerate() {
+        if field.name() != column_name {
+            continue;
+        }
+        let Some(expr) = proj.exprs().get(idx) else {
+            return false;
+        };
+        return !matches!(unwrap_alias(expr), Expr::Column(_));
+    }
+    false
+}
+
+fn find_assign_node(
+    graph: &LogicalGraph,
+    site: &AssignSite,
+    window_idxs: &[NodeIndex],
+) -> Result<NodeIndex> {
+    let keybys = window_idxs
+        .iter()
+        .map(|&w| window_keyby(graph, w))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut candidates = Vec::new();
+    for idx in graph.get_all_node_indices() {
+        if !keybys.iter().all(|&kb| reaches(graph, idx, kb)) {
+            continue;
+        }
+        match (site, &graph.get_node_by_index(idx).operator_config) {
+            (AssignSite::Source { .. }, OperatorConfig::SourceConfig(_)) => {
+                candidates.push(idx);
+            }
+            (AssignSite::Projection { column_name }, OperatorConfig::MapConfig(map))
+                if projection_defines_computed_column(map, column_name) =>
+            {
+                candidates.push(idx);
+            }
+            _ => {}
+        }
+    }
+
+    match candidates.as_slice() {
+        [only] => Ok(*only),
+        [] => Err(DataFusionError::Plan(format!(
+            "no logical node found for watermark assign site {site:?}"
+        ))),
+        _ => Err(DataFusionError::Plan(format!(
+            "ambiguous logical nodes for watermark assign site {site:?}: {} candidates",
+            candidates.len()
+        ))),
+    }
+}
+
+fn attach_assign(graph: &mut LogicalGraph, assign_idx: NodeIndex, column_name: String) -> Result<()> {
+    let cfg = graph.watermark_assign_config_for_column(column_name);
+    let node = graph
+        .get_node_by_index_mut(assign_idx)
+        .expect("assign node index must exist");
+    match &node.watermark_assign {
+        Some(existing) => {
+            if existing.time_hint != cfg.time_hint {
+                return Err(DataFusionError::Plan(format!(
+                    "conflicting watermark assign time hints on {}: {:?} vs {:?}",
+                    node.operator_id, existing.time_hint, cfg.time_hint
+                )));
+            }
+        }
+        None => {
+            node.watermark_assign = Some(cfg);
+        }
+    }
+    Ok(())
+}
+
+/// Attach auto watermark assign configs on the defining Source/Projection nodes for each
+/// window in `plan`. Call after the logical graph has been built from that plan.
+pub fn apply_auto_watermark_assigns(plan: &LogicalPlan, graph: &mut LogicalGraph) -> Result<()> {
+    if !graph.watermarks_enabled() {
+        return Ok(());
+    }
+
+    let mut jobs: Vec<(AssignSite, String)> = Vec::new();
+    plan.apply(|node| {
+        if let LogicalPlan::Window(window) = node {
+            let site = resolve_event_time_assign_site(window)?;
+            let et = event_time_column_from_window(window)?;
+            jobs.push((site, et.name));
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+
+    for (site, window_et_name) in jobs {
+        let window_idxs: Vec<NodeIndex> = graph
+            .get_all_node_indices()
+            .into_iter()
+            .filter(|&idx| {
+                window_order_by_column_name(graph, idx).as_deref() == Some(window_et_name.as_str())
+            })
+            .collect();
+        if window_idxs.is_empty() {
+            return Err(DataFusionError::Plan(format!(
+                "no window operator with ORDER BY column '{window_et_name}' for watermark placement"
+            )));
+        }
+
+        let assign_idx = find_assign_node(graph, &site, &window_idxs)?;
+        for &window_idx in &window_idxs {
+            validate_assign_before_window_keyby(graph, assign_idx, window_idx)?;
+        }
+        attach_assign(graph, assign_idx, site.column_name().to_string())?;
     }
 
     Ok(())
@@ -203,7 +348,6 @@ mod tests {
     use super::*;
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use datafusion::catalog::MemTable;
-    use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
     use datafusion::prelude::SessionContext;
     use std::sync::Arc;
 
@@ -239,18 +383,6 @@ mod tests {
         found.expect("expected a Window in plan")
     }
 
-    fn find_plan_by_key<'a>(plan: &'a LogicalPlan, key: usize) -> Option<&'a LogicalPlan> {
-        let mut found = None;
-        plan.apply(|node| {
-            if plan_node_key(node) == key {
-                found = Some(node);
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })
-        .unwrap();
-        found
-    }
-
     #[tokio::test]
     async fn lineage_passthrough_column_stops_at_source() {
         let plan = plan_sql(
@@ -262,9 +394,13 @@ mod tests {
         .await;
         let window = find_window(&plan);
         let site = resolve_event_time_assign_site(&window).unwrap();
-        assert_eq!(site.column_name, "timestamp");
-        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
-        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+        assert_eq!(
+            site,
+            AssignSite::Source {
+                table_name: "events".to_string(),
+                column_name: "timestamp".to_string(),
+            }
+        );
     }
 
     #[tokio::test]
@@ -278,10 +414,13 @@ mod tests {
         .await;
         let window = find_window(&plan);
         let site = resolve_event_time_assign_site(&window).unwrap();
-        // After unwrapping the alias, assign on the source under the original column name.
-        assert_eq!(site.column_name, "timestamp");
-        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
-        assert!(matches!(site_plan, LogicalPlan::TableScan(_)));
+        assert_eq!(
+            site,
+            AssignSite::Source {
+                table_name: "events".to_string(),
+                column_name: "timestamp".to_string(),
+            }
+        );
     }
 
     #[tokio::test]
@@ -295,9 +434,12 @@ mod tests {
         .await;
         let window = find_window(&plan);
         let site = resolve_event_time_assign_site(&window).unwrap();
-        assert_eq!(site.column_name, "event_time");
-        let site_plan = find_plan_by_key(&plan, site.plan_node_key).unwrap();
-        assert!(matches!(site_plan, LogicalPlan::Projection(_)));
+        assert_eq!(
+            site,
+            AssignSite::Projection {
+                column_name: "event_time".to_string(),
+            }
+        );
     }
 
     #[tokio::test]

--- a/src/api/logical_graph.rs
+++ b/src/api/logical_graph.rs
@@ -77,18 +77,31 @@ impl LogicalGraph {
         self.watermarks_enabled = enabled;
     }
 
+    pub fn watermarks_enabled(&self) -> bool {
+        self.watermarks_enabled
+    }
+
     pub(crate) fn set_event_time(&mut self, event_time: EventTimeSpec) {
         self.event_time = event_time;
+        // Refresh ooo/idle on assign configs attached during planning.
+        for node in self.graph.node_weights_mut() {
+            if let Some(cfg) = node.watermark_assign.as_mut() {
+                cfg.out_of_orderness_ms = self.event_time.watermark.out_of_orderness_ms;
+                if let Some(idle) = self.event_time.watermark.idle_timeout_ms {
+                    cfg.idle_timeout_ms = Some(idle);
+                }
+            }
+        }
     }
 
     pub fn event_time(&self) -> &EventTimeSpec {
         &self.event_time
     }
 
-    fn auto_watermark_assign_config(&self) -> WatermarkAssignConfig {
+    pub(crate) fn watermark_assign_config_for_column(&self, column_name: String) -> WatermarkAssignConfig {
         let mut cfg = WatermarkAssignConfig::new(
             self.event_time.watermark.out_of_orderness_ms,
-            Some(TimeHint::WindowOrderByColumn),
+            TimeHint::ColumnName { name: column_name },
         );
         if let Some(idle) = self.event_time.watermark.idle_timeout_ms {
             cfg.idle_timeout_ms = Some(idle);
@@ -181,65 +194,11 @@ impl LogicalGraph {
 
     /// Convert logical graph to execution graph using parallelism from each logical node
     pub fn to_execution_graph(&self) -> ExecutionGraph {
-        // Planner-side heuristic watermark assigner placement:
-        // For now, for each Source, find the closest downstream Window operator(s) and attach a watermark assigner there.
-        // This keeps watermark generation as a StreamTask feature (no dedicated operator) while preserving
-        // downstream min-upstream watermark merge semantics.
+        // Watermark assign placement is decided during planning (event-time lineage) and stored
+        // on LogicalNode.watermark_assign. Execution mapping is a simple copy.
         //
-        // TODO: extend placement for joins/unions (multiple-input operators), where "closest window" is ambiguous
-        // and per-input watermark generation needs careful handling.
-        let mut auto_watermark_assign: HashMap<String, WatermarkAssignConfig> = HashMap::new();
-        if self.watermarks_enabled {
-            let source_nodes: Vec<NodeIndex> = self
-                .graph
-                .node_indices()
-                .filter(|&idx| matches!(self.graph[idx].operator_config, OperatorConfig::SourceConfig(_)))
-                .collect();
-
-            for src in source_nodes {
-            // Layered BFS: stop at first layer that contains any window node(s).
-            let mut visited: HashMap<NodeIndex, ()> = HashMap::new();
-            let mut frontier: Vec<NodeIndex> = vec![src];
-            visited.insert(src, ());
-
-            loop {
-                // Next layer
-                let mut next: Vec<NodeIndex> = Vec::new();
-                for &n in &frontier {
-                    for neigh in self.graph.neighbors_directed(n, Direction::Outgoing) {
-                        if visited.contains_key(&neigh) {
-                            continue;
-                        }
-                        visited.insert(neigh, ());
-                        next.push(neigh);
-                    }
-                }
-
-                if next.is_empty() {
-                    break;
-                }
-
-                let windows_at_layer: Vec<NodeIndex> = next
-                    .iter()
-                    .copied()
-                    .filter(|&idx| matches!(self.graph[idx].operator_config, OperatorConfig::WindowConfig(_)))
-                    .collect();
-                if !windows_at_layer.is_empty() {
-                    let assign = self.auto_watermark_assign_config();
-                    for w in windows_at_layer {
-                        let op_id = self.graph[w].operator_id.clone();
-                        auto_watermark_assign
-                            .entry(op_id)
-                            .or_insert_with(|| assign.clone());
-                    }
-                    break;
-                }
-
-                frontier = next;
-            }
-            }
-        } else {
-            // In Batch mode we expect no watermark assignment at all.
+        // TODO: extend placement for joins/unions (multiple-input operators / per-branch assign).
+        if !self.watermarks_enabled {
             debug_assert!(
                 self.graph.node_weights().all(|n| n.watermark_assign.is_none()),
                 "watermarks_disabled but some logical nodes have watermark_assign configured"
@@ -270,10 +229,7 @@ impl LogicalGraph {
                     i as i32,
                 );
                 let mut execution_vertex = execution_vertex;
-                execution_vertex.watermark_assign = logical_node
-                    .watermark_assign
-                    .clone()
-                    .or_else(|| auto_watermark_assign.get(&logical_node.operator_id).cloned());
+                execution_vertex.watermark_assign = logical_node.watermark_assign.clone();
 
                 execution_graph.add_vertex(execution_vertex);
                 execution_vertex_ids.push(execution_vertex_id);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod logical_graph;
+pub mod event_time_placement;
 pub mod planner;
 #[cfg(test)]
 pub mod logical_optimizer_examples;

--- a/src/api/planner.rs
+++ b/src/api/planner.rs
@@ -20,7 +20,7 @@ use datafusion::logical_expr::{
 use datafusion::physical_plan::aggregates::AggregateExec;
 use datafusion::common::{Result, DataFusionError};
 use datafusion::common::tree_node::TreeNodeRecursion;
-use datafusion::common::tree_node::TreeNodeVisitor;
+use datafusion::common::tree_node::{TreeNode, TreeNodeVisitor};
 use datafusion::prelude::SessionContext;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion::sql::TableReference;
@@ -28,6 +28,9 @@ use datafusion::optimizer::analyzer::type_coercion::TypeCoercion;
 use datafusion::optimizer::analyzer::AnalyzerRule;
 use petgraph::graph::NodeIndex;
 
+use super::event_time_placement::{
+    plan_node_key, resolve_event_time_assign_site, validate_assign_before_window_keyby, AssignSite,
+};
 use super::logical_graph::{LogicalNode, LogicalGraph};
 use crate::api::ExecutionMode;
 use crate::runtime::functions::key_by::key_by_function::{DataFusionKeyFunction};
@@ -111,6 +114,8 @@ pub struct Planner {
     logical_graph: LogicalGraph,
     node_stack: Vec<NodeIndex>,
     context: PlanningContext,
+    /// DF plan node pointer identity → logical graph node (for watermark assign placement).
+    df_plan_to_node: HashMap<usize, NodeIndex>,
 }
 
 #[derive(Clone)]
@@ -165,6 +170,7 @@ impl Planner {
             logical_graph: LogicalGraph::new(),
             node_stack: Vec::new(),
             context,
+            df_plan_to_node: HashMap::new(),
         }
     }
 
@@ -191,11 +197,71 @@ impl Planner {
 
     pub fn logical_plan_to_graph(&mut self, logical_plan: &LogicalPlan) -> Result<LogicalGraph> {
         self.node_stack.clear();
+        self.df_plan_to_node.clear();
 
         let optimized_plan = self.optimize_plan(logical_plan.clone())?;
         optimized_plan.visit_with_subqueries(self)?;
-        
+        self.apply_auto_watermark_assigns(&optimized_plan)?;
+
         Ok(self.logical_graph.clone())
+    }
+
+    fn apply_auto_watermark_assigns(&mut self, plan: &LogicalPlan) -> Result<()> {
+        // Batch mode forbids watermark_assign on StreamTasks.
+        if self.context.execution_mode == ExecutionMode::Batch {
+            return Ok(());
+        }
+        if !self.logical_graph.watermarks_enabled() {
+            return Ok(());
+        }
+
+        let mut sites: Vec<(usize, AssignSite)> = Vec::new();
+        plan.apply(|node| {
+            if let LogicalPlan::Window(window) = node {
+                let site = resolve_event_time_assign_site(window)?;
+                sites.push((plan_node_key(node), site));
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+
+        for (window_plan_key, site) in sites {
+            let assign_idx = *self.df_plan_to_node.get(&site.plan_node_key).ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "no logical node mapped for event-time assign site (column={})",
+                    site.column_name
+                ))
+            })?;
+            let window_idx = *self.df_plan_to_node.get(&window_plan_key).ok_or_else(|| {
+                DataFusionError::Plan(
+                    "no logical node mapped for window during watermark placement".to_string(),
+                )
+            })?;
+
+            validate_assign_before_window_keyby(&self.logical_graph, assign_idx, window_idx)?;
+
+            let cfg = self
+                .logical_graph
+                .watermark_assign_config_for_column(site.column_name.clone());
+            let node = self
+                .logical_graph
+                .get_node_by_index_mut(assign_idx)
+                .expect("assign node index must exist");
+            match &node.watermark_assign {
+                Some(existing) => {
+                    if existing.time_hint != cfg.time_hint {
+                        return Err(DataFusionError::Plan(format!(
+                            "conflicting watermark assign time hints on {}: {:?} vs {:?}",
+                            node.operator_id, existing.time_hint, cfg.time_hint
+                        )));
+                    }
+                }
+                None => {
+                    node.watermark_assign = Some(cfg);
+                }
+            }
+        }
+
+        Ok(())
     }
 
     pub fn sql_to_graph(&mut self, sql: &str) -> Result<LogicalGraph> {
@@ -453,11 +519,15 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
         // Process node and create operator
         match node {
             LogicalPlan::TableScan(table_scan) => {
-                self.create_source_node(table_scan, self.context.parallelism)?
+                self.create_source_node(table_scan, self.context.parallelism)?;
+                let idx = *self.node_stack.last().expect("source node just pushed");
+                self.df_plan_to_node.insert(plan_node_key(node), idx);
             }
             
             LogicalPlan::Projection(projection) => {
-                self.create_projection_node(projection, self.context.parallelism)?
+                self.create_projection_node(projection, self.context.parallelism)?;
+                let idx = *self.node_stack.last().expect("projection node just pushed");
+                self.df_plan_to_node.insert(plan_node_key(node), idx);
             }
             
             LogicalPlan::Filter(filter) => {
@@ -473,6 +543,9 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
             }
             LogicalPlan::Window(window) => {
                 self.handle_window(window, self.context.parallelism)?;
+                // Stack top is KeyBy, then Window (handle_window pushes window then keyby).
+                let window_idx = self.node_stack[self.node_stack.len() - 2];
+                self.df_plan_to_node.insert(plan_node_key(node), window_idx);
             }
             
             // skip subqueries as they simply wrap other plans
@@ -938,6 +1011,21 @@ mod tests {
             (NodeType::KeyBy, NodeType::Window, PartitionType::Hash, 1),
             (NodeType::Window, NodeType::Projection, PartitionType::RoundRobin, 1),
         ]);
+
+        // Event-time lineage: assign on Source (defining site), not Window/KeyBy.
+        assert!(
+            nodes[3].watermark_assign.is_some(),
+            "expected watermark_assign on Source"
+        );
+        assert!(
+            matches!(
+                &nodes[3].watermark_assign.as_ref().unwrap().time_hint,
+                crate::runtime::watermark::TimeHint::ColumnName { name } if name == "event_time"
+            ),
+            "expected ColumnName(event_time) time hint on Source"
+        );
+        assert!(nodes[1].watermark_assign.is_none(), "Window must not have watermark_assign");
+        assert!(nodes[2].watermark_assign.is_none(), "KeyBy must not have watermark_assign");
     }
 
     #[tokio::test]

--- a/src/api/planner.rs
+++ b/src/api/planner.rs
@@ -20,7 +20,7 @@ use datafusion::logical_expr::{
 use datafusion::physical_plan::aggregates::AggregateExec;
 use datafusion::common::{Result, DataFusionError};
 use datafusion::common::tree_node::TreeNodeRecursion;
-use datafusion::common::tree_node::{TreeNode, TreeNodeVisitor};
+use datafusion::common::tree_node::TreeNodeVisitor;
 use datafusion::prelude::SessionContext;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 use datafusion::sql::TableReference;
@@ -28,9 +28,7 @@ use datafusion::optimizer::analyzer::type_coercion::TypeCoercion;
 use datafusion::optimizer::analyzer::AnalyzerRule;
 use petgraph::graph::NodeIndex;
 
-use super::event_time_placement::{
-    plan_node_key, resolve_event_time_assign_site, validate_assign_before_window_keyby, AssignSite,
-};
+use super::event_time_placement::apply_auto_watermark_assigns;
 use super::logical_graph::{LogicalNode, LogicalGraph};
 use crate::api::ExecutionMode;
 use crate::runtime::functions::key_by::key_by_function::{DataFusionKeyFunction};
@@ -114,8 +112,6 @@ pub struct Planner {
     logical_graph: LogicalGraph,
     node_stack: Vec<NodeIndex>,
     context: PlanningContext,
-    /// DF plan node pointer identity → logical graph node (for watermark assign placement).
-    df_plan_to_node: HashMap<usize, NodeIndex>,
 }
 
 #[derive(Clone)]
@@ -170,7 +166,6 @@ impl Planner {
             logical_graph: LogicalGraph::new(),
             node_stack: Vec::new(),
             context,
-            df_plan_to_node: HashMap::new(),
         }
     }
 
@@ -197,71 +192,15 @@ impl Planner {
 
     pub fn logical_plan_to_graph(&mut self, logical_plan: &LogicalPlan) -> Result<LogicalGraph> {
         self.node_stack.clear();
-        self.df_plan_to_node.clear();
 
         let optimized_plan = self.optimize_plan(logical_plan.clone())?;
         optimized_plan.visit_with_subqueries(self)?;
-        self.apply_auto_watermark_assigns(&optimized_plan)?;
+        // Batch mode forbids watermark_assign on StreamTasks.
+        if self.context.execution_mode != ExecutionMode::Batch {
+            apply_auto_watermark_assigns(&optimized_plan, &mut self.logical_graph)?;
+        }
 
         Ok(self.logical_graph.clone())
-    }
-
-    fn apply_auto_watermark_assigns(&mut self, plan: &LogicalPlan) -> Result<()> {
-        // Batch mode forbids watermark_assign on StreamTasks.
-        if self.context.execution_mode == ExecutionMode::Batch {
-            return Ok(());
-        }
-        if !self.logical_graph.watermarks_enabled() {
-            return Ok(());
-        }
-
-        let mut sites: Vec<(usize, AssignSite)> = Vec::new();
-        plan.apply(|node| {
-            if let LogicalPlan::Window(window) = node {
-                let site = resolve_event_time_assign_site(window)?;
-                sites.push((plan_node_key(node), site));
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })?;
-
-        for (window_plan_key, site) in sites {
-            let assign_idx = *self.df_plan_to_node.get(&site.plan_node_key).ok_or_else(|| {
-                DataFusionError::Plan(format!(
-                    "no logical node mapped for event-time assign site (column={})",
-                    site.column_name
-                ))
-            })?;
-            let window_idx = *self.df_plan_to_node.get(&window_plan_key).ok_or_else(|| {
-                DataFusionError::Plan(
-                    "no logical node mapped for window during watermark placement".to_string(),
-                )
-            })?;
-
-            validate_assign_before_window_keyby(&self.logical_graph, assign_idx, window_idx)?;
-
-            let cfg = self
-                .logical_graph
-                .watermark_assign_config_for_column(site.column_name.clone());
-            let node = self
-                .logical_graph
-                .get_node_by_index_mut(assign_idx)
-                .expect("assign node index must exist");
-            match &node.watermark_assign {
-                Some(existing) => {
-                    if existing.time_hint != cfg.time_hint {
-                        return Err(DataFusionError::Plan(format!(
-                            "conflicting watermark assign time hints on {}: {:?} vs {:?}",
-                            node.operator_id, existing.time_hint, cfg.time_hint
-                        )));
-                    }
-                }
-                None => {
-                    node.watermark_assign = Some(cfg);
-                }
-            }
-        }
-
-        Ok(())
     }
 
     pub fn sql_to_graph(&mut self, sql: &str) -> Result<LogicalGraph> {
@@ -519,15 +458,11 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
         // Process node and create operator
         match node {
             LogicalPlan::TableScan(table_scan) => {
-                self.create_source_node(table_scan, self.context.parallelism)?;
-                let idx = *self.node_stack.last().expect("source node just pushed");
-                self.df_plan_to_node.insert(plan_node_key(node), idx);
+                self.create_source_node(table_scan, self.context.parallelism)?
             }
             
             LogicalPlan::Projection(projection) => {
-                self.create_projection_node(projection, self.context.parallelism)?;
-                let idx = *self.node_stack.last().expect("projection node just pushed");
-                self.df_plan_to_node.insert(plan_node_key(node), idx);
+                self.create_projection_node(projection, self.context.parallelism)?
             }
             
             LogicalPlan::Filter(filter) => {
@@ -543,9 +478,6 @@ impl<'a> TreeNodeVisitor<'a> for Planner {
             }
             LogicalPlan::Window(window) => {
                 self.handle_window(window, self.context.parallelism)?;
-                // Stack top is KeyBy, then Window (handle_window pushes window then keyby).
-                let window_idx = self.node_stack[self.node_stack.len() - 2];
-                self.df_plan_to_node.insert(plan_node_key(node), window_idx);
             }
             
             // skip subqueries as they simply wrap other plans

--- a/src/common/grpc.rs
+++ b/src/common/grpc.rs
@@ -1,0 +1,5 @@
+/// Max gRPC message size for control-plane and transport RPCs.
+///
+/// Must stay above the in-memory window checkpoint inline limit (8 MiB) so
+/// checkpoint/restore payloads are not rejected by tonic's 4 MiB default.
+pub const GRPC_MAX_MESSAGE_BYTES: usize = 12 * 1024 * 1024;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod grpc;
 pub mod message;
 pub mod ports;
 #[cfg(test)]
@@ -5,6 +6,8 @@ pub mod test_utils;
 pub mod key;
 pub mod types;
 pub mod failure;
+
+pub use grpc::GRPC_MAX_MESSAGE_BYTES;
 
 pub use message::*;
 pub use key::Key;

--- a/src/runtime/consts.rs
+++ b/src/runtime/consts.rs
@@ -21,6 +21,8 @@ pub const MASTER_HEARTBEAT_SEND_INTERVAL: &str = "master.heartbeat_send_interval
 pub const MASTER_WORKER_CONNECT_TIMEOUT: &str = "master.worker_connect_timeout";
 /// How often `run()` polls `get_worker_state` (completion + unreachable detection).
 pub const MASTER_STATE_POLL_INTERVAL: &str = "master.state_poll_interval";
+/// Bound on each `get_worker_state` RPC inside the run-loop poll (hang → poll failure).
+pub const MASTER_STATE_POLL_TIMEOUT: &str = "master.state_poll_timeout";
 /// Bound on `reset_worker` RPCs during attempt teardown (failed → expand replace set).
 pub const MASTER_RESET_WORKER_TIMEOUT: &str = "master.reset_worker_timeout";
 /// Sleep between worker-registry readiness polls (discovery / replacement wait).
@@ -62,6 +64,7 @@ const DURATION_KEYS: &[&str] = &[
     MASTER_HEARTBEAT_SEND_INTERVAL,
     MASTER_WORKER_CONNECT_TIMEOUT,
     MASTER_STATE_POLL_INTERVAL,
+    MASTER_STATE_POLL_TIMEOUT,
     MASTER_RESET_WORKER_TIMEOUT,
     MASTER_REGISTRY_WAIT_TICK,
     MASTER_CHECKPOINT_INTERVAL,

--- a/src/runtime/functions/map/projection_function.rs
+++ b/src/runtime/functions/map/projection_function.rs
@@ -57,6 +57,10 @@ impl ProjectionFunction {
     pub fn out_schema(&self) -> DFSchemaRef {
         self.out_schema.clone()
     }
+
+    pub fn exprs(&self) -> &[Expr] {
+        &self.exprs
+    }
 }
 
 #[async_trait]

--- a/src/runtime/master/attempt/execute.rs
+++ b/src/runtime/master/attempt/execute.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
+use std::future::pending;
+
 use tokio::time::{interval_at, sleep, timeout, Duration, Instant};
 
 use crate::runtime::consts::{
@@ -54,6 +56,10 @@ impl ExecutionAttempt {
         let mut last_drain_digest = Instant::now() - DRAIN_DIGEST_INTERVAL;
 
         loop {
+            // When draining, park the checkpoint arm entirely. A no-op tick still wins
+            // `biased` select over state_poll and cancels in-flight get_worker_state,
+            // so slow polls never complete and PipelineFinished hangs.
+            let checkpoints_enabled = self.state.checkpoints_enabled();
             tokio::select! {
                 biased;
 
@@ -63,24 +69,8 @@ impl ExecutionAttempt {
                     self.abort_in_flight("attempt failed").await;
                     return Ok(self.await_failure_window_and_recover(failure).await);
                 }
-                _ = optional_tick(&mut checkpoint_tick) => {
-                    if !self.state.checkpoints_enabled() {
-                        // StopSources published disabled via AtomicBool; skip without
-                        // contending on the checkpoints mutex.
-                    } else {
-                        match self.begin_checkpoint().await {
-                            Ok(_) => {}
-                            // Expected after StopSources; do not spam.
-                            Err(error) if error == "sources stopped for drain" => {}
-                            Err(error) => {
-                                println!(
-                                    "[MASTER] Interval checkpoint skipped attempt={}: {}",
-                                    self.id, error
-                                );
-                            }
-                        }
-                    }
-                }
+                // Prefer state_poll over checkpoint ticks so a slow get_worker_state is not
+                // cancelled every checkpoint interval (biased + arm cancel).
                 state_poll = async {
                     poll.tick().await;
                     poll_client_states(&self.clients, &self.state, poll_rpc_timeout).await
@@ -132,6 +122,25 @@ impl ExecutionAttempt {
                             self.id,
                             state_poll_digest(&state_poll.states, &self.clients)
                         );
+                    }
+                }
+                _ = async {
+                    if checkpoints_enabled {
+                        optional_tick(&mut checkpoint_tick).await;
+                    } else {
+                        pending::<()>().await;
+                    }
+                } => {
+                    match self.begin_checkpoint().await {
+                        Ok(_) => {}
+                        // Expected after StopSources; do not spam.
+                        Err(error) if error == "sources stopped for drain" => {}
+                        Err(error) => {
+                            println!(
+                                "[MASTER] Interval checkpoint skipped attempt={}: {}",
+                                self.id, error
+                            );
+                        }
                     }
                 }
             }

--- a/src/runtime/master/attempt/execute.rs
+++ b/src/runtime/master/attempt/execute.rs
@@ -60,11 +60,16 @@ impl ExecutionAttempt {
                     return Ok(self.await_failure_window_and_recover(failure).await);
                 }
                 _ = optional_tick(&mut checkpoint_tick) => {
-                    if let Err(error) = self.begin_checkpoint().await {
-                        println!(
-                            "[MASTER] Interval checkpoint skipped attempt={}: {}",
-                            self.id, error
-                        );
+                    match self.begin_checkpoint().await {
+                        Ok(_) => {}
+                        // Expected after StopSources; do not spam.
+                        Err(error) if error == "sources stopped for drain" => {}
+                        Err(error) => {
+                            println!(
+                                "[MASTER] Interval checkpoint skipped attempt={}: {}",
+                                self.id, error
+                            );
+                        }
                     }
                 }
                 state_poll = async {
@@ -130,6 +135,7 @@ impl ExecutionAttempt {
                 CheckpointStartError::NoCheckpointableTasks => {
                     "no checkpointable tasks".to_string()
                 }
+                CheckpointStartError::Disabled => "sources stopped for drain".to_string(),
             })?;
         println!(
             "[MASTER] Triggering checkpoint {} attempt={}",

--- a/src/runtime/master/attempt/execute.rs
+++ b/src/runtime/master/attempt/execute.rs
@@ -64,15 +64,20 @@ impl ExecutionAttempt {
                     return Ok(self.await_failure_window_and_recover(failure).await);
                 }
                 _ = optional_tick(&mut checkpoint_tick) => {
-                    match self.begin_checkpoint().await {
-                        Ok(_) => {}
-                        // Expected after StopSources; do not spam.
-                        Err(error) if error == "sources stopped for drain" => {}
-                        Err(error) => {
-                            println!(
-                                "[MASTER] Interval checkpoint skipped attempt={}: {}",
-                                self.id, error
-                            );
+                    if !self.state.checkpoints_enabled() {
+                        // StopSources published disabled via AtomicBool; skip without
+                        // contending on the checkpoints mutex.
+                    } else {
+                        match self.begin_checkpoint().await {
+                            Ok(_) => {}
+                            // Expected after StopSources; do not spam.
+                            Err(error) if error == "sources stopped for drain" => {}
+                            Err(error) => {
+                                println!(
+                                    "[MASTER] Interval checkpoint skipped attempt={}: {}",
+                                    self.id, error
+                                );
+                            }
                         }
                     }
                 }
@@ -92,6 +97,18 @@ impl ExecutionAttempt {
                         self.abort_in_flight("state poll failure").await;
                         return Ok(execution_poll_outcome(&state_poll.failures));
                     }
+                    // Drain detection must not wait on the checkpoints mutex — CP report/save
+                    // handlers can hold that lock across await and would stall PipelineFinished.
+                    if all_drained(&state_poll.states, &self.clients) {
+                        println!(
+                            "[MASTER] Pipeline drained attempt={} {}",
+                            self.id,
+                            state_poll_digest(&state_poll.states, &self.clients)
+                        );
+                        self.abort_in_flight("pipeline finished with in-flight checkpoint")
+                            .await;
+                        return Ok(AttemptOutcome::Finished);
+                    }
                     if let Some(checkpoint_id) = self
                         .state
                         .in_flight_checkpoint_timed_out(checkpoint_timeout)
@@ -105,19 +122,8 @@ impl ExecutionAttempt {
                         );
                         return Ok(AttemptOutcome::Recover(HashSet::new()));
                     }
-                    if all_drained(&state_poll.states, &self.clients) {
-                        println!(
-                            "[MASTER] Pipeline drained attempt={} {}",
-                            self.id,
-                            state_poll_digest(&state_poll.states, &self.clients)
-                        );
-                        self.abort_in_flight("pipeline finished with in-flight checkpoint")
-                            .await;
-                        return Ok(AttemptOutcome::Finished);
-                    }
-                    // Log while draining (CP disabled and/or some tasks already Finished) so a
-                    // stuck partial drain is visible instead of a silent harness timeout.
-                    let draining = !self.state.checkpoints_enabled().await
+                    // Lock-free enabled flag: digest path must not take checkpoints mutex.
+                    let draining = !self.state.checkpoints_enabled()
                         || has_terminal_tasks(&state_poll.states);
                     if draining && last_drain_digest.elapsed() >= DRAIN_DIGEST_INTERVAL {
                         last_drain_digest = Instant::now();

--- a/src/runtime/master/attempt/execute.rs
+++ b/src/runtime/master/attempt/execute.rs
@@ -1,10 +1,11 @@
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write as _;
 
 use tokio::time::{interval_at, sleep, timeout, Duration, Instant};
 
 use crate::runtime::consts::{
     runtime_consts, MASTER_CHECKPOINT_INTERVAL, MASTER_CHECKPOINT_TIMEOUT,
-    MASTER_FAILURE_AGGREGATION_WINDOW, MASTER_STATE_POLL_INTERVAL,
+    MASTER_FAILURE_AGGREGATION_WINDOW, MASTER_STATE_POLL_INTERVAL, MASTER_STATE_POLL_TIMEOUT,
 };
 use crate::runtime::observability::snapshot_types::{PipelineSnapshot, WorkerSnapshot};
 use crate::runtime::observability::StreamTaskStatus;
@@ -18,6 +19,7 @@ use super::{AttemptOutcome, ExecutionAttempt};
 
 const STATUS_POLL: Duration = Duration::from_millis(100);
 const STATUS_TIMEOUT: Duration = Duration::from_secs(30);
+const DRAIN_DIGEST_INTERVAL: Duration = Duration::from_secs(2);
 
 pub(super) struct StatePoll {
     pub states: HashMap<String, WorkerSnapshot>,
@@ -44,10 +46,12 @@ impl ExecutionAttempt {
             self.failure_tx.clone(),
         );
         let poll_interval = runtime_consts().duration(MASTER_STATE_POLL_INTERVAL);
+        let poll_rpc_timeout = runtime_consts().duration(MASTER_STATE_POLL_TIMEOUT);
         let mut poll = interval_at(Instant::now() + poll_interval, poll_interval);
         let checkpoint_interval = runtime_consts().duration(MASTER_CHECKPOINT_INTERVAL);
         let checkpoint_timeout = runtime_consts().duration(MASTER_CHECKPOINT_TIMEOUT);
         let mut checkpoint_tick = optional_interval(checkpoint_interval);
+        let mut last_drain_digest = Instant::now() - DRAIN_DIGEST_INTERVAL;
 
         loop {
             tokio::select! {
@@ -74,7 +78,7 @@ impl ExecutionAttempt {
                 }
                 state_poll = async {
                     poll.tick().await;
-                    poll_client_states(&self.clients, &self.state).await
+                    poll_client_states(&self.clients, &self.state, poll_rpc_timeout).await
                 } => {
                     if !state_poll.failures.is_empty() {
                         for (worker_id, error) in &state_poll.failures {
@@ -101,14 +105,22 @@ impl ExecutionAttempt {
                         );
                         return Ok(AttemptOutcome::Recover(HashSet::new()));
                     }
-                    if all_have_status(
-                        &state_poll.states,
-                        &self.clients,
-                        StreamTaskStatus::Finished,
-                    ) {
+                    if all_drained(&state_poll.states, &self.clients) {
                         self.abort_in_flight("pipeline finished with in-flight checkpoint")
                             .await;
                         return Ok(AttemptOutcome::Finished);
+                    }
+                    // After StopSources, checkpoints are disabled — log status digests so a
+                    // stuck/partial drain is visible instead of silent harness timeout.
+                    if !self.state.checkpoints_enabled().await
+                        && last_drain_digest.elapsed() >= DRAIN_DIGEST_INTERVAL
+                    {
+                        last_drain_digest = Instant::now();
+                        println!(
+                            "[MASTER] Drain poll attempt={} {}",
+                            self.id,
+                            state_poll_digest(&state_poll.states, &self.clients)
+                        );
                     }
                 }
             }
@@ -229,8 +241,9 @@ async fn wait_for_status(
     timeout: Option<Duration>,
 ) -> Result<(), HashSet<String>> {
     let start = Instant::now();
+    let poll_rpc_timeout = runtime_consts().duration(MASTER_STATE_POLL_TIMEOUT);
     loop {
-        let poll = poll_client_states(clients, state).await;
+        let poll = poll_client_states(clients, state, poll_rpc_timeout).await;
         if !poll.failures.is_empty() {
             return Err(poll
                 .failures
@@ -291,10 +304,19 @@ async fn optional_tick(tick: &mut Option<tokio::time::Interval>) {
 async fn poll_client_states(
     clients: &HashMap<String, WorkerClient>,
     state: &MasterState,
+    rpc_timeout: Duration,
 ) -> StatePoll {
     let futures = clients.iter().map(|(worker_id, client)| {
         let worker_id = worker_id.clone();
-        async move { (worker_id, client.get_worker_state().await) }
+        async move {
+            let result = match timeout(rpc_timeout, client.get_worker_state()).await {
+                Ok(result) => result,
+                Err(_) => Err(WorkerCallError::Unreachable(format!(
+                    "get_worker_state timed out after {rpc_timeout:?}"
+                ))),
+            };
+            (worker_id, result)
+        }
     });
     let mut states = HashMap::new();
     let mut failures = Vec::new();
@@ -324,4 +346,71 @@ fn all_have_status(
                 .map(|state| !state.task_statuses.is_empty() && state.all_tasks_have_status(status))
                 .unwrap_or(false)
         })
+}
+
+fn all_drained(
+    states: &HashMap<String, WorkerSnapshot>,
+    clients: &HashMap<String, WorkerClient>,
+) -> bool {
+    !clients.is_empty()
+        && clients.keys().all(|worker_id| {
+            states
+                .get(worker_id)
+                .map(|state| state.all_tasks_drained())
+                .unwrap_or(false)
+        })
+}
+
+fn state_poll_digest(
+    states: &HashMap<String, WorkerSnapshot>,
+    clients: &HashMap<String, WorkerClient>,
+) -> String {
+    let mut out = String::new();
+    for worker_id in clients.keys() {
+        if !out.is_empty() {
+            out.push_str("; ");
+        }
+        match states.get(worker_id) {
+            None => {
+                let _ = write!(out, "{worker_id}=missing");
+            }
+            Some(state) if state.task_statuses.is_empty() => {
+                let _ = write!(out, "{worker_id}=empty");
+            }
+            Some(state) => {
+                let mut created = 0usize;
+                let mut opened = 0usize;
+                let mut running = 0usize;
+                let mut finished = 0usize;
+                let mut closed = 0usize;
+                let mut non_terminal = Vec::new();
+                for (vertex_id, status) in &state.task_statuses {
+                    match status {
+                        StreamTaskStatus::Created => created += 1,
+                        StreamTaskStatus::Opened => opened += 1,
+                        StreamTaskStatus::Running => running += 1,
+                        StreamTaskStatus::Finished => finished += 1,
+                        StreamTaskStatus::Closed => closed += 1,
+                    }
+                    if !matches!(
+                        status,
+                        StreamTaskStatus::Finished | StreamTaskStatus::Closed
+                    ) {
+                        if non_terminal.len() < 4 {
+                            non_terminal.push(format!("{vertex_id}={status:?}"));
+                        }
+                    }
+                }
+                let _ = write!(
+                    out,
+                    "{worker_id}=n={} created={created} opened={opened} running={running} finished={finished} closed={closed}",
+                    state.task_statuses.len(),
+                );
+                if !non_terminal.is_empty() {
+                    let _ = write!(out, " pending=[{}]", non_terminal.join(","));
+                }
+            }
+        }
+    }
+    out
 }

--- a/src/runtime/master/attempt/execute.rs
+++ b/src/runtime/master/attempt/execute.rs
@@ -106,15 +106,20 @@ impl ExecutionAttempt {
                         return Ok(AttemptOutcome::Recover(HashSet::new()));
                     }
                     if all_drained(&state_poll.states, &self.clients) {
+                        println!(
+                            "[MASTER] Pipeline drained attempt={} {}",
+                            self.id,
+                            state_poll_digest(&state_poll.states, &self.clients)
+                        );
                         self.abort_in_flight("pipeline finished with in-flight checkpoint")
                             .await;
                         return Ok(AttemptOutcome::Finished);
                     }
-                    // After StopSources, checkpoints are disabled — log status digests so a
-                    // stuck/partial drain is visible instead of silent harness timeout.
-                    if !self.state.checkpoints_enabled().await
-                        && last_drain_digest.elapsed() >= DRAIN_DIGEST_INTERVAL
-                    {
+                    // Log while draining (CP disabled and/or some tasks already Finished) so a
+                    // stuck partial drain is visible instead of a silent harness timeout.
+                    let draining = !self.state.checkpoints_enabled().await
+                        || has_terminal_tasks(&state_poll.states);
+                    if draining && last_drain_digest.elapsed() >= DRAIN_DIGEST_INTERVAL {
                         last_drain_digest = Instant::now();
                         println!(
                             "[MASTER] Drain poll attempt={} {}",
@@ -323,7 +328,9 @@ async fn poll_client_states(
     for (worker_id, result) in futures::future::join_all(futures).await {
         match result {
             Ok(worker_state) => {
-                states.insert(worker_state.worker_id.clone(), worker_state);
+                // Key by the client map id (request target), not the snapshot's
+                // self-reported worker_id — mismatch would make all_drained stuck.
+                states.insert(worker_id, worker_state);
             }
             Err(error) => failures.push((worker_id, error)),
         }
@@ -359,6 +366,14 @@ fn all_drained(
                 .map(|state| state.all_tasks_drained())
                 .unwrap_or(false)
         })
+}
+
+fn has_terminal_tasks(states: &HashMap<String, WorkerSnapshot>) -> bool {
+    states.values().any(|state| {
+        state.task_statuses.values().any(|status| {
+            matches!(status, StreamTaskStatus::Finished | StreamTaskStatus::Closed)
+        })
+    })
 }
 
 fn state_poll_digest(

--- a/src/runtime/master/attempt/teardown.rs
+++ b/src/runtime/master/attempt/teardown.rs
@@ -69,23 +69,32 @@ impl ExecutionAttempt {
     }
 
     pub(in crate::runtime::master) async fn finish(&mut self) {
-        self.state.clear_workers_execution_attempt().await;
+        let rpc_timeout = runtime_consts().duration(MASTER_RESET_WORKER_TIMEOUT);
+        println!(
+            "[MASTER] finish: close_worker_tasks attempt={} workers={} timeout={rpc_timeout:?}",
+            self.id,
+            self.clients.len(),
+        );
+        // Close first (while workers still bound to this attempt). Clearing the
+        // registry before close made finish hangs harder to distinguish from drain stalls.
         let close_tasks: Vec<_> = self
             .clients
             .iter()
             .map(|(worker_id, client)| {
                 let worker_id = worker_id.clone();
                 async move {
-                    log_close(
-                        "close_worker_tasks",
-                        &worker_id,
-                        client.close_worker_tasks().await,
-                    );
+                    match timeout(rpc_timeout, client.close_worker_tasks()).await {
+                        Ok(result) => log_close("close_worker_tasks", &worker_id, result),
+                        Err(_) => println!(
+                            "[MASTER] finish: close_worker_tasks timed out on {worker_id}"
+                        ),
+                    }
                 }
             })
             .collect();
         futures::future::join_all(close_tasks).await;
 
+        println!("[MASTER] finish: waiting for Closed attempt={}", self.id);
         if let Err(workers) = self.wait_status(StreamTaskStatus::Closed).await {
             println!(
                 "[MASTER] finish: workers did not reach Closed (continuing cleanup): {:?}",
@@ -93,14 +102,27 @@ impl ExecutionAttempt {
             );
         }
 
+        self.state.clear_workers_execution_attempt().await;
+
+        println!(
+            "[MASTER] finish: shutdown_worker attempt={} workers={}",
+            self.id,
+            self.clients.len(),
+        );
         let shutdown_workers: Vec<_> = self
             .clients
             .drain()
             .map(|(worker_id, client)| async move {
-                log_close("shutdown_worker", &worker_id, client.shutdown_worker().await);
+                match timeout(rpc_timeout, client.shutdown_worker()).await {
+                    Ok(result) => log_close("shutdown_worker", &worker_id, result),
+                    Err(_) => println!(
+                        "[MASTER] finish: shutdown_worker timed out on {worker_id}"
+                    ),
+                }
             })
             .collect();
         futures::future::join_all(shutdown_workers).await;
+        println!("[MASTER] finish: cleanup done attempt={}", self.id);
     }
 }
 

--- a/src/runtime/master/checkpoint/mod.rs
+++ b/src/runtime/master/checkpoint/mod.rs
@@ -20,6 +20,8 @@ pub use store::{create_checkpoint_store, CheckpointStore, InMemoryCheckpointStor
 pub enum CheckpointStartError {
     AlreadyInFlight { checkpoint_id: u64 },
     NoCheckpointableTasks,
+    /// Sources were stopped for drain; new checkpoints must not start.
+    Disabled,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,6 +55,8 @@ pub struct Checkpoints {
     protocol: CheckpointProtocol,
     store: Option<Arc<dyn CheckpointStore>>,
     pending: HashMap<u64, HashMap<TaskKey, SerializedCheckpoint>>,
+    /// Cleared on `StopSources` so interval ticks cannot open a CP on a draining graph.
+    enabled: bool,
 }
 
 impl Default for Checkpoints {
@@ -65,6 +69,7 @@ impl Default for Checkpoints {
             protocol: CheckpointProtocol::default(),
             store: None,
             pending: HashMap::new(),
+            enabled: true,
         }
     }
 }
@@ -85,9 +90,17 @@ impl Checkpoints {
         self.store = Some(store);
         self.protocol = CheckpointProtocol::default();
         self.pending.clear();
+        self.enabled = true;
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
     }
 
     pub fn start(&mut self) -> Result<u64, CheckpointStartError> {
+        if !self.enabled {
+            return Err(CheckpointStartError::Disabled);
+        }
         self.protocol
             .start(&self.expected_acks, &self.expected_aligns)
     }
@@ -282,6 +295,18 @@ mod tests {
         assert!(cps.load(id).await.is_err());
         assert_eq!(cps.abort_in_flight().await.unwrap(), Some(id));
         assert!(cps.load(id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn disabled_rejects_start() {
+        let mut cps = Checkpoints::default();
+        let acks: HashSet<_> = [task("a", 0)].into_iter().collect();
+        let aligns = acks.clone();
+        cps.configure(pipeline(), acks, aligns, 1, store());
+        cps.set_enabled(false);
+        assert_eq!(cps.start(), Err(CheckpointStartError::Disabled));
+        cps.set_enabled(true);
+        assert!(cps.start().is_ok());
     }
 
     #[tokio::test]

--- a/src/runtime/master/checkpoint/mod.rs
+++ b/src/runtime/master/checkpoint/mod.rs
@@ -97,6 +97,10 @@ impl Checkpoints {
         self.enabled = enabled;
     }
 
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
     pub fn start(&mut self) -> Result<u64, CheckpointStartError> {
         if !self.enabled {
             return Err(CheckpointStartError::Disabled);

--- a/src/runtime/master/checkpoint/mod.rs
+++ b/src/runtime/master/checkpoint/mod.rs
@@ -42,6 +42,14 @@ pub enum CheckpointAckReject {
     AlreadyComplete,
 }
 
+/// Store IO for a newly completed checkpoint — run outside `Mutex<Checkpoints>`.
+pub struct CompletedPersist {
+    pipeline_id: PipelineId,
+    store: Arc<dyn CheckpointStore>,
+    checkpoint: CompletedCheckpoint,
+    prune: Vec<u64>,
+}
+
 /// Checkpoint protocol + completed-checkpoint store.
 #[derive(Debug)]
 pub struct Checkpoints {
@@ -141,15 +149,17 @@ impl Checkpoints {
     }
 
     /// Record operator state and its ack. May complete if aligns are already done.
-    pub async fn report(
+    /// Sync protocol update only — caller must `apply_persist` outside any mutex.
+    pub fn report(
         &mut self,
         checkpoint_id: u64,
         task: TaskKey,
         checkpoint: SerializedCheckpoint,
-    ) -> anyhow::Result<CheckpointAckOutcome> {
+    ) -> anyhow::Result<(CheckpointAckOutcome, Option<CompletedPersist>)> {
         if !self.expected_acks.contains(&task) {
-            return Ok(CheckpointAckOutcome::Rejected(
-                CheckpointAckReject::UnexpectedTask,
+            return Ok((
+                CheckpointAckOutcome::Rejected(CheckpointAckReject::UnexpectedTask),
+                None,
             ));
         }
         let outcome = self.protocol.ack(
@@ -164,51 +174,61 @@ impl Checkpoints {
                 .or_default()
                 .insert(task, checkpoint);
         }
-        self.finish_if_completed(checkpoint_id, outcome).await
+        self.finish_if_completed(checkpoint_id, outcome)
     }
 
     /// Record barrier Injected/Aligned for a task. May complete if acks are already done.
-    pub async fn note_barrier_progress(
+    /// Sync protocol update only — caller must `apply_persist` outside any mutex.
+    pub fn note_barrier_progress(
         &mut self,
         checkpoint_id: u64,
         task: TaskKey,
-    ) -> anyhow::Result<CheckpointAckOutcome> {
+    ) -> anyhow::Result<(CheckpointAckOutcome, Option<CompletedPersist>)> {
         let outcome = self.protocol.align(
             checkpoint_id,
             task,
             &self.expected_acks,
             &self.expected_aligns,
         );
-        self.finish_if_completed(checkpoint_id, outcome).await
+        self.finish_if_completed(checkpoint_id, outcome)
     }
 
-    async fn finish_if_completed(
+    fn finish_if_completed(
         &mut self,
         checkpoint_id: u64,
         outcome: CheckpointAckOutcome,
-    ) -> anyhow::Result<CheckpointAckOutcome> {
-        if matches!(outcome, CheckpointAckOutcome::Completed) {
-            let tasks = self.pending.remove(&checkpoint_id).unwrap_or_default();
-            anyhow::ensure!(
-                tasks.len() == self.expected_acks.len(),
-                "checkpoint {checkpoint_id} completed without all task state"
-            );
-            self.store()?
-                .save(
-                    self.pipeline_id()?,
-                    CompletedCheckpoint {
-                        checkpoint_id,
-                        tasks,
-                    },
-                )
-                .await?;
-            for pruned_id in self.protocol.retain_completed(self.retention) {
-                self.store()?
-                    .remove(self.pipeline_id()?, pruned_id)
-                    .await?;
-            }
+    ) -> anyhow::Result<(CheckpointAckOutcome, Option<CompletedPersist>)> {
+        if !matches!(outcome, CheckpointAckOutcome::Completed) {
+            return Ok((outcome, None));
         }
-        Ok(outcome)
+        let tasks = self.pending.remove(&checkpoint_id).unwrap_or_default();
+        anyhow::ensure!(
+            tasks.len() == self.expected_acks.len(),
+            "checkpoint {checkpoint_id} completed without all task state"
+        );
+        let prune = self.protocol.retain_completed(self.retention);
+        let persist = CompletedPersist {
+            pipeline_id: self.pipeline_id()?.clone(),
+            store: Arc::clone(self.store()?),
+            checkpoint: CompletedCheckpoint {
+                checkpoint_id,
+                tasks,
+            },
+            prune,
+        };
+        Ok((outcome, Some(persist)))
+    }
+
+    /// Persist a completed checkpoint (call with checkpoints mutex released).
+    pub async fn apply_persist(persist: CompletedPersist) -> anyhow::Result<()> {
+        persist
+            .store
+            .save(&persist.pipeline_id, persist.checkpoint)
+            .await?;
+        for pruned_id in persist.prune {
+            persist.store.remove(&persist.pipeline_id, pruned_id).await?;
+        }
+        Ok(())
     }
 
     fn pipeline_id(&self) -> anyhow::Result<&PipelineId> {
@@ -247,17 +267,25 @@ mod tests {
         SerializedCheckpoint::new(vec![value])
     }
 
+    async fn apply(
+        result: anyhow::Result<(CheckpointAckOutcome, Option<CompletedPersist>)>,
+    ) -> CheckpointAckOutcome {
+        let (outcome, persist) = result.unwrap();
+        if let Some(persist) = persist {
+            Checkpoints::apply_persist(persist).await.unwrap();
+        }
+        outcome
+    }
+
     async fn complete(cps: &mut Checkpoints, id_hint: u64) -> u64 {
         let id = cps.start().unwrap();
         assert_eq!(id, id_hint);
         assert_eq!(
-            cps.report(id, task("a", 0), checkpoint(id as u8),)
-                .await
-                .unwrap(),
+            apply(cps.report(id, task("a", 0), checkpoint(id as u8))).await,
             CheckpointAckOutcome::Pending
         );
         assert_eq!(
-            cps.note_barrier_progress(id, task("a", 0)).await.unwrap(),
+            apply(cps.note_barrier_progress(id, task("a", 0))).await,
             CheckpointAckOutcome::Completed
         );
         id
@@ -293,7 +321,7 @@ mod tests {
         cps.configure(pipeline(), acks, aligns, 1, store());
         let id = cps.start().unwrap();
         assert_eq!(
-            cps.report(id, task("a", 0), checkpoint(1),).await.unwrap(),
+            apply(cps.report(id, task("a", 0), checkpoint(1))).await,
             CheckpointAckOutcome::Pending
         );
         assert!(cps.load(id).await.is_err());
@@ -321,19 +349,15 @@ mod tests {
         cps.configure(pipeline(), acks, aligns, 1, store());
         let id = cps.start().unwrap();
         assert_eq!(
-            cps.note_barrier_progress(id, task("src", 0)).await.unwrap(),
+            apply(cps.note_barrier_progress(id, task("src", 0))).await,
             CheckpointAckOutcome::Pending
         );
         assert_eq!(
-            cps.report(id, task("src", 0), checkpoint(1),)
-                .await
-                .unwrap(),
+            apply(cps.report(id, task("src", 0), checkpoint(1))).await,
             CheckpointAckOutcome::Pending
         );
         assert_eq!(
-            cps.note_barrier_progress(id, task("sink", 0))
-                .await
-                .unwrap(),
+            apply(cps.note_barrier_progress(id, task("sink", 0))).await,
             CheckpointAckOutcome::Completed
         );
     }

--- a/src/runtime/master/lifecycle.rs
+++ b/src/runtime/master/lifecycle.rs
@@ -31,6 +31,7 @@ impl MasterLifecycle {
                 })
                 .await;
             self.state.set_current_attempt_id(execution_attempt_id);
+            self.state.enable_checkpoints().await;
             let mut attempt = ExecutionAttempt::new(
                 execution_attempt_id,
                 restore_checkpoint_id,

--- a/src/runtime/master/mod.rs
+++ b/src/runtime/master/mod.rs
@@ -106,6 +106,11 @@ impl Master {
             .current_execution_worker_endpoints()
             .await
             .ok_or_else(|| "no workers on current execution attempt".to_string())?;
+        // Disable interval CPs before stopping sources so a tick cannot open a
+        // barrier on an already-draining graph (acks/aligns stay at 0 forever).
+        self.state
+            .disable_checkpoints_for_drain(execution_attempt_id)
+            .await?;
         let futures = workers.iter().map(|(worker_id, addr)| {
             let worker_id = worker_id.clone();
             let addr = addr.clone();
@@ -152,6 +157,9 @@ impl Master {
                 } => format!("already in flight checkpoint_id={checkpoint_id}"),
                 crate::runtime::master::checkpoint::CheckpointStartError::NoCheckpointableTasks => {
                     "no checkpointable tasks".to_string()
+                }
+                crate::runtime::master::checkpoint::CheckpointStartError::Disabled => {
+                    "sources stopped for drain".to_string()
                 }
             })
     }

--- a/src/runtime/master/server.rs
+++ b/src/runtime/master/server.rs
@@ -50,7 +50,9 @@ impl MasterServer {
     pub async fn start(&mut self, addr: &str) -> anyhow::Result<()> {
         let addr = addr.parse()?;
         let service =
-            master_service::master_service_server::MasterServiceServer::new(self.service.clone());
+            master_service::master_service_server::MasterServiceServer::new(self.service.clone())
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[MASTER_SERVER] Starting MasterService server on {}", addr);
 

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -280,6 +280,37 @@ impl MasterState {
         self.current_attempt_id.load(Ordering::SeqCst)
     }
 
+    pub(super) async fn enable_checkpoints(&self) {
+        self.checkpoints.lock().await.set_enabled(true);
+    }
+
+    /// Stop taking new checkpoints and drop any in-flight one (pipeline is draining).
+    pub(super) async fn disable_checkpoints_for_drain(
+        &self,
+        attempt_id: u64,
+    ) -> Result<Option<u64>, String> {
+        let mut checkpoints = self.checkpoints.lock().await;
+        checkpoints.set_enabled(false);
+        let checkpoint_id = checkpoints
+            .abort_in_flight()
+            .await
+            .map_err(|error| format!("failed to remove aborted checkpoint: {error}"))?;
+        drop(checkpoints);
+        if let Some(checkpoint_id) = checkpoint_id {
+            self.record_lifecycle_event(LifecycleEvent::CheckpointFailed {
+                checkpoint_id,
+                attempt_id,
+                detail: "aborted: sources stopped for drain".to_string(),
+            })
+            .await;
+            println!(
+                "[MASTER] Checkpoint {} aborted: sources stopped for drain attempt={}",
+                checkpoint_id, attempt_id
+            );
+        }
+        Ok(checkpoint_id)
+    }
+
     pub(super) async fn begin_checkpoint(
         &self,
         attempt_id: u64,

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -284,6 +284,10 @@ impl MasterState {
         self.checkpoints.lock().await.set_enabled(true);
     }
 
+    pub(super) async fn checkpoints_enabled(&self) -> bool {
+        self.checkpoints.lock().await.enabled()
+    }
+
     /// Stop taking new checkpoints and drop any in-flight one (pipeline is draining).
     pub(super) async fn disable_checkpoints_for_drain(
         &self,

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
@@ -152,6 +152,8 @@ impl fmt::Display for WorkerReadinessError {
 pub(super) struct MasterState {
     config: Mutex<Option<MasterConfig>>,
     checkpoints: Mutex<Checkpoints>,
+    /// Lock-free mirror of `Checkpoints::enabled` for the run-loop drain path.
+    checkpoints_enabled: AtomicBool,
     pub orchestrator: Arc<dyn MasterOrchestrator>,
     workers: Mutex<WorkerRegistry>,
     latest_pipeline_snapshot: Mutex<Option<PipelineSnapshot>>,
@@ -166,6 +168,7 @@ impl MasterState {
         Self {
             config: Mutex::new(None),
             checkpoints: Mutex::new(Checkpoints::default()),
+            checkpoints_enabled: AtomicBool::new(true),
             orchestrator,
             workers: Mutex::new(WorkerRegistry::default()),
             latest_pipeline_snapshot: Mutex::new(None),
@@ -250,6 +253,7 @@ impl MasterState {
             retention,
             checkpoint_store,
         );
+        self.checkpoints_enabled.store(true, Ordering::SeqCst);
         *self.config.lock().await = Some(config);
     }
 
@@ -282,10 +286,12 @@ impl MasterState {
 
     pub(super) async fn enable_checkpoints(&self) {
         self.checkpoints.lock().await.set_enabled(true);
+        self.checkpoints_enabled.store(true, Ordering::SeqCst);
     }
 
-    pub(super) async fn checkpoints_enabled(&self) -> bool {
-        self.checkpoints.lock().await.enabled()
+    /// Lock-free; kept in sync with `Checkpoints::enabled` by enable/disable.
+    pub(super) fn checkpoints_enabled(&self) -> bool {
+        self.checkpoints_enabled.load(Ordering::SeqCst)
     }
 
     /// Stop taking new checkpoints and drop any in-flight one (pipeline is draining).
@@ -293,6 +299,9 @@ impl MasterState {
         &self,
         attempt_id: u64,
     ) -> Result<Option<u64>, String> {
+        // Publish disabled before taking the mutex so the run loop can observe drain
+        // even if a report handler is holding `checkpoints` across store IO.
+        self.checkpoints_enabled.store(false, Ordering::SeqCst);
         let mut checkpoints = self.checkpoints.lock().await;
         checkpoints.set_enabled(false);
         let checkpoint_id = checkpoints
@@ -372,16 +381,20 @@ impl MasterState {
             return Ok(());
         }
 
-        let outcome = {
+        let (outcome, persist) = {
             let mut cps = self.checkpoints.lock().await;
             // Only in-flight CPs accept barrier progress (Completed implies align already done).
             if cps.in_flight_id() != Some(checkpoint_id) {
                 return Ok(());
             }
             cps.note_barrier_progress(checkpoint_id, task.clone())
-                .await
                 .map_err(|error| format!("failed to update checkpoint store: {error}"))?
         };
+        if let Some(persist) = persist {
+            Checkpoints::apply_persist(persist)
+                .await
+                .map_err(|error| format!("failed to persist checkpoint: {error}"))?;
+        }
 
         self.record_lifecycle_event(LifecycleEvent::CheckpointPropagation {
             checkpoint_id,
@@ -436,13 +449,16 @@ impl MasterState {
                 task.vertex_id, task.task_index
             ));
         }
-        let outcome = self
-            .checkpoints
-            .lock()
-            .await
-            .report(checkpoint_id, task, checkpoint)
-            .await
-            .map_err(|error| format!("failed to update checkpoint store: {error}"))?;
+        let (outcome, persist) = {
+            let mut cps = self.checkpoints.lock().await;
+            cps.report(checkpoint_id, task, checkpoint)
+                .map_err(|error| format!("failed to update checkpoint store: {error}"))?
+        };
+        if let Some(persist) = persist {
+            Checkpoints::apply_persist(persist)
+                .await
+                .map_err(|error| format!("failed to persist checkpoint: {error}"))?;
+        }
 
         match outcome {
             CheckpointAckOutcome::Completed => {

--- a/src/runtime/master/worker_client.rs
+++ b/src/runtime/master/worker_client.rs
@@ -114,7 +114,11 @@ pub(super) async fn connect_worker_client(
     endpoint
         .connect()
         .await
-        .map(WorkerServiceClient::new)
+        .map(|channel| {
+            WorkerServiceClient::new(channel)
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        })
         .map_err(|e| format!("connect to {addr} failed: {e}"))
 }
 

--- a/src/runtime/observability/snapshot_types.rs
+++ b/src/runtime/observability/snapshot_types.rs
@@ -73,6 +73,14 @@ impl WorkerSnapshot {
         self.task_statuses.values().all(|_status| *_status == status)
     }
 
+    /// Drain complete: every task has stopped producing (`Finished` or already `Closed`).
+    pub fn all_tasks_drained(&self) -> bool {
+        !self.task_statuses.is_empty()
+            && self.task_statuses.values().all(|status| {
+                matches!(status, StreamTaskStatus::Finished | StreamTaskStatus::Closed)
+            })
+    }
+
     pub fn to_bytes(&self) -> Result<Vec<u8>> {
         Ok(bincode::serialize(self)?)
     }

--- a/src/runtime/operators/window/README.md
+++ b/src/runtime/operators/window/README.md
@@ -155,7 +155,7 @@ partitioning, publication, fencing, caching, and cleanup. They must preserve:
 uses one read lock as the WRO snapshot boundary, and embeds complete namespace
 snapshots, including durable triggers, in checkpoint data. Its live state
 remains process-local and is not a cross-worker backend. It is intended only
-for development and tests: inline checkpoint snapshots are limited to 3 MiB to
+for development and tests: inline checkpoint snapshots are limited to 8 MiB to
 stay below the gRPC control-plane message limit.
 
 ## Checkpoint and restore

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -22,7 +22,7 @@ use crate::runtime::operators::window::store::{
     KeyState, PartitionKey, StateNamespace, TileMap, WindowData,
 };
 
-const MAX_INLINE_CHECKPOINT_BYTES: usize = 3 * 1024 * 1024;
+const MAX_INLINE_CHECKPOINT_BYTES: usize = 8 * 1024 * 1024;
 
 fn validate_checkpoint_size(snapshot: &[u8]) -> Result<()> {
     anyhow::ensure!(
@@ -61,7 +61,7 @@ struct InMemState {
     triggers: BTreeSet<WindowTrigger>,
 }
 
-/// Development/test reference backend with inline checkpoints limited to 3 MiB.
+/// Development/test reference backend with inline checkpoints limited to 8 MiB.
 /// One read lock is the WRO snapshot boundary.
 #[derive(Debug, Clone, Default)]
 pub struct InMemWindowStore {
@@ -276,6 +276,13 @@ impl WindowOperatorStore for InMemWindowStore {
                 .collect(),
         };
         let snapshot = bincode::serialize(&checkpoint)?;
+        println!(
+            "[WINDOW][INMEM] checkpoint size={} bytes (limit={} bytes, partitions={}, triggers={})",
+            snapshot.len(),
+            MAX_INLINE_CHECKPOINT_BYTES,
+            checkpoint.partitions.len(),
+            checkpoint.triggers.len(),
+        );
         validate_checkpoint_size(&snapshot)?;
         Ok(WindowBackendSnapshot::InMemory { snapshot })
     }

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -322,7 +322,6 @@ impl StreamTask {
     pub(crate) fn create_preprocessed_input_stream(
         input_stream: MessageStream,
         vertex_id: VertexId,
-        operator_config: OperatorConfig,
         watermark_assign: Option<WatermarkAssignConfig>,
         upstream_vertices: Vec<String>,
         upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
@@ -336,7 +335,6 @@ impl StreamTask {
             let mut input_stream = input_stream;
             let mut watermark_manager = WatermarkManager::new(
                 watermark_assign,
-                Some(&operator_config),
                 upstream_vertices.clone(),
                 upstream_watermarks.clone(),
                 current_watermark.clone(),
@@ -591,7 +589,6 @@ impl StreamTask {
                 .get_vertex(&vertex_id)
                 .expect("vertex should exist in execution graph");
             let watermark_assign = vertex_meta.watermark_assign.clone();
-            let vertex_operator_config = vertex_meta.operator_config.clone();
 
             // Runtime invariant: watermark assigners must not run in Batch mode.
             // Batch pipelines rely on source completion to emit a terminal MAX_WATERMARK_VALUE.
@@ -610,7 +607,6 @@ impl StreamTask {
             let mut source_watermark_manager = if is_source {
                 Some(WatermarkManager::new(
                     watermark_assign.clone(),
-                    Some(&vertex_operator_config),
                     upstream_vertices.clone(),
                     upstream_watermarks.clone(),
                     current_watermark.clone(),
@@ -631,7 +627,6 @@ impl StreamTask {
                 let preprocessed_stream = Self::create_preprocessed_input_stream(
                     input_stream,
                     vertex_id.clone(),
-                    vertex_operator_config.clone(),
                     watermark_assign.clone(),
                     upstream_vertices.clone(),
                     upstream_watermarks.clone(),

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -547,6 +547,11 @@ impl StreamTask {
                 Some(
                     MasterServiceClient::connect(endpoint)
                         .await
+                        .map(|client| {
+                            client
+                                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        })
                         .map_err(|e| anyhow::anyhow!("Failed to connect to master service: {}", e))?,
                 )
             } else {

--- a/src/runtime/watermark/confg.rs
+++ b/src/runtime/watermark/confg.rs
@@ -1,14 +1,14 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WatermarkAssignConfig {
     pub out_of_orderness_ms: u64,
-    pub time_hint: Option<TimeHint>,
+    pub time_hint: TimeHint,
     pub idle_timeout_ms: Option<u64>,
 }
 
 impl WatermarkAssignConfig {
     pub const DEFAULT_IDLE_TIMEOUT_MS: u64 = 1_000;
 
-    pub fn new(out_of_orderness_ms: u64, time_hint: Option<TimeHint>) -> Self {
+    pub fn new(out_of_orderness_ms: u64, time_hint: TimeHint) -> Self {
         Self {
             out_of_orderness_ms,
             time_hint,
@@ -19,8 +19,5 @@ impl WatermarkAssignConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TimeHint {
-    WindowOrderByColumn,
     ColumnName { name: String },
-    // TODO: auto-resolve for non-window operators (timestamp-like column heuristics).
 }
-

--- a/src/runtime/watermark/manager.rs
+++ b/src/runtime/watermark/manager.rs
@@ -8,17 +8,8 @@ use arrow::record_batch::RecordBatch;
 use tokio::sync::Mutex;
 
 use crate::common::message::{Message, WatermarkMessage};
-use crate::runtime::operators::operator::OperatorConfig;
-
-use datafusion::physical_plan::expressions::Column;
 
 use super::confg::{TimeHint, WatermarkAssignConfig};
-
-#[derive(Debug, Clone)]
-enum TsColumnSpec {
-    Index(usize),
-    ColumnName(String),
-}
 
 #[derive(Debug, Default, Clone)]
 struct UpstreamWatermarkProgress {
@@ -28,66 +19,33 @@ struct UpstreamWatermarkProgress {
 
 /// Stateful event-time watermark generator.
 ///
-/// Progress is tracked **per upstream vertex id** so we can attach this generator to a downstream
-/// task (e.g. Window) while still simulating independent upstream watermark production.
+/// Progress is tracked **per upstream vertex id** (sources use the task's own id; map/preprocess
+/// uses the message upstream id).
 #[derive(Debug)]
 pub struct WatermarkAssignerState {
     out_of_orderness_ms: u64,
-    ts_column: TsColumnSpec,
+    ts_column_name: String,
     per_upstream: HashMap<String, UpstreamWatermarkProgress>,
 }
 
 impl WatermarkAssignerState {
-    pub fn new(cfg: WatermarkAssignConfig, operator_config: Option<&OperatorConfig>) -> Self {
-        let ts_column = match cfg.time_hint {
-            Some(TimeHint::WindowOrderByColumn) => TsColumnSpec::Index(
-                Self::derive_window_ts_column_index(
-                    operator_config.expect("WindowOrderByColumn requires operator_config"),
-                ),
-            ),
-            Some(TimeHint::ColumnName { name }) => TsColumnSpec::ColumnName(name),
-            None => {
-                // Auto-resolve only for Window vertices.
-                TsColumnSpec::Index(Self::derive_window_ts_column_index(
-                    operator_config.expect("Auto-resolve requires operator_config"),
-                ))
-            }
-        };
-
+    pub fn new(cfg: WatermarkAssignConfig) -> Self {
+        let TimeHint::ColumnName { name } = cfg.time_hint;
         Self {
             out_of_orderness_ms: cfg.out_of_orderness_ms,
-            ts_column,
+            ts_column_name: name,
             per_upstream: HashMap::new(),
         }
     }
 
-    fn derive_window_ts_column_index(operator_config: &OperatorConfig) -> usize {
-        let OperatorConfig::WindowConfig(window_cfg) = operator_config else {
-            panic!("WatermarkAssign auto-resolve requires Window vertex or explicit time hint");
-        };
-        window_cfg.window_exec.window_expr()[0]
-            .order_by()[0]
-            .expr
-            .as_any()
-            .downcast_ref::<Column>()
-            .expect("Expected Column expression in Window ORDER BY")
-            .index()
-    }
-
     fn resolve_ts_column_index(&self, batch: &RecordBatch) -> usize {
-        match &self.ts_column {
-            TsColumnSpec::Index(idx) => *idx,
-            TsColumnSpec::ColumnName(name) => batch
-                .schema()
-                .index_of(name)
-                .unwrap_or_else(|_| {
-                    panic!(
-                        "WatermarkAssign failed: missing column '{}' in schema {:?}",
-                        name,
-                        batch.schema()
-                    )
-                }),
-        }
+        batch.schema().index_of(&self.ts_column_name).unwrap_or_else(|_| {
+            panic!(
+                "WatermarkAssign failed: missing column '{}' in schema {:?}",
+                self.ts_column_name,
+                batch.schema()
+            )
+        })
     }
 
     fn batch_max_ts_ms(&self, batch: &RecordBatch, ts_column_index: usize) -> Option<u64> {
@@ -180,13 +138,12 @@ pub struct WatermarkManager {
 impl WatermarkManager {
     pub fn new(
         watermark_assign: Option<WatermarkAssignConfig>,
-        operator_config: Option<&OperatorConfig>,
         upstream_vertices: Vec<String>,
         upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
         current_watermark: Arc<AtomicU64>,
     ) -> Self {
         let idle_timeout_ms = watermark_assign.as_ref().and_then(|cfg| cfg.idle_timeout_ms);
-        let assigner = watermark_assign.map(|cfg| WatermarkAssignerState::new(cfg, operator_config));
+        let assigner = watermark_assign.map(WatermarkAssignerState::new);
         let last_seen_processing_time = upstream_vertices
             .iter()
             .map(|u| (u.clone(), Instant::now()))
@@ -339,12 +296,12 @@ mod tests {
 
         let cfg = WatermarkAssignConfig {
             out_of_orderness_ms: 0,
-            time_hint: Some(TimeHint::ColumnName {
+            time_hint: TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
             idle_timeout_ms: Some(WatermarkAssignConfig::DEFAULT_IDLE_TIMEOUT_MS),
         };
-        let mut assigner = WatermarkAssignerState::new(cfg, None);
+        let mut assigner = WatermarkAssignerState::new(cfg);
 
         let wm1 = assigner.on_data_message("upA", &msg).unwrap();
         assert_eq!(wm1.metadata.upstream_vertex_id.as_deref(), Some("upA"));
@@ -386,17 +343,14 @@ mod tests {
 
         let cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string()],
             Arc::new(Mutex::new(HashMap::new())),
@@ -460,17 +414,14 @@ mod tests {
         let input = Box::pin(stream::iter(vec![m0, m1]));
         let cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string(), "u1".to_string()],
             Arc::new(Mutex::new(HashMap::new())),
@@ -523,18 +474,15 @@ mod tests {
 
         let mut cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
         cfg.idle_timeout_ms = Some(1);
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string(), "u1".to_string()],
             Arc::new(Mutex::new(HashMap::new())),
@@ -580,18 +528,15 @@ mod tests {
 
         let mut cfg = WatermarkAssignConfig::new(
             0,
-            Some(TimeHint::ColumnName {
+            TimeHint::ColumnName {
                 name: "ts_ms".to_string(),
-            }),
+            },
         );
         cfg.idle_timeout_ms = None;
 
         let mut out = StreamTask::create_preprocessed_input_stream(
             input,
             Arc::<str>::from("v0"),
-            OperatorConfig::MapConfig(crate::runtime::functions::map::MapFunction::new_custom(
-                crate::common::test_utils::IdentityMapFunction,
-            )),
             Some(cfg),
             vec!["u0".to_string(), "u1".to_string()],
             Arc::new(Mutex::new(HashMap::new())),

--- a/src/runtime/worker.rs
+++ b/src/runtime/worker.rs
@@ -70,6 +70,20 @@ impl WorkerConfig {
 
 // WorkerState moved to runtime/observability/snapshot_types.rs
 
+/// Inputs for refreshing worker state without holding `Mutex<Worker>` across asks.
+pub enum WorkerStatePoll {
+    Cached(Arc<tokio::sync::Mutex<WorkerSnapshot>>),
+    Live {
+        worker_id: String,
+        pipeline_id: PipelineId,
+        task_runtime_handles: HashMap<VertexId, Handle>,
+        task_actors: HashMap<VertexId, ActorRef<StreamTaskActor>>,
+        graph: ExecutionGraph,
+        operator_states: Arc<OperatorStates>,
+        worker_state: Arc<tokio::sync::Mutex<WorkerSnapshot>>,
+    },
+}
+
 pub struct Worker {
     worker_id: String,
     health: Arc<WorkerHealth>,
@@ -612,29 +626,61 @@ impl Worker {
     }
 
     pub async fn get_state(&self) -> WorkerSnapshot {
-        if self.running.load(Ordering::SeqCst) {
-            let config = self
-                .config
-                .as_ref()
-                .expect("Worker must be configured before use");
-            let task_runtime_handles: HashMap<VertexId, Handle> = self.task_runtimes.iter()
-                .map(|(k, v)| (k.clone(), v.handle().clone()))
-                .collect();
-            let task_actors = self.task_actors.clone();
-            let graph = config.graph.clone();
-            let state = self.worker_state.clone();
-            Self::poll_and_update_tasks_state(
-                config.worker_id.clone(),
-                config.pipeline_id.clone(),
+        Self::finish_state_poll(self.state_poll_handles()).await
+    }
+
+    /// Clone everything needed for a state refresh so callers can drop
+    /// `Mutex<Worker>` before awaiting task-actor asks.
+    pub fn state_poll_handles(&self) -> WorkerStatePoll {
+        if !self.running.load(Ordering::SeqCst) {
+            return WorkerStatePoll::Cached(self.worker_state.clone());
+        }
+        let config = self
+            .config
+            .as_ref()
+            .expect("Worker must be configured before use");
+        let task_runtime_handles: HashMap<VertexId, Handle> = self
+            .task_runtimes
+            .iter()
+            .map(|(k, v)| (k.clone(), v.handle().clone()))
+            .collect();
+        WorkerStatePoll::Live {
+            worker_id: config.worker_id.clone(),
+            pipeline_id: config.pipeline_id.clone(),
+            task_runtime_handles,
+            task_actors: self.task_actors.clone(),
+            graph: config.graph.clone(),
+            operator_states: self.operator_states.clone(),
+            worker_state: self.worker_state.clone(),
+        }
+    }
+
+    pub async fn finish_state_poll(poll: WorkerStatePoll) -> WorkerSnapshot {
+        match poll {
+            WorkerStatePoll::Cached(state) => state.lock().await.clone(),
+            WorkerStatePoll::Live {
+                worker_id,
+                pipeline_id,
                 task_runtime_handles,
                 task_actors,
                 graph,
-                self.operator_states.clone(),
-                state,
-                None,
-            ).await;
+                operator_states,
+                worker_state,
+            } => {
+                Self::poll_and_update_tasks_state(
+                    worker_id,
+                    pipeline_id,
+                    task_runtime_handles,
+                    task_actors,
+                    graph,
+                    operator_states,
+                    worker_state.clone(),
+                    None,
+                )
+                .await;
+                worker_state.lock().await.clone()
+            }
         }
-        self.worker_state.lock().await.clone()
     }
 
     pub fn operator_states(&self) -> Arc<OperatorStates> {

--- a/src/runtime/worker.rs
+++ b/src/runtime/worker.rs
@@ -12,7 +12,7 @@ use std::{collections::HashMap};
 use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 use kameo::{spawn, prelude::ActorRef};
 use tokio::runtime::{Builder, Handle, Runtime};
-use tokio::time::{sleep, Duration};
+use tokio::time::{sleep, timeout, Duration};
 use futures::future::join_all;
 // (serde/Result imports removed; this module does not serialize Worker directly)
 use crate::api::spec::state::{OperatorStateBackendConfig, RequestStoreConfig};
@@ -606,22 +606,52 @@ impl Worker {
         }
     }
 
+    /// Clone actor refs + runtime handles so callers can drop `Mutex<Worker>`
+    /// before awaiting asks (same pattern as state poll).
+    pub fn task_signal_handles(&self) -> Vec<(VertexId, Handle, ActorRef<StreamTaskActor>)> {
+        self.task_runtimes
+            .iter()
+            .filter_map(|(vertex_id, runtime)| {
+                let task_ref = self.task_actors.get(vertex_id)?.clone();
+                Some((vertex_id.clone(), runtime.handle().clone(), task_ref))
+            })
+            .collect()
+    }
+
     async fn send_signal_to_task_actors(&mut self, signal: StreamTaskMessage) {
+        Self::send_signal_with_handles(self.task_signal_handles(), signal).await;
+    }
+
+    pub async fn send_signal_with_handles(
+        handles: Vec<(VertexId, Handle, ActorRef<StreamTaskActor>)>,
+        signal: StreamTaskMessage,
+    ) {
         println!("[WORKER] Sending {:?} signal to all task actors", signal);
-        
-        for (vertex_id, task_runtime) in &self.task_runtimes {
-            let vertex_id = vertex_id.clone();
-            let task_ref = self.task_actors.get(&vertex_id).unwrap().clone();
+        // Fan out in parallel; a single stuck ask must not block the rest (or close RPC).
+        let ask_timeout = Duration::from_secs(2);
+        let futs = handles.into_iter().map(|(vertex_id, handle, task_ref)| {
             let signal_clone = signal.clone();
             let signal_for_error = signal.clone();
-            let fut = task_runtime.spawn(async move {
-                if let Err(e) = task_ref.ask(signal_clone).await {
-                    eprintln!("Error sending {:?} signal to task {}: {}", signal_for_error, vertex_id, e);
+            async move {
+                let ask = handle.spawn(async move { task_ref.ask(signal_clone).await });
+                match timeout(ask_timeout, ask).await {
+                    Ok(Ok(Ok(_))) => {}
+                    Ok(Ok(Err(e))) => eprintln!(
+                        "Error sending {:?} signal to task {}: {}",
+                        signal_for_error, vertex_id, e
+                    ),
+                    Ok(Err(e)) => eprintln!(
+                        "Error joining {:?} signal to task {}: {}",
+                        signal_for_error, vertex_id, e
+                    ),
+                    Err(_) => eprintln!(
+                        "Timeout sending {:?} signal to task {} after {:?}",
+                        signal_for_error, vertex_id, ask_timeout
+                    ),
                 }
-            });
-            let _ = fut.await;
-        }
-
+            }
+        });
+        join_all(futs).await;
         println!("[WORKER] {:?} signal sent to all task actors", signal);
     }
 

--- a/src/runtime/worker_server.rs
+++ b/src/runtime/worker_server.rs
@@ -504,7 +504,9 @@ impl WorkerServer {
         let addr = addr.parse()?;
         let service = worker_service::worker_service_server::WorkerServiceServer::new(
             self.service.clone()
-        );
+        )
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[WORKER_SERVER] Starting WorkerService server on {}", addr);
         
@@ -550,7 +552,10 @@ impl WorkerServer {
             match endpoint.clone().connect().await {
                 Ok(channel) => match tokio::time::timeout(
                     rpc_timeout,
-                    MasterServiceClient::new(channel).register_worker(tonic::Request::new(req)),
+                    MasterServiceClient::new(channel)
+                        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .register_worker(tonic::Request::new(req)),
                 )
                 .await
                 {

--- a/src/runtime/worker_server.rs
+++ b/src/runtime/worker_server.rs
@@ -289,8 +289,17 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<CloseWorkerTasksResponse>, Status> {
         self.validate_execution_attempt(request.get_ref().execution_attempt_id)
             .await?;
-        let mut worker_guard = self.worker.lock().await;
-        worker_guard.signal_tasks_close().await;
+        // Drop Mutex<Worker> before actor asks — holding it across Close starved
+        // concurrent get_worker_state / heartbeat and could hang finish().
+        let handles = {
+            let worker_guard = self.worker.lock().await;
+            worker_guard.task_signal_handles()
+        };
+        Worker::send_signal_with_handles(
+            handles,
+            crate::runtime::stream_task_actor::StreamTaskMessage::Close,
+        )
+        .await;
         println!("[WORKER_SERVER] Tasks closed successfully");
         Ok(Response::new(CloseWorkerTasksResponse {
             success: true,

--- a/src/runtime/worker_server.rs
+++ b/src/runtime/worker_server.rs
@@ -187,17 +187,23 @@ impl WorkerService for WorkerServiceImpl {
     ) -> Result<Response<GetWorkerStateResponse>, Status> {
         self.validate_execution_attempt(request.get_ref().execution_attempt_id)
             .await?;
-        let worker_guard = self.worker.lock().await;
-        if !worker_guard.is_configured() {
-            return Err(Status::failed_precondition(
-                "worker is not configured for this attempt",
-            ));
-        }
-        let state = worker_guard.get_state().await;
+        // Clone poll inputs under the lock, then release before awaiting task asks.
+        // Holding `Mutex<Worker>` across get_state starved concurrent control RPCs
+        // (stop_sources / heartbeat / second poll) and could hang PipelineFinished.
+        let poll = {
+            let worker_guard = self.worker.lock().await;
+            if !worker_guard.is_configured() {
+                return Err(Status::failed_precondition(
+                    "worker is not configured for this attempt",
+                ));
+            }
+            worker_guard.state_poll_handles()
+        };
+        let state = Worker::finish_state_poll(poll).await;
         let state_bytes = bincode::serialize(&state).map_err(|e| {
             Status::internal(format!("Failed to serialize worker state: {}", e))
         })?;
-        
+
         Ok(Response::new(GetWorkerStateResponse {
             worker_state_bytes: state_bytes,
         }))

--- a/src/storage/in_memory_storage_grpc_client.rs
+++ b/src/storage/in_memory_storage_grpc_client.rs
@@ -40,8 +40,8 @@ impl InMemoryStorageClient {
                 Ok(client) => {
                     println!("[IN_MEMORY_STORAGE_CLIENT] Successfully connected to {} on attempt {}", addr, attempt + 1);
                     let client = client
-                        .max_decoding_message_size(12*1024*1024)
-                        .max_encoding_message_size(12*1024*1024); // 12 MB
+                        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
                     
                     return Ok(Self { client });
                 }

--- a/src/storage/in_memory_storage_grpc_server.rs
+++ b/src/storage/in_memory_storage_grpc_server.rs
@@ -216,7 +216,9 @@ impl InMemoryStorageServer {
         let addr = addr.parse()?;
         let service = in_memory_storage_service::in_memory_storage_service_server::InMemoryStorageServiceServer::new(
             self.service.clone()
-        );
+        )
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[IN_MEMORY_STORAGE_SERVER] Starting InMemoryStorageService server on {}", addr);
         
@@ -225,7 +227,7 @@ impl InMemoryStorageServer {
         
         let server_handle = tokio::spawn(async move {
             match tonic::transport::Server::builder()
-                .max_frame_size(Some(12 * 1024 * 1024)) // 12MB
+                .max_frame_size(Some(crate::common::GRPC_MAX_MESSAGE_BYTES as u32))
                 .add_service(service)
                 .serve_with_shutdown(addr, async {
                     shutdown_receiver.await.ok();

--- a/src/tests/inprocess/transport/grpc_streaming.rs
+++ b/src/tests/inprocess/transport/grpc_streaming.rs
@@ -20,7 +20,9 @@ pub async fn start_server(
     println!("[SERVER] Starting gRPC server on {}", addr);
     let addr = addr.parse()?;
     let service = MessageStreamServiceImpl::new(tx);
-    let svc = MessageStreamServiceServer::new(service);
+    let svc = MessageStreamServiceServer::new(service)
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
     println!("[SERVER] gRPC server listening on {}", addr);
     let router = Server::builder().add_service(svc);

--- a/src/tests/inprocess/watermark_streaming.rs
+++ b/src/tests/inprocess/watermark_streaming.rs
@@ -118,7 +118,7 @@ pub(crate) async fn run_watermark_window_pipeline(
     exec_graph.configure_channels(None, None);
     let vertex_ids = exec_graph.get_vertices().keys().cloned().collect();
 
-    // Sanity: ensure we actually built a window operator (planner-side watermark placement should attach to it).
+    // Sanity: window exists; watermark assign is on Source (pre-KeyBy), not Window.
     assert!(
         exec_graph
             .get_vertices()
@@ -126,6 +126,26 @@ pub(crate) async fn run_watermark_window_pipeline(
             .any(|v| matches!(v.operator_config, OperatorConfig::WindowConfig(_))),
         "expected execution graph to contain a Window operator"
     );
+    let assign_vertices: Vec<_> = exec_graph
+        .get_vertices()
+        .values()
+        .filter(|v| v.watermark_assign.is_some())
+        .collect();
+    assert!(
+        !assign_vertices.is_empty(),
+        "expected watermark_assign on at least one vertex"
+    );
+    for v in &assign_vertices {
+        assert!(
+            matches!(v.operator_config, OperatorConfig::SourceConfig(_)),
+            "watermark_assign should be on Source, got {:?}",
+            v.operator_config
+        );
+        assert!(
+            !matches!(v.operator_config, OperatorConfig::WindowConfig(_)),
+            "Window must not have watermark_assign"
+        );
+    }
 
     let mut worker = Worker::from_config(WorkerConfig::new(
         "wm-e2e-worker".to_string(),

--- a/src/transport/grpc/grpc_streaming_service.rs
+++ b/src/transport/grpc/grpc_streaming_service.rs
@@ -1,6 +1,7 @@
 use tonic::{Request, Response, Status};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
+use crate::common::grpc::GRPC_MAX_MESSAGE_BYTES;
 use crate::common::message::Message;
 use crate::runtime::consts::{
     runtime_consts, TRANSPORT_GRPC_CONNECT_MAX_RETRIES, TRANSPORT_GRPC_CONNECT_RETRY_DELAY,
@@ -81,6 +82,9 @@ impl MessageStreamClient {
         for attempt in 0..=max_retries {
             match MessageStreamServiceClient::connect(addr.clone()).await {
                 Ok(client) => {
+                    let client = client
+                        .max_decoding_message_size(GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(GRPC_MAX_MESSAGE_BYTES);
                     println!("[GRPC_CLIENT] Successfully connected to {} after {} attempts", addr, attempt + 1);
                     return Ok(Self { client });
                 }

--- a/src/transport/transport_backend.rs
+++ b/src/transport/transport_backend.rs
@@ -193,7 +193,9 @@ impl TransportBackend {
                 .parse()
                 .expect("[GRPC_BACKEND] invalid listen address");
             let service = MessageStreamServiceImpl::new(server_tx);
-            let svc = MessageStreamServiceServer::new(service);
+            let svc = MessageStreamServiceServer::new(service)
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
             println!("[GRPC_BACKEND] Starting gRPC server on {}", addr);
 


### PR DESCRIPTION
## Summary
- Release `Mutex<Worker>` before task-state asks in `get_worker_state` (lock-over-await stall)
- Bound run-loop `get_worker_state` with `master.state_poll_timeout` (timeout → state-poll failure/recovery)
- Treat `Finished | Closed` as drained for `AttemptOutcome::Finished`
- Log drain status digests after StopSources so silent hangs are diagnosable

Fixes #184. Stack tip on #183 (WM lineage); depends on #182 StopSources drain gate.

## Test plan
- [ ] Local/CI inproc-stress `test_local_multi_worker_window_checkpoint_restore` 4×10
- [ ] Confirm no Finished-but-no-`PipelineFinished` hang; if fail, drain digests name stuck workers


Made with [Cursor](https://cursor.com)