### PR TITLE
Lower scheduled kube stress to 15×10

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -182,7 +182,7 @@ jobs:
             # Free org ~18 usable concurrent runners in practice. Alternate so
             # each suite gets a dedicated wave (not half the pool), 15 machines:
             # - inproc 100× window restore ≈ 10–15s/run → ~25–40m
-            # - kube 50× --all + fresh Kind (heavier per run; may still span >1h)
+            # - kube 10× --all + fresh Kind ≈ 3–4m/outer-run historically → ~30–45m
             # Cron fires at UTC hours 0,4,8,12,16,20 — alternate by slot so we
             # do not always land on the same suite (hour%2 would be stuck on even).
             hour=$((10#$(date -u +%H)))
@@ -194,7 +194,7 @@ jobs:
               runs=100
             else
               schedule_mode=kube
-              runs=50
+              runs=10
             fi
           else
             machines="${{ inputs.stress_machines }}"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,7 +49,7 @@ Scheduled stress (every 4h UTC; suites alternate each tick → each suite ~8h):
 | UTC hours (cron `17 */4`) | Suite | Shape | Notes |
 | --- | --- | --- | --- |
 | 0, 8, 16 | inproc | 15 × 1 × 100 | `test_local_multi_worker_window_checkpoint_restore` (~25–40m) |
-| 4, 12, 20 | kube | 15 × 1 × 50 | full kube suite + fresh Kind (heavier per run) |
+| 4, 12, 20 | kube | 15 × 1 × 10 | full kube suite + fresh Kind (~30–45m/machine) |
 
 Prefer `stress_shards_per_machine=1` so parallelism comes from machines, not
 co-tenancy on one runner. Sized for ~18 usable Free-plan runners (leave headroom).


### PR DESCRIPTION
## Summary
- Scheduled kube stress: **15×50 → 15×10** (still `--all` + fresh Kind).
- Inproc schedule unchanged at 15×100.
- Per-machine work matches the prior 3×10 schedule that finished in ~30–45m; higher run counts overrun the 180m job timeout because Kind is recreated every outer run.

## Test plan
- [ ] After merge, next odd schedule slot uses `runs=10`


Made with [Cursor](https://cursor.com)