### PR TITLE
Introduce CheckpointCoordinator actor

### DIFF
--- a/src/runtime/master/checkpoint/actor.rs
+++ b/src/runtime/master/checkpoint/actor.rs
@@ -1,0 +1,177 @@
+//! Owns checkpoint protocol + store IO on a single mailbox.
+//!
+//! Persist runs inside the actor turn (no `PendingPersist` / lock escape hatch).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use kameo::message::{Context, Message};
+use kameo::Actor;
+
+use crate::common::types::PipelineId;
+use crate::runtime::checkpoint::{CompletedCheckpoint, SerializedCheckpoint};
+
+use super::store::CheckpointStore;
+use super::{CheckpointAckOutcome, CheckpointStartError, Checkpoints, TaskKey};
+
+#[derive(Actor, Debug, Default)]
+pub struct CheckpointCoordinator {
+    inner: Checkpoints,
+}
+
+/// Configure expected tasks and store for a pipeline.
+pub struct ConfigureCheckpoints {
+    pub pipeline_id: PipelineId,
+    pub expected_acks: HashSet<TaskKey>,
+    pub expected_aligns: HashSet<TaskKey>,
+    pub retention: usize,
+    pub store: Arc<dyn CheckpointStore>,
+}
+
+pub struct StartCheckpoint;
+
+pub struct AbortInFlightCheckpoint;
+
+pub struct ReportCheckpoint {
+    pub checkpoint_id: u64,
+    pub task: TaskKey,
+    pub checkpoint: SerializedCheckpoint,
+}
+
+/// Barrier Injected/Aligned. `None` reply = not in-flight (soft ignore).
+pub struct NoteBarrierProgress {
+    pub checkpoint_id: u64,
+    pub task: TaskKey,
+}
+
+pub struct InFlightCheckpointId;
+
+pub struct InFlightCheckpointTimedOut(pub Duration);
+
+pub struct LatestCompleteCheckpoint;
+
+pub struct LoadCheckpoint(pub u64);
+
+impl Message<ConfigureCheckpoints> for CheckpointCoordinator {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: ConfigureCheckpoints,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.inner.configure(
+            msg.pipeline_id,
+            msg.expected_acks,
+            msg.expected_aligns,
+            msg.retention,
+            msg.store,
+        );
+    }
+}
+
+impl Message<StartCheckpoint> for CheckpointCoordinator {
+    type Reply = Result<u64, CheckpointStartError>;
+
+    async fn handle(
+        &mut self,
+        _msg: StartCheckpoint,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.inner.start()
+    }
+}
+
+impl Message<AbortInFlightCheckpoint> for CheckpointCoordinator {
+    type Reply = Option<u64>;
+
+    async fn handle(
+        &mut self,
+        _msg: AbortInFlightCheckpoint,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.inner.abort_in_flight()
+    }
+}
+
+impl Message<ReportCheckpoint> for CheckpointCoordinator {
+    type Reply = Result<CheckpointAckOutcome>;
+
+    async fn handle(
+        &mut self,
+        msg: ReportCheckpoint,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.inner
+            .report(msg.checkpoint_id, msg.task, msg.checkpoint)
+            .await
+    }
+}
+
+impl Message<NoteBarrierProgress> for CheckpointCoordinator {
+    type Reply = Result<Option<CheckpointAckOutcome>>;
+
+    async fn handle(
+        &mut self,
+        msg: NoteBarrierProgress,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.inner.in_flight_id() != Some(msg.checkpoint_id) {
+            return Ok(None);
+        }
+        self.inner
+            .note_barrier_progress(msg.checkpoint_id, msg.task)
+            .await
+            .map(Some)
+    }
+}
+
+impl Message<InFlightCheckpointId> for CheckpointCoordinator {
+    type Reply = Option<u64>;
+
+    async fn handle(
+        &mut self,
+        _msg: InFlightCheckpointId,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.inner.in_flight_id()
+    }
+}
+
+impl Message<InFlightCheckpointTimedOut> for CheckpointCoordinator {
+    type Reply = Option<u64>;
+
+    async fn handle(
+        &mut self,
+        msg: InFlightCheckpointTimedOut,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.inner.in_flight_timed_out(msg.0)
+    }
+}
+
+impl Message<LatestCompleteCheckpoint> for CheckpointCoordinator {
+    type Reply = Option<u64>;
+
+    async fn handle(
+        &mut self,
+        _msg: LatestCompleteCheckpoint,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.inner.latest_complete()
+    }
+}
+
+impl Message<LoadCheckpoint> for CheckpointCoordinator {
+    type Reply = Result<CompletedCheckpoint>;
+
+    async fn handle(
+        &mut self,
+        msg: LoadCheckpoint,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.inner.load(msg.0).await
+    }
+}

--- a/src/runtime/master/checkpoint/mod.rs
+++ b/src/runtime/master/checkpoint/mod.rs
@@ -1,5 +1,6 @@
 //! Master checkpoint domain: protocol + task checkpoint storage.
 
+mod actor;
 mod protocol;
 mod restore;
 mod store;
@@ -11,6 +12,11 @@ use std::time::Duration;
 use crate::common::types::PipelineId;
 use crate::runtime::checkpoint::{CompletedCheckpoint, SerializedCheckpoint};
 
+pub use actor::{
+    AbortInFlightCheckpoint, CheckpointCoordinator, ConfigureCheckpoints, InFlightCheckpointId,
+    InFlightCheckpointTimedOut, LatestCompleteCheckpoint, LoadCheckpoint, NoteBarrierProgress,
+    ReportCheckpoint, StartCheckpoint,
+};
 pub use crate::runtime::checkpoint::TaskKey;
 use protocol::CheckpointProtocol;
 pub use restore::RestorePlanner;
@@ -41,8 +47,9 @@ pub enum CheckpointAckReject {
 }
 
 /// Checkpoint protocol + completed-checkpoint store.
+/// Owned by [`CheckpointCoordinator`]; not shared behind a mutex.
 #[derive(Debug)]
-pub struct Checkpoints {
+pub(super) struct Checkpoints {
     /// Tasks that must report operator checkpoint data.
     expected_acks: HashSet<TaskKey>,
     /// All tasks that must report barrier progress (Injected or Aligned).
@@ -121,7 +128,7 @@ impl Checkpoints {
             .ok_or_else(|| anyhow::anyhow!("completed checkpoint {checkpoint_id} not found"))
     }
 
-    /// Record operator state and its ack. May complete if aligns are already done.
+    /// Record operator state and its ack. May complete (and persist) if aligns are done.
     pub async fn report(
         &mut self,
         checkpoint_id: u64,
@@ -148,7 +155,7 @@ impl Checkpoints {
         self.finish_if_completed(checkpoint_id, outcome).await
     }
 
-    /// Record barrier Injected/Aligned for a task. May complete if acks are already done.
+    /// Record barrier Injected/Aligned for a task. May complete (and persist) if acks are done.
     pub async fn note_barrier_progress(
         &mut self,
         checkpoint_id: u64,
@@ -168,26 +175,28 @@ impl Checkpoints {
         checkpoint_id: u64,
         outcome: CheckpointAckOutcome,
     ) -> anyhow::Result<CheckpointAckOutcome> {
-        if matches!(outcome, CheckpointAckOutcome::Completed) {
-            let tasks = self.pending.remove(&checkpoint_id).unwrap_or_default();
-            anyhow::ensure!(
-                tasks.len() == self.expected_acks.len(),
-                "checkpoint {checkpoint_id} completed without all task state"
-            );
-            self.store()?
-                .save(
-                    self.pipeline_id()?,
-                    CompletedCheckpoint {
-                        checkpoint_id,
-                        tasks,
-                    },
-                )
-                .await?;
-            for pruned_id in self.protocol.retain_completed(self.retention) {
-                self.store()?
-                    .remove(self.pipeline_id()?, pruned_id)
-                    .await?;
-            }
+        if !matches!(outcome, CheckpointAckOutcome::Completed) {
+            return Ok(outcome);
+        }
+        let tasks = self.pending.remove(&checkpoint_id).unwrap_or_default();
+        anyhow::ensure!(
+            tasks.len() == self.expected_acks.len(),
+            "checkpoint {checkpoint_id} completed without all task state"
+        );
+        let prune = self.protocol.retain_completed(self.retention);
+        let pipeline_id = self.pipeline_id()?.clone();
+        let store = Arc::clone(self.store()?);
+        store
+            .save(
+                &pipeline_id,
+                CompletedCheckpoint {
+                    checkpoint_id,
+                    tasks,
+                },
+            )
+            .await?;
+        for pruned_id in prune {
+            store.remove(&pipeline_id, pruned_id).await?;
         }
         Ok(outcome)
     }

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use kameo::actor::ActorRef;
+use kameo::spawn;
 use tokio::sync::Mutex;
 use tokio::sync::broadcast;
 use tokio::time::{sleep, Duration, Instant};
@@ -21,8 +22,10 @@ use crate::runtime::operators::operator::operator_config_requires_checkpoint;
 
 use super::attempt::ExecutionAttempt;
 use super::checkpoint::{
-    create_checkpoint_store, CheckpointAckOutcome, CheckpointStartError, Checkpoints,
-    RestorePlanner, TaskKey,
+    create_checkpoint_store, AbortInFlightCheckpoint, CheckpointAckOutcome, CheckpointCoordinator,
+    CheckpointStartError, ConfigureCheckpoints, InFlightCheckpointId, InFlightCheckpointTimedOut,
+    LatestCompleteCheckpoint, LoadCheckpoint, NoteBarrierProgress, ReportCheckpoint,
+    RestorePlanner, StartCheckpoint, TaskKey,
 };
 use super::events::{
     CheckpointPropagationPhase, LifecycleEvent, LifecycleEventRecord, LifecycleJournal,
@@ -154,7 +157,7 @@ impl fmt::Display for WorkerReadinessError {
 
 pub(super) struct MasterState {
     config: Mutex<Option<MasterConfig>>,
-    checkpoints: Mutex<Checkpoints>,
+    checkpoints: ActorRef<CheckpointCoordinator>,
     pub orchestrator: Arc<dyn MasterOrchestrator>,
     workers: Mutex<WorkerRegistry>,
     latest_pipeline_snapshot: Mutex<Option<PipelineSnapshot>>,
@@ -172,7 +175,7 @@ impl MasterState {
         let (lifecycle_event_tx, _) = broadcast::channel(256);
         Self {
             config: Mutex::new(None),
-            checkpoints: Mutex::new(Checkpoints::default()),
+            checkpoints: spawn(CheckpointCoordinator::default()),
             orchestrator,
             workers: Mutex::new(WorkerRegistry::default()),
             latest_pipeline_snapshot: Mutex::new(None),
@@ -249,13 +252,16 @@ impl MasterState {
             })
             .collect();
         let retention = runtime_consts().u64(MASTER_CHECKPOINT_RETENTION) as usize;
-        self.checkpoints.lock().await.configure(
-            pipeline_id,
-            expected_acks.into_iter().collect(),
-            expected_aligns,
-            retention,
-            checkpoint_store,
-        );
+        self.checkpoints
+            .ask(ConfigureCheckpoints {
+                pipeline_id,
+                expected_acks: expected_acks.into_iter().collect(),
+                expected_aligns,
+                retention,
+                store: checkpoint_store,
+            })
+            .await
+            .expect("checkpoint coordinator");
         *self.config.lock().await = Some(config);
     }
 
@@ -290,7 +296,11 @@ impl MasterState {
         &self,
         attempt_id: u64,
     ) -> Result<u64, CheckpointStartError> {
-        let checkpoint_id = self.checkpoints.lock().await.start()?;
+        // kameo flattens `Result` replies: Ok(id) / Err(SendError::HandlerError(start_err)).
+        let checkpoint_id = match self.checkpoints.ask(StartCheckpoint).await {
+            Ok(checkpoint_id) => checkpoint_id,
+            Err(error) => return Err(error.unwrap_err()),
+        };
         self.record_lifecycle_event(LifecycleEvent::CheckpointStarted {
             checkpoint_id,
             attempt_id,
@@ -304,7 +314,11 @@ impl MasterState {
         attempt_id: u64,
         detail: String,
     ) -> Result<Option<u64>, String> {
-        let checkpoint_id = self.checkpoints.lock().await.abort_in_flight();
+        let checkpoint_id = self
+            .checkpoints
+            .ask(AbortInFlightCheckpoint)
+            .await
+            .map_err(|error| format!("checkpoint coordinator: {error}"))?;
         if let Some(checkpoint_id) = checkpoint_id {
             self.record_lifecycle_event(LifecycleEvent::CheckpointFailed {
                 checkpoint_id,
@@ -318,13 +332,18 @@ impl MasterState {
 
     pub(super) async fn in_flight_checkpoint_timed_out(&self, timeout: Duration) -> Option<u64> {
         self.checkpoints
-            .lock()
+            .ask(InFlightCheckpointTimedOut(timeout))
             .await
-            .in_flight_timed_out(timeout)
+            .ok()
+            .flatten()
     }
 
     pub(super) async fn in_flight_checkpoint_id(&self) -> Option<u64> {
-        self.checkpoints.lock().await.in_flight_id()
+        self.checkpoints
+            .ask(InFlightCheckpointId)
+            .await
+            .ok()
+            .flatten()
     }
 
     /// Journal barrier progress and count it toward completion (with state acks).
@@ -341,15 +360,16 @@ impl MasterState {
             return Ok(());
         }
 
-        let outcome = {
-            let mut cps = self.checkpoints.lock().await;
-            // Only in-flight CPs accept barrier progress (Completed implies align already done).
-            if cps.in_flight_id() != Some(checkpoint_id) {
-                return Ok(());
-            }
-            cps.note_barrier_progress(checkpoint_id, task.clone())
-                .await
-                .map_err(|error| format!("failed to update checkpoint store: {error}"))?
+        let outcome = self
+            .checkpoints
+            .ask(NoteBarrierProgress {
+                checkpoint_id,
+                task: task.clone(),
+            })
+            .await
+            .map_err(|error| format!("failed to update checkpoint store: {error}"))?;
+        let Some(outcome) = outcome else {
+            return Ok(());
         };
 
         self.record_lifecycle_event(LifecycleEvent::CheckpointPropagation {
@@ -405,12 +425,15 @@ impl MasterState {
                 task.vertex_id, task.task_index
             ));
         }
-        let outcome = {
-            let mut cps = self.checkpoints.lock().await;
-            cps.report(checkpoint_id, task, checkpoint)
-                .await
-                .map_err(|error| format!("failed to update checkpoint store: {error}"))?
-        };
+        let outcome = self
+            .checkpoints
+            .ask(ReportCheckpoint {
+                checkpoint_id,
+                task,
+                checkpoint,
+            })
+            .await
+            .map_err(|error| format!("failed to update checkpoint store: {error}"))?;
 
         match outcome {
             CheckpointAckOutcome::Completed => {
@@ -428,9 +451,7 @@ impl MasterState {
     pub(super) async fn plan_restore(&self, checkpoint_id: u64) -> Result<RestorePlan, String> {
         let completed = self
             .checkpoints
-            .lock()
-            .await
-            .load(checkpoint_id)
+            .ask(LoadCheckpoint(checkpoint_id))
             .await
             .map_err(|error| format!("failed to load checkpoint: {error}"))?;
         let target_graph = {
@@ -445,7 +466,11 @@ impl MasterState {
     }
 
     pub(super) async fn latest_complete_checkpoint(&self) -> Option<u64> {
-        self.checkpoints.lock().await.latest_complete()
+        self.checkpoints
+            .ask(LatestCompleteCheckpoint)
+            .await
+            .ok()
+            .flatten()
     }
 
     pub(super) async fn publish_snapshot(&self, snapshot: PipelineSnapshot) {


### PR DESCRIPTION
## Summary
- Own checkpoint protocol + store IO on `CheckpointCoordinator` (kameo actor)
- Remove `Mutex<Checkpoints>` / deferred `PendingPersist` from `MasterState`
- Persist completes inside the actor turn

First master-side extract toward actorized control plane — **#192** (same class of redesign as worker #191).

Depends on worker concurrency PR.

## Test plan
- [ ] `cargo test --lib runtime::master::checkpoint::`
- [ ] Checkpoint / recovery paths in harness


Made with [Cursor](https://cursor.com)