### PR TITLE
Raise nextest stress timeout to 360s

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,7 +19,9 @@ fail-fast = false
 slow-timeout = { period = "90s", terminate-after = 1 }
 fail-fast = false
 
-# scripts/stress-test (kube-heavy).
+# scripts/stress-test (kube-heavy). Must exceed harness kube kill-restore
+# budget (recovery_started+replacement+attempt1_running ≈ 300s) so nextest
+# does not mask LifecycleOracle diagnostics on slow replaces.
 [profile.stress]
-slow-timeout = { period = "180s", terminate-after = 1 }
+slow-timeout = { period = "360s", terminate-after = 1 }
 fail-fast = false


### PR DESCRIPTION
## Summary
- Bump `[profile.stress]` slow-timeout **180s → 360s**.
- Kube harness `wait_for_kill_restore` alone allows ~300s; nextest was killing first and hiding lifecycle diagnostics (seen on kube window stress: pass ×3, then hang after kill with only “(test timed out)”).

## Test plan
- [ ] Re-run a kube stress shard; on a slow replace, expect harness timeout text / lifecycle dump rather than a bare nextest TIMEOUT under 180s


Made with [Cursor](https://cursor.com)