### PR TITLE
Raise gRPC/inmem limits and centralize gRPC construction

### DIFF
--- a/src/common/grpc.rs
+++ b/src/common/grpc.rs
@@ -1,5 +1,0 @@
-/// Max gRPC message size for control-plane and transport RPCs.
-///
-/// Must stay above the in-memory window checkpoint inline limit (8 MiB) so
-/// checkpoint/restore payloads are not rejected by tonic's 4 MiB default.
-pub const GRPC_MAX_MESSAGE_BYTES: usize = 12 * 1024 * 1024;

--- a/src/common/grpc.rs
+++ b/src/common/grpc.rs
@@ -1,0 +1,5 @@
+/// Max gRPC message size for control-plane and transport RPCs.
+///
+/// Must stay above the in-memory window checkpoint inline limit (8 MiB) so
+/// checkpoint/restore payloads are not rejected by tonic's 4 MiB default.
+pub const GRPC_MAX_MESSAGE_BYTES: usize = 12 * 1024 * 1024;

--- a/src/common/grpc/master.rs
+++ b/src/common/grpc/master.rs
@@ -1,6 +1,11 @@
+use std::time::Duration;
+
 use tonic::transport::Channel;
 
-use crate::runtime::consts::{runtime_consts, WORKER_REGISTER_CONNECT_TIMEOUT};
+use crate::runtime::consts::{
+    runtime_consts, WORKER_REGISTER_CONNECT_TIMEOUT, WORKER_REGISTER_MAX_RETRIES,
+    WORKER_REGISTER_RETRY_DELAY, WORKER_REGISTER_RPC_TIMEOUT,
+};
 
 use super::stubs::master_service::master_service_client::MasterServiceClient;
 use super::stubs::master_service::master_service_server::{MasterService, MasterServiceServer};
@@ -12,10 +17,27 @@ pub fn control_plane_config() -> GrpcConfig {
     GrpcConfig::default_limits()
 }
 
-/// Worker → master registration dials (`worker.register_connect_timeout` per profile).
-pub fn worker_register_config() -> GrpcConfig {
-    GrpcConfig::default_limits()
-        .with_connect_timeout(runtime_consts().duration(WORKER_REGISTER_CONNECT_TIMEOUT))
+/// Full worker → master registration policy (dial + outer retry + per-RPC timeout).
+#[derive(Debug, Clone)]
+pub struct WorkerRegisterPolicy {
+    pub dial: GrpcConfig,
+    pub retry: RetryPolicy,
+    pub rpc_timeout: Duration,
+}
+
+/// Profile knobs: `worker.register_connect_timeout`, `register_max_retries`,
+/// `register_retry_delay`, `register_rpc_timeout`.
+pub fn worker_register_policy() -> WorkerRegisterPolicy {
+    WorkerRegisterPolicy {
+        dial: GrpcConfig::default_limits().with_connect_timeout(
+            runtime_consts().duration(WORKER_REGISTER_CONNECT_TIMEOUT),
+        ),
+        retry: RetryPolicy::linear(
+            runtime_consts().u64(WORKER_REGISTER_MAX_RETRIES) as u32,
+            runtime_consts().duration(WORKER_REGISTER_RETRY_DELAY),
+        ),
+        rpc_timeout: runtime_consts().duration(WORKER_REGISTER_RPC_TIMEOUT),
+    }
 }
 
 pub fn master_server<S>(svc: S) -> MasterServiceServer<S>

--- a/src/common/grpc/master.rs
+++ b/src/common/grpc/master.rs
@@ -1,0 +1,43 @@
+use tonic::transport::Channel;
+
+use crate::runtime::consts::{runtime_consts, WORKER_REGISTER_CONNECT_TIMEOUT};
+
+use super::stubs::master_service::master_service_client::MasterServiceClient;
+use super::stubs::master_service::master_service_server::{MasterService, MasterServiceServer};
+use super::{connect, connect_with_retry, GrpcConfig, RetryPolicy, WithMessageLimits};
+
+/// Limits-only config for master servers and clients that historically used
+/// `MasterServiceClient::connect` with no Endpoint dial timeout (stream_task, harness).
+pub fn control_plane_config() -> GrpcConfig {
+    GrpcConfig::default_limits()
+}
+
+/// Worker → master registration dials (`worker.register_connect_timeout` per profile).
+pub fn worker_register_config() -> GrpcConfig {
+    GrpcConfig::default_limits()
+        .with_connect_timeout(runtime_consts().duration(WORKER_REGISTER_CONNECT_TIMEOUT))
+}
+
+pub fn master_server<S>(svc: S) -> MasterServiceServer<S>
+where
+    S: MasterService,
+{
+    MasterServiceServer::new(svc).with_message_limits()
+}
+
+pub async fn master_client(
+    addr: &str,
+    cfg: &GrpcConfig,
+) -> Result<MasterServiceClient<Channel>, tonic::transport::Error> {
+    let channel = connect(addr, cfg).await?;
+    Ok(MasterServiceClient::new(channel).with_message_limits())
+}
+
+pub async fn master_client_with_retry(
+    addr: &str,
+    cfg: &GrpcConfig,
+    retry: &RetryPolicy,
+) -> Result<MasterServiceClient<Channel>, tonic::transport::Error> {
+    let channel = connect_with_retry(addr, cfg, retry).await?;
+    Ok(MasterServiceClient::new(channel).with_message_limits())
+}

--- a/src/common/grpc/master.rs
+++ b/src/common/grpc/master.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use tonic::transport::Channel;
 
 use crate::runtime::consts::{
@@ -9,35 +7,16 @@ use crate::runtime::consts::{
 
 use super::stubs::master_service::master_service_client::MasterServiceClient;
 use super::stubs::master_service::master_service_server::{MasterService, MasterServiceServer};
-use super::{connect, connect_with_retry, GrpcConfig, RetryPolicy, WithMessageLimits};
+use super::{connect_with_retry, GrpcConfig, WithMessageLimits};
 
-/// Limits-only config for master servers and clients that historically used
-/// `MasterServiceClient::connect` with no Endpoint dial timeout (stream_task, harness).
-pub fn control_plane_config() -> GrpcConfig {
-    GrpcConfig::default_limits()
-}
-
-/// Full worker → master registration policy (dial + outer retry + per-RPC timeout).
-#[derive(Debug, Clone)]
-pub struct WorkerRegisterPolicy {
-    pub dial: GrpcConfig,
-    pub retry: RetryPolicy,
-    pub rpc_timeout: Duration,
-}
-
-/// Profile knobs: `worker.register_connect_timeout`, `register_max_retries`,
-/// `register_retry_delay`, `register_rpc_timeout`.
-pub fn worker_register_policy() -> WorkerRegisterPolicy {
-    WorkerRegisterPolicy {
-        dial: GrpcConfig::default_limits().with_connect_timeout(
-            runtime_consts().duration(WORKER_REGISTER_CONNECT_TIMEOUT),
-        ),
-        retry: RetryPolicy::linear(
+pub fn worker_register() -> GrpcConfig {
+    GrpcConfig::new()
+        .with_connect_timeout(runtime_consts().duration(WORKER_REGISTER_CONNECT_TIMEOUT))
+        .with_retries(
             runtime_consts().u64(WORKER_REGISTER_MAX_RETRIES) as u32,
             runtime_consts().duration(WORKER_REGISTER_RETRY_DELAY),
-        ),
-        rpc_timeout: runtime_consts().duration(WORKER_REGISTER_RPC_TIMEOUT),
-    }
+        )
+        .with_rpc_timeout(runtime_consts().duration(WORKER_REGISTER_RPC_TIMEOUT))
 }
 
 pub fn master_server<S>(svc: S) -> MasterServiceServer<S>
@@ -51,15 +30,6 @@ pub async fn master_client(
     addr: &str,
     cfg: &GrpcConfig,
 ) -> Result<MasterServiceClient<Channel>, tonic::transport::Error> {
-    let channel = connect(addr, cfg).await?;
-    Ok(MasterServiceClient::new(channel).with_message_limits())
-}
-
-pub async fn master_client_with_retry(
-    addr: &str,
-    cfg: &GrpcConfig,
-    retry: &RetryPolicy,
-) -> Result<MasterServiceClient<Channel>, tonic::transport::Error> {
-    let channel = connect_with_retry(addr, cfg, retry).await?;
+    let channel = connect_with_retry(addr, cfg).await?;
     Ok(MasterServiceClient::new(channel).with_message_limits())
 }

--- a/src/common/grpc/mod.rs
+++ b/src/common/grpc/mod.rs
@@ -93,7 +93,8 @@ impl RetryPolicy {
         }
     }
 
-    fn delay_for_attempt(&self, attempt: u32) -> Duration {
+    /// Delay before the next attempt after `attempt` (0-based) failed.
+    pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
         match self.backoff {
             RetryBackoff::Fixed => self.base_delay,
             RetryBackoff::Linear => self.base_delay.saturating_mul(attempt.saturating_add(1)),

--- a/src/common/grpc/mod.rs
+++ b/src/common/grpc/mod.rs
@@ -1,8 +1,3 @@
-//! Shared gRPC construction: limits, channel connect, server serve, typed factories.
-//!
-//! Call sites should use the factories in [`master`], [`worker`], [`storage`], and
-//! [`transport`] instead of `*Client::connect` / ad-hoc message-size setters.
-
 pub mod master;
 pub mod storage;
 pub mod stubs;
@@ -16,98 +11,55 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tonic::transport::{Channel, Endpoint, Server};
 
-/// Max gRPC message size for control-plane and transport RPCs.
-///
-/// Must stay above the in-memory window checkpoint inline limit (8 MiB) so
-/// checkpoint/restore payloads are not rejected by tonic's 4 MiB default.
+// Above inmem window checkpoint inline limit (8 MiB); tonic default decode is 4 MiB.
 pub const GRPC_MAX_MESSAGE_BYTES: usize = 12 * 1024 * 1024;
 
-/// Shared transport settings applied at client/server construction.
 #[derive(Debug, Clone)]
 pub struct GrpcConfig {
-    pub max_decoding_message_bytes: usize,
-    pub max_encoding_message_bytes: usize,
-    /// HTTP/2 max frame size for [`Server::builder`] (not the gRPC message limit).
-    pub max_frame_size: Option<u32>,
-    /// When set, applied via [`Endpoint::connect_timeout`].
-    ///
-    /// `None` matches historical `*Client::connect` (no dial deadline). Only set this
-    /// from profile `runtime_consts` at call sites that previously used an Endpoint timeout
-    /// (`master.worker_connect_timeout`, `worker.register_connect_timeout`).
     pub connect_timeout: Option<Duration>,
+    pub max_attempts: u32,
+    pub retry_delay: Duration,
+    pub rpc_timeout: Option<Duration>,
 }
 
 impl GrpcConfig {
-    /// Message / frame size limits only — no dial timeout.
-    pub fn default_limits() -> Self {
+    pub fn new() -> Self {
         Self {
-            max_decoding_message_bytes: GRPC_MAX_MESSAGE_BYTES,
-            max_encoding_message_bytes: GRPC_MAX_MESSAGE_BYTES,
-            max_frame_size: Some(GRPC_MAX_MESSAGE_BYTES as u32),
             connect_timeout: None,
+            max_attempts: 1,
+            retry_delay: Duration::ZERO,
+            rpc_timeout: None,
         }
     }
 
-    pub fn with_connect_timeout(mut self, connect_timeout: Duration) -> Self {
-        self.connect_timeout = Some(connect_timeout);
+    pub fn with_connect_timeout(mut self, t: Duration) -> Self {
+        self.connect_timeout = Some(t);
         self
     }
 
-    pub fn without_frame_size_limit(mut self) -> Self {
-        self.max_frame_size = None;
+    pub fn with_retries(mut self, max_attempts: u32, retry_delay: Duration) -> Self {
+        self.max_attempts = max_attempts.max(1);
+        self.retry_delay = retry_delay;
+        self
+    }
+
+    pub fn with_rpc_timeout(mut self, t: Duration) -> Self {
+        self.rpc_timeout = Some(t);
         self
     }
 }
 
-/// Retry policy for [`connect_with_retry`].
-#[derive(Debug, Clone)]
-pub struct RetryPolicy {
-    /// Total connection attempts (must be >= 1).
-    pub max_attempts: u32,
-    pub base_delay: Duration,
-    pub backoff: RetryBackoff,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum RetryBackoff {
-    /// Sleep `base_delay` between attempts.
-    Fixed,
-    /// Sleep `base_delay * attempt_number` (1-based) between attempts.
-    Linear,
-}
-
-impl RetryPolicy {
-    pub fn fixed(max_attempts: u32, base_delay: Duration) -> Self {
-        Self {
-            max_attempts: max_attempts.max(1),
-            base_delay,
-            backoff: RetryBackoff::Fixed,
-        }
-    }
-
-    pub fn linear(max_attempts: u32, base_delay: Duration) -> Self {
-        Self {
-            max_attempts: max_attempts.max(1),
-            base_delay,
-            backoff: RetryBackoff::Linear,
-        }
-    }
-
-    /// Delay before the next attempt after `attempt` (0-based) failed.
-    pub fn delay_for_attempt(&self, attempt: u32) -> Duration {
-        match self.backoff {
-            RetryBackoff::Fixed => self.base_delay,
-            RetryBackoff::Linear => self.base_delay.saturating_mul(attempt.saturating_add(1)),
-        }
+impl Default for GrpcConfig {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
-/// Apply Volga message-size limits to a generated tonic client or server stub.
 pub trait WithMessageLimits: Sized {
     fn with_message_limits(self) -> Self;
 }
 
-macro_rules! impl_client_message_limits {
+macro_rules! impl_client_limits {
     ($($ty:ty),+ $(,)?) => {$(
         impl WithMessageLimits for $ty {
             fn with_message_limits(self) -> Self {
@@ -118,7 +70,7 @@ macro_rules! impl_client_message_limits {
     )+};
 }
 
-macro_rules! impl_server_message_limits {
+macro_rules! impl_server_limits {
     ($($ty:ty),+ $(,)?) => {$(
         impl<T> WithMessageLimits for $ty {
             fn with_message_limits(self) -> Self {
@@ -129,14 +81,14 @@ macro_rules! impl_server_message_limits {
     )+};
 }
 
-impl_client_message_limits! {
+impl_client_limits! {
     stubs::master_service::master_service_client::MasterServiceClient<Channel>,
     stubs::worker_service::worker_service_client::WorkerServiceClient<Channel>,
     stubs::in_memory_storage_service::in_memory_storage_service_client::InMemoryStorageServiceClient<Channel>,
     stubs::message_stream::message_stream_service_client::MessageStreamServiceClient<Channel>,
 }
 
-impl_server_message_limits! {
+impl_server_limits! {
     stubs::master_service::master_service_server::MasterServiceServer<T>,
     stubs::worker_service::worker_service_server::WorkerServiceServer<T>,
     stubs::in_memory_storage_service::in_memory_storage_service_server::InMemoryStorageServiceServer<T>,
@@ -151,7 +103,6 @@ fn normalize_endpoint(addr: &str) -> String {
     }
 }
 
-/// Dial a channel (single attempt). Applies `cfg.connect_timeout` when present.
 pub async fn connect(addr: &str, cfg: &GrpcConfig) -> Result<Channel, tonic::transport::Error> {
     let mut endpoint = Endpoint::from_shared(normalize_endpoint(addr))?;
     if let Some(timeout) = cfg.connect_timeout {
@@ -160,20 +111,18 @@ pub async fn connect(addr: &str, cfg: &GrpcConfig) -> Result<Channel, tonic::tra
     endpoint.connect().await
 }
 
-/// Dial with retries. `max_attempts` includes the first try.
 pub async fn connect_with_retry(
     addr: &str,
     cfg: &GrpcConfig,
-    retry: &RetryPolicy,
 ) -> Result<Channel, tonic::transport::Error> {
     let mut last_err = None;
-    for attempt in 0..retry.max_attempts {
+    for attempt in 0..cfg.max_attempts {
         match connect(addr, cfg).await {
             Ok(channel) => return Ok(channel),
             Err(e) => {
                 last_err = Some(e);
-                if attempt + 1 < retry.max_attempts {
-                    tokio::time::sleep(retry.delay_for_attempt(attempt)).await;
+                if attempt + 1 < cfg.max_attempts {
+                    tokio::time::sleep(cfg.retry_delay).await;
                 }
             }
         }
@@ -181,16 +130,10 @@ pub async fn connect_with_retry(
     Err(last_err.expect("retry loop ran at least once"))
 }
 
-/// Build a tonic [`Server`] with optional HTTP/2 frame size from `cfg`.
-pub fn server_builder(cfg: &GrpcConfig) -> Server {
-    let mut builder = Server::builder();
-    if let Some(frame) = cfg.max_frame_size {
-        builder = builder.max_frame_size(Some(frame));
-    }
-    builder
+pub fn server_builder() -> Server {
+    Server::builder().max_frame_size(Some(GRPC_MAX_MESSAGE_BYTES as u32))
 }
 
-/// Own a spawned serve task and its shutdown signal.
 pub struct GrpcServeHandle {
     join: Option<JoinHandle<()>>,
     shutdown_tx: Option<oneshot::Sender<()>>,
@@ -204,7 +147,6 @@ impl GrpcServeHandle {
         }
     }
 
-    /// Signal shutdown and wait for the serve task to finish.
     pub async fn stop(&mut self) {
         if let Some(tx) = self.shutdown_tx.take() {
             let _ = tx.send(());
@@ -214,7 +156,6 @@ impl GrpcServeHandle {
         }
     }
 
-    /// Abort the serve task without graceful shutdown (used from `Drop`).
     pub fn abort(&mut self) {
         self.shutdown_tx.take();
         if let Some(join) = self.join.take() {
@@ -229,7 +170,6 @@ impl Drop for GrpcServeHandle {
     }
 }
 
-/// Serve a pre-built tonic [`Router`] until `signal` completes.
 pub async fn serve_with_shutdown(
     addr: SocketAddr,
     router: tonic::transport::server::Router,
@@ -238,9 +178,6 @@ pub async fn serve_with_shutdown(
     router.serve_with_shutdown(addr, signal).await
 }
 
-/// Spawn [`serve_with_shutdown`] and return a handle for graceful stop.
-///
-/// Build the router with [`server_builder`] + `add_service(...)` at the call site.
 pub fn spawn_with_shutdown(
     addr: SocketAddr,
     router: tonic::transport::server::Router,

--- a/src/common/grpc/mod.rs
+++ b/src/common/grpc/mod.rs
@@ -1,0 +1,255 @@
+//! Shared gRPC construction: limits, channel connect, server serve, typed factories.
+//!
+//! Call sites should use the factories in [`master`], [`worker`], [`storage`], and
+//! [`transport`] instead of `*Client::connect` / ad-hoc message-size setters.
+
+pub mod master;
+pub mod storage;
+pub mod stubs;
+pub mod transport;
+pub mod worker;
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+use tonic::transport::{Channel, Endpoint, Server};
+
+/// Max gRPC message size for control-plane and transport RPCs.
+///
+/// Must stay above the in-memory window checkpoint inline limit (8 MiB) so
+/// checkpoint/restore payloads are not rejected by tonic's 4 MiB default.
+pub const GRPC_MAX_MESSAGE_BYTES: usize = 12 * 1024 * 1024;
+
+/// Shared transport settings applied at client/server construction.
+#[derive(Debug, Clone)]
+pub struct GrpcConfig {
+    pub max_decoding_message_bytes: usize,
+    pub max_encoding_message_bytes: usize,
+    /// HTTP/2 max frame size for [`Server::builder`] (not the gRPC message limit).
+    pub max_frame_size: Option<u32>,
+    /// When set, applied via [`Endpoint::connect_timeout`].
+    ///
+    /// `None` matches historical `*Client::connect` (no dial deadline). Only set this
+    /// from profile `runtime_consts` at call sites that previously used an Endpoint timeout
+    /// (`master.worker_connect_timeout`, `worker.register_connect_timeout`).
+    pub connect_timeout: Option<Duration>,
+}
+
+impl GrpcConfig {
+    /// Message / frame size limits only — no dial timeout.
+    pub fn default_limits() -> Self {
+        Self {
+            max_decoding_message_bytes: GRPC_MAX_MESSAGE_BYTES,
+            max_encoding_message_bytes: GRPC_MAX_MESSAGE_BYTES,
+            max_frame_size: Some(GRPC_MAX_MESSAGE_BYTES as u32),
+            connect_timeout: None,
+        }
+    }
+
+    pub fn with_connect_timeout(mut self, connect_timeout: Duration) -> Self {
+        self.connect_timeout = Some(connect_timeout);
+        self
+    }
+
+    pub fn without_frame_size_limit(mut self) -> Self {
+        self.max_frame_size = None;
+        self
+    }
+}
+
+/// Retry policy for [`connect_with_retry`].
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    /// Total connection attempts (must be >= 1).
+    pub max_attempts: u32,
+    pub base_delay: Duration,
+    pub backoff: RetryBackoff,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum RetryBackoff {
+    /// Sleep `base_delay` between attempts.
+    Fixed,
+    /// Sleep `base_delay * attempt_number` (1-based) between attempts.
+    Linear,
+}
+
+impl RetryPolicy {
+    pub fn fixed(max_attempts: u32, base_delay: Duration) -> Self {
+        Self {
+            max_attempts: max_attempts.max(1),
+            base_delay,
+            backoff: RetryBackoff::Fixed,
+        }
+    }
+
+    pub fn linear(max_attempts: u32, base_delay: Duration) -> Self {
+        Self {
+            max_attempts: max_attempts.max(1),
+            base_delay,
+            backoff: RetryBackoff::Linear,
+        }
+    }
+
+    fn delay_for_attempt(&self, attempt: u32) -> Duration {
+        match self.backoff {
+            RetryBackoff::Fixed => self.base_delay,
+            RetryBackoff::Linear => self.base_delay.saturating_mul(attempt.saturating_add(1)),
+        }
+    }
+}
+
+/// Apply Volga message-size limits to a generated tonic client or server stub.
+pub trait WithMessageLimits: Sized {
+    fn with_message_limits(self) -> Self;
+}
+
+macro_rules! impl_client_message_limits {
+    ($($ty:ty),+ $(,)?) => {$(
+        impl WithMessageLimits for $ty {
+            fn with_message_limits(self) -> Self {
+                self.max_decoding_message_size(GRPC_MAX_MESSAGE_BYTES)
+                    .max_encoding_message_size(GRPC_MAX_MESSAGE_BYTES)
+            }
+        }
+    )+};
+}
+
+macro_rules! impl_server_message_limits {
+    ($($ty:ty),+ $(,)?) => {$(
+        impl<T> WithMessageLimits for $ty {
+            fn with_message_limits(self) -> Self {
+                self.max_decoding_message_size(GRPC_MAX_MESSAGE_BYTES)
+                    .max_encoding_message_size(GRPC_MAX_MESSAGE_BYTES)
+            }
+        }
+    )+};
+}
+
+impl_client_message_limits! {
+    stubs::master_service::master_service_client::MasterServiceClient<Channel>,
+    stubs::worker_service::worker_service_client::WorkerServiceClient<Channel>,
+    stubs::in_memory_storage_service::in_memory_storage_service_client::InMemoryStorageServiceClient<Channel>,
+    stubs::message_stream::message_stream_service_client::MessageStreamServiceClient<Channel>,
+}
+
+impl_server_message_limits! {
+    stubs::master_service::master_service_server::MasterServiceServer<T>,
+    stubs::worker_service::worker_service_server::WorkerServiceServer<T>,
+    stubs::in_memory_storage_service::in_memory_storage_service_server::InMemoryStorageServiceServer<T>,
+    stubs::message_stream::message_stream_service_server::MessageStreamServiceServer<T>,
+}
+
+fn normalize_endpoint(addr: &str) -> String {
+    if addr.starts_with("http://") || addr.starts_with("https://") {
+        addr.to_string()
+    } else {
+        format!("http://{addr}")
+    }
+}
+
+/// Dial a channel (single attempt). Applies `cfg.connect_timeout` when present.
+pub async fn connect(addr: &str, cfg: &GrpcConfig) -> Result<Channel, tonic::transport::Error> {
+    let mut endpoint = Endpoint::from_shared(normalize_endpoint(addr))?;
+    if let Some(timeout) = cfg.connect_timeout {
+        endpoint = endpoint.connect_timeout(timeout);
+    }
+    endpoint.connect().await
+}
+
+/// Dial with retries. `max_attempts` includes the first try.
+pub async fn connect_with_retry(
+    addr: &str,
+    cfg: &GrpcConfig,
+    retry: &RetryPolicy,
+) -> Result<Channel, tonic::transport::Error> {
+    let mut last_err = None;
+    for attempt in 0..retry.max_attempts {
+        match connect(addr, cfg).await {
+            Ok(channel) => return Ok(channel),
+            Err(e) => {
+                last_err = Some(e);
+                if attempt + 1 < retry.max_attempts {
+                    tokio::time::sleep(retry.delay_for_attempt(attempt)).await;
+                }
+            }
+        }
+    }
+    Err(last_err.expect("retry loop ran at least once"))
+}
+
+/// Build a tonic [`Server`] with optional HTTP/2 frame size from `cfg`.
+pub fn server_builder(cfg: &GrpcConfig) -> Server {
+    let mut builder = Server::builder();
+    if let Some(frame) = cfg.max_frame_size {
+        builder = builder.max_frame_size(Some(frame));
+    }
+    builder
+}
+
+/// Own a spawned serve task and its shutdown signal.
+pub struct GrpcServeHandle {
+    join: Option<JoinHandle<()>>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+impl GrpcServeHandle {
+    fn new(join: JoinHandle<()>, shutdown_tx: oneshot::Sender<()>) -> Self {
+        Self {
+            join: Some(join),
+            shutdown_tx: Some(shutdown_tx),
+        }
+    }
+
+    /// Signal shutdown and wait for the serve task to finish.
+    pub async fn stop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(join) = self.join.take() {
+            let _ = join.await;
+        }
+    }
+
+    /// Abort the serve task without graceful shutdown (used from `Drop`).
+    pub fn abort(&mut self) {
+        self.shutdown_tx.take();
+        if let Some(join) = self.join.take() {
+            join.abort();
+        }
+    }
+}
+
+impl Drop for GrpcServeHandle {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
+/// Serve a pre-built tonic [`Router`] until `signal` completes.
+pub async fn serve_with_shutdown(
+    addr: SocketAddr,
+    router: tonic::transport::server::Router,
+    signal: impl std::future::Future<Output = ()>,
+) -> Result<(), tonic::transport::Error> {
+    router.serve_with_shutdown(addr, signal).await
+}
+
+/// Spawn [`serve_with_shutdown`] and return a handle for graceful stop.
+///
+/// Build the router with [`server_builder`] + `add_service(...)` at the call site.
+pub fn spawn_with_shutdown(
+    addr: SocketAddr,
+    router: tonic::transport::server::Router,
+) -> GrpcServeHandle {
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    let join = tokio::spawn(async move {
+        let _ = serve_with_shutdown(addr, router, async {
+            let _ = shutdown_rx.await;
+        })
+        .await;
+    });
+    GrpcServeHandle::new(join, shutdown_tx)
+}

--- a/src/common/grpc/storage.rs
+++ b/src/common/grpc/storage.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+use tonic::transport::Channel;
+
+use super::stubs::in_memory_storage_service::in_memory_storage_service_client::InMemoryStorageServiceClient;
+use super::stubs::in_memory_storage_service::in_memory_storage_service_server::{
+    InMemoryStorageService, InMemoryStorageServiceServer,
+};
+use super::{connect_with_retry, GrpcConfig, RetryPolicy, WithMessageLimits};
+
+/// Historical inmem client defaults (not profile-driven): 5 attempts, linear 1s backoff.
+pub fn inmem_retry_policy() -> RetryPolicy {
+    RetryPolicy::linear(5, Duration::from_secs(1))
+}
+
+/// Limits only — no dial timeout (matches prior `InMemoryStorageServiceClient::connect`).
+pub fn storage_config() -> GrpcConfig {
+    GrpcConfig::default_limits()
+}
+
+pub fn storage_server<S>(svc: S) -> InMemoryStorageServiceServer<S>
+where
+    S: InMemoryStorageService,
+{
+    InMemoryStorageServiceServer::new(svc).with_message_limits()
+}
+
+pub async fn storage_client(
+    addr: &str,
+) -> Result<InMemoryStorageServiceClient<Channel>, tonic::transport::Error> {
+    storage_client_with_retry(addr, &storage_config(), &inmem_retry_policy()).await
+}
+
+pub async fn storage_client_with_retry(
+    addr: &str,
+    cfg: &GrpcConfig,
+    retry: &RetryPolicy,
+) -> Result<InMemoryStorageServiceClient<Channel>, tonic::transport::Error> {
+    let channel = connect_with_retry(addr, cfg, retry).await?;
+    Ok(InMemoryStorageServiceClient::new(channel).with_message_limits())
+}

--- a/src/common/grpc/storage.rs
+++ b/src/common/grpc/storage.rs
@@ -6,16 +6,10 @@ use super::stubs::in_memory_storage_service::in_memory_storage_service_client::I
 use super::stubs::in_memory_storage_service::in_memory_storage_service_server::{
     InMemoryStorageService, InMemoryStorageServiceServer,
 };
-use super::{connect_with_retry, GrpcConfig, RetryPolicy, WithMessageLimits};
+use super::{connect_with_retry, GrpcConfig, WithMessageLimits};
 
-/// Historical inmem client defaults (not profile-driven): 5 attempts, linear 1s backoff.
-pub fn inmem_retry_policy() -> RetryPolicy {
-    RetryPolicy::linear(5, Duration::from_secs(1))
-}
-
-/// Limits only — no dial timeout (matches prior `InMemoryStorageServiceClient::connect`).
-pub fn storage_config() -> GrpcConfig {
-    GrpcConfig::default_limits()
+pub fn storage() -> GrpcConfig {
+    GrpcConfig::new().with_retries(5, Duration::from_secs(1))
 }
 
 pub fn storage_server<S>(svc: S) -> InMemoryStorageServiceServer<S>
@@ -28,14 +22,6 @@ where
 pub async fn storage_client(
     addr: &str,
 ) -> Result<InMemoryStorageServiceClient<Channel>, tonic::transport::Error> {
-    storage_client_with_retry(addr, &storage_config(), &inmem_retry_policy()).await
-}
-
-pub async fn storage_client_with_retry(
-    addr: &str,
-    cfg: &GrpcConfig,
-    retry: &RetryPolicy,
-) -> Result<InMemoryStorageServiceClient<Channel>, tonic::transport::Error> {
-    let channel = connect_with_retry(addr, cfg, retry).await?;
+    let channel = connect_with_retry(addr, &storage()).await?;
     Ok(InMemoryStorageServiceClient::new(channel).with_message_limits())
 }

--- a/src/common/grpc/stubs.rs
+++ b/src/common/grpc/stubs.rs
@@ -1,0 +1,17 @@
+//! Generated tonic stubs. Include each proto exactly once here.
+
+pub mod master_service {
+    tonic::include_proto!("master_service");
+}
+
+pub mod worker_service {
+    tonic::include_proto!("worker_service");
+}
+
+pub mod in_memory_storage_service {
+    tonic::include_proto!("in_memory_storage_service");
+}
+
+pub mod message_stream {
+    tonic::include_proto!("message_stream");
+}

--- a/src/common/grpc/transport.rs
+++ b/src/common/grpc/transport.rs
@@ -8,22 +8,11 @@ use super::stubs::message_stream::message_stream_service_client::MessageStreamSe
 use super::stubs::message_stream::message_stream_service_server::{
     MessageStreamService, MessageStreamServiceServer,
 };
-use super::{connect_with_retry, GrpcConfig, RetryPolicy, WithMessageLimits};
+use super::{connect_with_retry, GrpcConfig, WithMessageLimits};
 
-/// Data-plane servers/clients: message limits only (no dial timeout; matches prior
-/// `MessageStreamServiceClient::connect`).
-pub fn transport_config() -> GrpcConfig {
-    GrpcConfig::default_limits()
-}
-
-/// `transport.grpc_connect_max_retries` / `transport.grpc_connect_retry_delay` per profile.
-///
-/// Historical `MessageStreamClient` treated max_retries as *additional* retries after the
-/// first try, so total attempts = max_retries + 1.
-pub fn transport_retry_policy() -> RetryPolicy {
-    let max_retries = runtime_consts().u64(TRANSPORT_GRPC_CONNECT_MAX_RETRIES) as u32;
-    RetryPolicy::fixed(
-        max_retries.saturating_add(1),
+pub fn transport() -> GrpcConfig {
+    GrpcConfig::new().with_retries(
+        runtime_consts().u64(TRANSPORT_GRPC_CONNECT_MAX_RETRIES) as u32,
         runtime_consts().duration(TRANSPORT_GRPC_CONNECT_RETRY_DELAY),
     )
 }
@@ -38,14 +27,6 @@ where
 pub async fn message_stream_client(
     addr: &str,
 ) -> Result<MessageStreamServiceClient<Channel>, tonic::transport::Error> {
-    message_stream_client_with_retry(addr, &transport_config(), &transport_retry_policy()).await
-}
-
-pub async fn message_stream_client_with_retry(
-    addr: &str,
-    cfg: &GrpcConfig,
-    retry: &RetryPolicy,
-) -> Result<MessageStreamServiceClient<Channel>, tonic::transport::Error> {
-    let channel = connect_with_retry(addr, cfg, retry).await?;
+    let channel = connect_with_retry(addr, &transport()).await?;
     Ok(MessageStreamServiceClient::new(channel).with_message_limits())
 }

--- a/src/common/grpc/transport.rs
+++ b/src/common/grpc/transport.rs
@@ -1,0 +1,51 @@
+use tonic::transport::Channel;
+
+use crate::runtime::consts::{
+    runtime_consts, TRANSPORT_GRPC_CONNECT_MAX_RETRIES, TRANSPORT_GRPC_CONNECT_RETRY_DELAY,
+};
+
+use super::stubs::message_stream::message_stream_service_client::MessageStreamServiceClient;
+use super::stubs::message_stream::message_stream_service_server::{
+    MessageStreamService, MessageStreamServiceServer,
+};
+use super::{connect_with_retry, GrpcConfig, RetryPolicy, WithMessageLimits};
+
+/// Data-plane servers/clients: message limits only (no dial timeout; matches prior
+/// `MessageStreamServiceClient::connect`).
+pub fn transport_config() -> GrpcConfig {
+    GrpcConfig::default_limits()
+}
+
+/// `transport.grpc_connect_max_retries` / `transport.grpc_connect_retry_delay` per profile.
+///
+/// Historical `MessageStreamClient` treated max_retries as *additional* retries after the
+/// first try, so total attempts = max_retries + 1.
+pub fn transport_retry_policy() -> RetryPolicy {
+    let max_retries = runtime_consts().u64(TRANSPORT_GRPC_CONNECT_MAX_RETRIES) as u32;
+    RetryPolicy::fixed(
+        max_retries.saturating_add(1),
+        runtime_consts().duration(TRANSPORT_GRPC_CONNECT_RETRY_DELAY),
+    )
+}
+
+pub fn message_stream_server<S>(svc: S) -> MessageStreamServiceServer<S>
+where
+    S: MessageStreamService,
+{
+    MessageStreamServiceServer::new(svc).with_message_limits()
+}
+
+pub async fn message_stream_client(
+    addr: &str,
+) -> Result<MessageStreamServiceClient<Channel>, tonic::transport::Error> {
+    message_stream_client_with_retry(addr, &transport_config(), &transport_retry_policy()).await
+}
+
+pub async fn message_stream_client_with_retry(
+    addr: &str,
+    cfg: &GrpcConfig,
+    retry: &RetryPolicy,
+) -> Result<MessageStreamServiceClient<Channel>, tonic::transport::Error> {
+    let channel = connect_with_retry(addr, cfg, retry).await?;
+    Ok(MessageStreamServiceClient::new(channel).with_message_limits())
+}

--- a/src/common/grpc/worker.rs
+++ b/src/common/grpc/worker.rs
@@ -1,37 +1,20 @@
-use std::time::Duration;
-
 use tonic::transport::Channel;
 
 use crate::runtime::consts::{
-    runtime_consts, MASTER_RESET_WORKER_TIMEOUT, MASTER_RPC_MAX_RETRIES, MASTER_RPC_RETRY_DELAY,
-    MASTER_WORKER_CONNECT_TIMEOUT,
+    runtime_consts, MASTER_RPC_MAX_RETRIES, MASTER_RPC_RETRY_DELAY, MASTER_WORKER_CONNECT_TIMEOUT,
 };
 
 use super::stubs::worker_service::worker_service_client::WorkerServiceClient;
 use super::stubs::worker_service::worker_service_server::{WorkerService, WorkerServiceServer};
-use super::{connect, connect_with_retry, GrpcConfig, RetryPolicy, WithMessageLimits};
+use super::{connect_with_retry, GrpcConfig, WithMessageLimits};
 
-/// Master → worker control-plane policy (dial + RPC retry + reset timeout).
-#[derive(Debug, Clone)]
-pub struct MasterToWorkerPolicy {
-    pub dial: GrpcConfig,
-    /// Retries for control RPCs / dial after connect (`master.rpc_*`).
-    pub rpc_retry: RetryPolicy,
-    pub reset_worker_timeout: Duration,
-}
-
-/// Profile knobs: `master.worker_connect_timeout`, `master.rpc_max_retries`,
-/// `master.rpc_retry_delay`, `master.reset_worker_timeout`.
-pub fn master_to_worker_policy() -> MasterToWorkerPolicy {
-    MasterToWorkerPolicy {
-        dial: GrpcConfig::default_limits()
-            .with_connect_timeout(runtime_consts().duration(MASTER_WORKER_CONNECT_TIMEOUT)),
-        rpc_retry: RetryPolicy::linear(
+pub fn master_to_worker() -> GrpcConfig {
+    GrpcConfig::new()
+        .with_connect_timeout(runtime_consts().duration(MASTER_WORKER_CONNECT_TIMEOUT))
+        .with_retries(
             runtime_consts().u64(MASTER_RPC_MAX_RETRIES) as u32,
             runtime_consts().duration(MASTER_RPC_RETRY_DELAY),
-        ),
-        reset_worker_timeout: runtime_consts().duration(MASTER_RESET_WORKER_TIMEOUT),
-    }
+        )
 }
 
 pub fn worker_server<S>(svc: S) -> WorkerServiceServer<S>
@@ -44,22 +27,6 @@ where
 pub async fn worker_client(
     addr: &str,
 ) -> Result<WorkerServiceClient<Channel>, tonic::transport::Error> {
-    worker_client_with_config(addr, &master_to_worker_policy().dial).await
-}
-
-pub async fn worker_client_with_config(
-    addr: &str,
-    cfg: &GrpcConfig,
-) -> Result<WorkerServiceClient<Channel>, tonic::transport::Error> {
-    let channel = connect(addr, cfg).await?;
-    Ok(WorkerServiceClient::new(channel).with_message_limits())
-}
-
-pub async fn worker_client_with_retry(
-    addr: &str,
-    cfg: &GrpcConfig,
-    retry: &RetryPolicy,
-) -> Result<WorkerServiceClient<Channel>, tonic::transport::Error> {
-    let channel = connect_with_retry(addr, cfg, retry).await?;
+    let channel = connect_with_retry(addr, &master_to_worker()).await?;
     Ok(WorkerServiceClient::new(channel).with_message_limits())
 }

--- a/src/common/grpc/worker.rs
+++ b/src/common/grpc/worker.rs
@@ -1,15 +1,37 @@
+use std::time::Duration;
+
 use tonic::transport::Channel;
 
-use crate::runtime::consts::{runtime_consts, MASTER_WORKER_CONNECT_TIMEOUT};
+use crate::runtime::consts::{
+    runtime_consts, MASTER_RESET_WORKER_TIMEOUT, MASTER_RPC_MAX_RETRIES, MASTER_RPC_RETRY_DELAY,
+    MASTER_WORKER_CONNECT_TIMEOUT,
+};
 
 use super::stubs::worker_service::worker_service_client::WorkerServiceClient;
 use super::stubs::worker_service::worker_service_server::{WorkerService, WorkerServiceServer};
 use super::{connect, connect_with_retry, GrpcConfig, RetryPolicy, WithMessageLimits};
 
-/// Master → worker control-plane dials (`master.worker_connect_timeout` per profile).
-pub fn master_to_worker_config() -> GrpcConfig {
-    GrpcConfig::default_limits()
-        .with_connect_timeout(runtime_consts().duration(MASTER_WORKER_CONNECT_TIMEOUT))
+/// Master → worker control-plane policy (dial + RPC retry + reset timeout).
+#[derive(Debug, Clone)]
+pub struct MasterToWorkerPolicy {
+    pub dial: GrpcConfig,
+    /// Retries for control RPCs / dial after connect (`master.rpc_*`).
+    pub rpc_retry: RetryPolicy,
+    pub reset_worker_timeout: Duration,
+}
+
+/// Profile knobs: `master.worker_connect_timeout`, `master.rpc_max_retries`,
+/// `master.rpc_retry_delay`, `master.reset_worker_timeout`.
+pub fn master_to_worker_policy() -> MasterToWorkerPolicy {
+    MasterToWorkerPolicy {
+        dial: GrpcConfig::default_limits()
+            .with_connect_timeout(runtime_consts().duration(MASTER_WORKER_CONNECT_TIMEOUT)),
+        rpc_retry: RetryPolicy::linear(
+            runtime_consts().u64(MASTER_RPC_MAX_RETRIES) as u32,
+            runtime_consts().duration(MASTER_RPC_RETRY_DELAY),
+        ),
+        reset_worker_timeout: runtime_consts().duration(MASTER_RESET_WORKER_TIMEOUT),
+    }
 }
 
 pub fn worker_server<S>(svc: S) -> WorkerServiceServer<S>
@@ -22,7 +44,7 @@ where
 pub async fn worker_client(
     addr: &str,
 ) -> Result<WorkerServiceClient<Channel>, tonic::transport::Error> {
-    worker_client_with_config(addr, &master_to_worker_config()).await
+    worker_client_with_config(addr, &master_to_worker_policy().dial).await
 }
 
 pub async fn worker_client_with_config(

--- a/src/common/grpc/worker.rs
+++ b/src/common/grpc/worker.rs
@@ -1,0 +1,43 @@
+use tonic::transport::Channel;
+
+use crate::runtime::consts::{runtime_consts, MASTER_WORKER_CONNECT_TIMEOUT};
+
+use super::stubs::worker_service::worker_service_client::WorkerServiceClient;
+use super::stubs::worker_service::worker_service_server::{WorkerService, WorkerServiceServer};
+use super::{connect, connect_with_retry, GrpcConfig, RetryPolicy, WithMessageLimits};
+
+/// Master → worker control-plane dials (`master.worker_connect_timeout` per profile).
+pub fn master_to_worker_config() -> GrpcConfig {
+    GrpcConfig::default_limits()
+        .with_connect_timeout(runtime_consts().duration(MASTER_WORKER_CONNECT_TIMEOUT))
+}
+
+pub fn worker_server<S>(svc: S) -> WorkerServiceServer<S>
+where
+    S: WorkerService,
+{
+    WorkerServiceServer::new(svc).with_message_limits()
+}
+
+pub async fn worker_client(
+    addr: &str,
+) -> Result<WorkerServiceClient<Channel>, tonic::transport::Error> {
+    worker_client_with_config(addr, &master_to_worker_config()).await
+}
+
+pub async fn worker_client_with_config(
+    addr: &str,
+    cfg: &GrpcConfig,
+) -> Result<WorkerServiceClient<Channel>, tonic::transport::Error> {
+    let channel = connect(addr, cfg).await?;
+    Ok(WorkerServiceClient::new(channel).with_message_limits())
+}
+
+pub async fn worker_client_with_retry(
+    addr: &str,
+    cfg: &GrpcConfig,
+    retry: &RetryPolicy,
+) -> Result<WorkerServiceClient<Channel>, tonic::transport::Error> {
+    let channel = connect_with_retry(addr, cfg, retry).await?;
+    Ok(WorkerServiceClient::new(channel).with_message_limits())
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,4 @@
+pub mod grpc;
 pub mod message;
 pub mod ports;
 #[cfg(test)]
@@ -5,6 +6,8 @@ pub mod test_utils;
 pub mod key;
 pub mod types;
 pub mod failure;
+
+pub use grpc::GRPC_MAX_MESSAGE_BYTES;
 
 pub use message::*;
 pub use key::Key;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -7,7 +7,7 @@ pub mod key;
 pub mod types;
 pub mod failure;
 
-pub use grpc::{GrpcConfig, GrpcServeHandle, RetryPolicy, GRPC_MAX_MESSAGE_BYTES};
+pub use grpc::{GrpcConfig, GrpcServeHandle, GRPC_MAX_MESSAGE_BYTES};
 
 pub use message::*;
 pub use key::Key;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -7,7 +7,7 @@ pub mod key;
 pub mod types;
 pub mod failure;
 
-pub use grpc::GRPC_MAX_MESSAGE_BYTES;
+pub use grpc::{GrpcConfig, GrpcServeHandle, RetryPolicy, GRPC_MAX_MESSAGE_BYTES};
 
 pub use message::*;
 pub use key::Key;

--- a/src/runtime/master/attempt/teardown.rs
+++ b/src/runtime/master/attempt/teardown.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use tokio::time::timeout;
 
-use crate::common::grpc::worker::master_to_worker_policy;
+use crate::runtime::consts::{runtime_consts, MASTER_RESET_WORKER_TIMEOUT};
 use crate::runtime::observability::StreamTaskStatus;
 
 use super::ExecutionAttempt;
@@ -17,7 +17,7 @@ impl ExecutionAttempt {
             .state
             .abort_in_flight_checkpoint(self.id, "recovering".to_string())
             .await;
-        let reset_timeout = master_to_worker_policy().reset_worker_timeout;
+        let reset_timeout = runtime_consts().duration(MASTER_RESET_WORKER_TIMEOUT);
         let reset_futures: Vec<_> = self
             .clients
             .drain()

--- a/src/runtime/master/attempt/teardown.rs
+++ b/src/runtime/master/attempt/teardown.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use tokio::time::timeout;
 
-use crate::runtime::consts::{runtime_consts, MASTER_RESET_WORKER_TIMEOUT};
+use crate::common::grpc::worker::master_to_worker_policy;
 use crate::runtime::observability::StreamTaskStatus;
 
 use super::ExecutionAttempt;
@@ -17,17 +17,14 @@ impl ExecutionAttempt {
             .state
             .abort_in_flight_checkpoint(self.id, "recovering".to_string())
             .await;
+        let reset_timeout = master_to_worker_policy().reset_worker_timeout;
         let reset_futures: Vec<_> = self
             .clients
             .drain()
             .map(|(worker_id, client)| async move {
                 (
                     worker_id,
-                    timeout(
-                        runtime_consts().duration(MASTER_RESET_WORKER_TIMEOUT),
-                        client.reset_worker(),
-                    )
-                    .await,
+                    timeout(reset_timeout, client.reset_worker()).await,
                 )
             })
             .collect();

--- a/src/runtime/master/mod.rs
+++ b/src/runtime/master/mod.rs
@@ -7,9 +7,8 @@ use crate::runtime::execution_graph::ExecutionGraph;
 use crate::runtime::master::checkpoint::TaskKey;
 use crate::runtime::observability::snapshot_types::PipelineSnapshot;
 
-pub mod worker_service {
-    tonic::include_proto!("worker_service");
-}
+/// Re-export generated stubs (single include lives in `common::grpc::stubs`).
+pub use crate::common::grpc::stubs::worker_service;
 
 pub mod checkpoint;
 pub mod events;

--- a/src/runtime/master/server.rs
+++ b/src/runtime/master/server.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 
 use super::service::MasterServiceImpl;
 use crate::common::grpc::{
-    master::{control_plane_config, master_server},
-    server_builder, spawn_with_shutdown, GrpcServeHandle,
+    master::master_server, server_builder, spawn_with_shutdown, GrpcServeHandle,
 };
 use crate::orchestrator::orchestrator::MasterOrchestrator;
 use crate::runtime::master::MasterConfig;
@@ -54,10 +53,9 @@ impl MasterServer {
 
         println!("[MASTER_SERVER] Starting MasterService server on {}", addr);
 
-        let cfg = control_plane_config();
         self.serve = Some(spawn_with_shutdown(
             addr,
-            server_builder(&cfg).add_service(service),
+            server_builder().add_service(service),
         ));
         Ok(())
     }

--- a/src/runtime/master/server.rs
+++ b/src/runtime/master/server.rs
@@ -50,7 +50,9 @@ impl MasterServer {
     pub async fn start(&mut self, addr: &str) -> anyhow::Result<()> {
         let addr = addr.parse()?;
         let service =
-            master_service::master_service_server::MasterServiceServer::new(self.service.clone());
+            master_service::master_service_server::MasterServiceServer::new(self.service.clone())
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[MASTER_SERVER] Starting MasterService server on {}", addr);
 

--- a/src/runtime/master/server.rs
+++ b/src/runtime/master/server.rs
@@ -1,27 +1,28 @@
 use std::sync::Arc;
 
 use super::service::MasterServiceImpl;
+use crate::common::grpc::{
+    master::{control_plane_config, master_server},
+    server_builder, spawn_with_shutdown, GrpcServeHandle,
+};
 use crate::orchestrator::orchestrator::MasterOrchestrator;
 use crate::runtime::master::MasterConfig;
 use crate::runtime::master::LifecycleEventRecord;
 
-pub mod master_service {
-    tonic::include_proto!("master_service");
-}
+/// Re-export generated stubs (single include lives in `common::grpc::stubs`).
+pub use crate::common::grpc::stubs::master_service;
 
 /// Server that hosts MasterService
 pub struct MasterServer {
     service: MasterServiceImpl,
-    server_handle: Option<tokio::task::JoinHandle<()>>,
-    shutdown_sender: Option<tokio::sync::oneshot::Sender<()>>,
+    serve: Option<GrpcServeHandle>,
 }
 
 impl MasterServer {
     pub fn new(orchestrator: Arc<dyn MasterOrchestrator>) -> Self {
         Self {
             service: MasterServiceImpl::new(orchestrator),
-            server_handle: None,
-            shutdown_sender: None,
+            serve: None,
         }
     }
 
@@ -49,42 +50,29 @@ impl MasterServer {
 
     pub async fn start(&mut self, addr: &str) -> anyhow::Result<()> {
         let addr = addr.parse()?;
-        let service =
-            master_service::master_service_server::MasterServiceServer::new(self.service.clone())
-                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
+        let service = master_server(self.service.clone());
 
         println!("[MASTER_SERVER] Starting MasterService server on {}", addr);
 
-        let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel::<()>();
-        let server_handle = tokio::spawn(async move {
-            let _ = tonic::transport::Server::builder()
-                .add_service(service)
-                .serve_with_shutdown(addr, async {
-                    shutdown_receiver.await.ok();
-                })
-                .await;
-        });
-
-        self.server_handle = Some(server_handle);
-        self.shutdown_sender = Some(shutdown_sender);
+        let cfg = control_plane_config();
+        self.serve = Some(spawn_with_shutdown(
+            addr,
+            server_builder(&cfg).add_service(service),
+        ));
         Ok(())
     }
 
     pub async fn stop(&mut self) {
-        if let Some(shutdown_sender) = self.shutdown_sender.take() {
-            let _ = shutdown_sender.send(());
-        }
-        if let Some(handle) = self.server_handle.take() {
-            let _ = handle.await;
+        if let Some(mut serve) = self.serve.take() {
+            serve.stop().await;
         }
     }
 }
 
 impl Drop for MasterServer {
     fn drop(&mut self) {
-        if let Some(handle) = self.server_handle.take() {
-            handle.abort();
+        if let Some(mut serve) = self.serve.take() {
+            serve.abort();
         }
     }
 }

--- a/src/runtime/master/worker_client.rs
+++ b/src/runtime/master/worker_client.rs
@@ -2,24 +2,22 @@ use std::fmt;
 
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
-use tonic::transport::Endpoint;
 use tonic::Code;
 
 use crate::api::PipelineSpec;
+use crate::common::failure::FailureEvent;
+use crate::common::grpc::worker::worker_client;
 use crate::orchestrator::task_assignment::TaskWorkerMapping;
 use crate::runtime::checkpoint::{SerializedRestore, TaskKey};
+use crate::runtime::consts::{runtime_consts, MASTER_RPC_MAX_RETRIES, MASTER_RPC_RETRY_DELAY};
 use crate::runtime::observability::snapshot_types::WorkerSnapshot;
 use crate::runtime::worker_config_utils::WorkerInitPayload;
-use crate::runtime::consts::{
-    runtime_consts, MASTER_RPC_MAX_RETRIES, MASTER_RPC_RETRY_DELAY, MASTER_WORKER_CONNECT_TIMEOUT,
-};
 
-use crate::common::failure::FailureEvent;
 use super::heartbeat::WorkerHeartbeatMonitor;
 use super::worker_service::{
-    worker_service_client::WorkerServiceClient, CloseWorkerTasksRequest, ResetWorkerRequest,
-    ShutdownWorkerRequest, StopSourcesRequest, ConfigureWorkerRequest, GetWorkerStateRequest,
-    RunWorkerTasksRequest, StartWorkerRequest, TaskRestoreData, TriggerCheckpointBarrierRequest,
+    worker_service_client::WorkerServiceClient, CloseWorkerTasksRequest, ConfigureWorkerRequest,
+    GetWorkerStateRequest, ResetWorkerRequest, RunWorkerTasksRequest, ShutdownWorkerRequest,
+    StartWorkerRequest, StopSourcesRequest, TaskRestoreData, TriggerCheckpointBarrierRequest,
 };
 
 enum Attempt<T> {
@@ -107,18 +105,8 @@ where
 pub(super) async fn connect_worker_client(
     addr: &str,
 ) -> Result<WorkerServiceClient<tonic::transport::Channel>, String> {
-    let connect_timeout = runtime_consts().duration(MASTER_WORKER_CONNECT_TIMEOUT);
-    let endpoint = Endpoint::from_shared(format!("http://{addr}"))
-        .map_err(|e| format!("invalid worker endpoint {addr}: {e}"))?
-        .connect_timeout(connect_timeout);
-    endpoint
-        .connect()
+    worker_client(addr)
         .await
-        .map(|channel| {
-            WorkerServiceClient::new(channel)
-                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-        })
         .map_err(|e| format!("connect to {addr} failed: {e}"))
 }
 

--- a/src/runtime/master/worker_client.rs
+++ b/src/runtime/master/worker_client.rs
@@ -1,15 +1,14 @@
 use std::fmt;
 
 use tokio::sync::mpsc;
-use tokio::time::{sleep, Duration};
+use tokio::time::sleep;
 use tonic::Code;
 
 use crate::api::PipelineSpec;
 use crate::common::failure::FailureEvent;
-use crate::common::grpc::worker::worker_client;
+use crate::common::grpc::worker::{master_to_worker_policy, worker_client};
 use crate::orchestrator::task_assignment::TaskWorkerMapping;
 use crate::runtime::checkpoint::{SerializedRestore, TaskKey};
-use crate::runtime::consts::{runtime_consts, MASTER_RPC_MAX_RETRIES, MASTER_RPC_RETRY_DELAY};
 use crate::runtime::observability::snapshot_types::WorkerSnapshot;
 use crate::runtime::worker_config_utils::WorkerInitPayload;
 
@@ -43,10 +42,6 @@ impl fmt::Display for WorkerCallError {
 
 impl std::error::Error for WorkerCallError {}
 
-fn retry_delay(attempt: u32) -> Duration {
-    runtime_consts().duration(MASTER_RPC_RETRY_DELAY) * (attempt + 1)
-}
-
 fn is_retryable_status(status: &tonic::Status) -> bool {
     matches!(
         status.code(),
@@ -75,8 +70,9 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Attempt<T>>,
 {
+    let retry = master_to_worker_policy().rpc_retry;
     let mut last_error = None;
-    for attempt in 0..runtime_consts().u64(MASTER_RPC_MAX_RETRIES) as u32 {
+    for attempt in 0..retry.max_attempts {
         match op().await {
             Attempt::Done(v) => return Ok(v),
             Attempt::Fail(e) => return Err(e),
@@ -89,15 +85,15 @@ where
                     msg
                 );
                 last_error = Some(msg);
-                if attempt + 1 < runtime_consts().u64(MASTER_RPC_MAX_RETRIES) as u32 {
-                    sleep(retry_delay(attempt)).await;
+                if attempt + 1 < retry.max_attempts {
+                    sleep(retry.delay_for_attempt(attempt)).await;
                 }
             }
         }
     }
     Err(WorkerCallError::Unreachable(format!(
         "{} failed on {} after {} attempts: {:?}",
-        op_name, target, runtime_consts().u64(MASTER_RPC_MAX_RETRIES), last_error
+        op_name, target, retry.max_attempts, last_error
     )))
 }
 

--- a/src/runtime/master/worker_client.rs
+++ b/src/runtime/master/worker_client.rs
@@ -114,7 +114,11 @@ pub(super) async fn connect_worker_client(
     endpoint
         .connect()
         .await
-        .map(WorkerServiceClient::new)
+        .map(|channel| {
+            WorkerServiceClient::new(channel)
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        })
         .map_err(|e| format!("connect to {addr} failed: {e}"))
 }
 

--- a/src/runtime/master/worker_client.rs
+++ b/src/runtime/master/worker_client.rs
@@ -6,7 +6,7 @@ use tonic::Code;
 
 use crate::api::PipelineSpec;
 use crate::common::failure::FailureEvent;
-use crate::common::grpc::worker::{master_to_worker_policy, worker_client};
+use crate::common::grpc::worker::{master_to_worker, worker_client};
 use crate::orchestrator::task_assignment::TaskWorkerMapping;
 use crate::runtime::checkpoint::{SerializedRestore, TaskKey};
 use crate::runtime::observability::snapshot_types::WorkerSnapshot;
@@ -70,9 +70,9 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Attempt<T>>,
 {
-    let retry = master_to_worker_policy().rpc_retry;
+    let cfg = master_to_worker();
     let mut last_error = None;
-    for attempt in 0..retry.max_attempts {
+    for attempt in 0..cfg.max_attempts {
         match op().await {
             Attempt::Done(v) => return Ok(v),
             Attempt::Fail(e) => return Err(e),
@@ -85,19 +85,18 @@ where
                     msg
                 );
                 last_error = Some(msg);
-                if attempt + 1 < retry.max_attempts {
-                    sleep(retry.delay_for_attempt(attempt)).await;
+                if attempt + 1 < cfg.max_attempts {
+                    sleep(cfg.retry_delay).await;
                 }
             }
         }
     }
     Err(WorkerCallError::Unreachable(format!(
         "{} failed on {} after {} attempts: {:?}",
-        op_name, target, retry.max_attempts, last_error
+        op_name, target, cfg.max_attempts, last_error
     )))
 }
 
-/// Dial worker control gRPC with a bounded connect timeout (see `MASTER_WORKER_CONNECT_TIMEOUT`).
 pub(super) async fn connect_worker_client(
     addr: &str,
 ) -> Result<WorkerServiceClient<tonic::transport::Channel>, String> {

--- a/src/runtime/operators/window/README.md
+++ b/src/runtime/operators/window/README.md
@@ -155,7 +155,7 @@ partitioning, publication, fencing, caching, and cleanup. They must preserve:
 uses one read lock as the WRO snapshot boundary, and embeds complete namespace
 snapshots, including durable triggers, in checkpoint data. Its live state
 remains process-local and is not a cross-worker backend. It is intended only
-for development and tests: inline checkpoint snapshots are limited to 3 MiB to
+for development and tests: inline checkpoint snapshots are limited to 8 MiB to
 stay below the gRPC control-plane message limit.
 
 ## Checkpoint and restore

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -22,7 +22,7 @@ use crate::runtime::operators::window::store::{
     KeyState, PartitionKey, StateNamespace, TileMap, WindowData,
 };
 
-const MAX_INLINE_CHECKPOINT_BYTES: usize = 3 * 1024 * 1024;
+const MAX_INLINE_CHECKPOINT_BYTES: usize = 8 * 1024 * 1024;
 
 fn validate_checkpoint_size(snapshot: &[u8]) -> Result<()> {
     anyhow::ensure!(
@@ -61,7 +61,7 @@ struct InMemState {
     triggers: BTreeSet<WindowTrigger>,
 }
 
-/// Development/test reference backend with inline checkpoints limited to 3 MiB.
+/// Development/test reference backend with inline checkpoints limited to 8 MiB.
 /// One read lock is the WRO snapshot boundary.
 #[derive(Debug, Clone, Default)]
 pub struct InMemWindowStore {
@@ -276,6 +276,13 @@ impl WindowOperatorStore for InMemWindowStore {
                 .collect(),
         };
         let snapshot = bincode::serialize(&checkpoint)?;
+        println!(
+            "[WINDOW][INMEM] checkpoint size={} bytes (limit={} bytes, partitions={}, triggers={})",
+            snapshot.len(),
+            MAX_INLINE_CHECKPOINT_BYTES,
+            checkpoint.partitions.len(),
+            checkpoint.triggers.len(),
+        );
         validate_checkpoint_size(&snapshot)?;
         Ok(WindowBackendSnapshot::InMemory { snapshot })
     }

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -32,6 +32,7 @@ use crate::transport::transport_client::TransportClient;
 use crate::common::message::{Message, WatermarkMessage};
 use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, Arc}, time::{Duration, SystemTime, UNIX_EPOCH}};
 // serde imports removed; this module does not define serializable DTOs directly.
+use crate::common::grpc::master::{control_plane_config, master_client as connect_master_client};
 use crate::runtime::master::server::master_service::master_service_client::MasterServiceClient;
 use std::sync::atomic::AtomicBool;
 use crate::runtime::VertexId;
@@ -540,21 +541,18 @@ impl StreamTask {
             }
 
             // Optional master client used for checkpoint reporting.
-            let mut master_client: Option<MasterServiceClient<tonic::transport::Channel>> = if let Some(master_addr) = master_addr {
-                let endpoint = format!("http://{}", master_addr);
-                Some(
-                    MasterServiceClient::connect(endpoint)
-                        .await
-                        .map(|client| {
-                            client
-                                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-                                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-                        })
-                        .map_err(|e| anyhow::anyhow!("Failed to connect to master service: {}", e))?,
-                )
-            } else {
-                None
-            };
+            let mut master_client: Option<MasterServiceClient<tonic::transport::Channel>> =
+                if let Some(master_addr) = master_addr {
+                    Some(
+                        connect_master_client(&master_addr, &control_plane_config())
+                            .await
+                            .map_err(|e| {
+                                anyhow::anyhow!("Failed to connect to master service: {}", e)
+                            })?,
+                    )
+                } else {
+                    None
+                };
 
             operator.open(&runtime_context).await?;
             println!("{:?} Operator {:?} opened with {} output edges", timestamp(), vertex_id, num_output_edges);

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -545,6 +545,11 @@ impl StreamTask {
                 Some(
                     MasterServiceClient::connect(endpoint)
                         .await
+                        .map(|client| {
+                            client
+                                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        })
                         .map_err(|e| anyhow::anyhow!("Failed to connect to master service: {}", e))?,
                 )
             } else {

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -32,7 +32,8 @@ use crate::transport::transport_client::TransportClient;
 use crate::common::message::{Message, WatermarkMessage};
 use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, Arc}, time::{Duration, SystemTime, UNIX_EPOCH}};
 // serde imports removed; this module does not define serializable DTOs directly.
-use crate::common::grpc::master::{control_plane_config, master_client as connect_master_client};
+use crate::common::grpc::master::master_client as connect_master_client;
+use crate::common::grpc::GrpcConfig;
 use crate::runtime::master::server::master_service::master_service_client::MasterServiceClient;
 use std::sync::atomic::AtomicBool;
 use crate::runtime::VertexId;
@@ -544,7 +545,7 @@ impl StreamTask {
             let mut master_client: Option<MasterServiceClient<tonic::transport::Channel>> =
                 if let Some(master_addr) = master_addr {
                     Some(
-                        connect_master_client(&master_addr, &control_plane_config())
+                        connect_master_client(&master_addr, &GrpcConfig::new())
                             .await
                             .map_err(|e| {
                                 anyhow::anyhow!("Failed to connect to master service: {}", e)

--- a/src/runtime/worker_server.rs
+++ b/src/runtime/worker_server.rs
@@ -8,7 +8,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
-use crate::common::grpc::master::{master_client, worker_register_config};
+use crate::common::grpc::master::{master_client, worker_register_policy};
 use crate::common::grpc::server_builder;
 use crate::common::grpc::spawn_with_shutdown;
 use crate::common::grpc::worker::worker_server;
@@ -18,7 +18,6 @@ use crate::orchestrator::orchestrator::WorkerOrchestrator;
 use crate::runtime::checkpoint::{SerializedRestore, TaskKey};
 use crate::runtime::consts::{
     runtime_consts, WORKER_HEARTBEAT_MASTER_SILENCE_TIMEOUT, WORKER_HEARTBEAT_SEND_INTERVAL,
-    WORKER_REGISTER_MAX_RETRIES, WORKER_REGISTER_RETRY_DELAY, WORKER_REGISTER_RPC_TIMEOUT,
 };
 use crate::runtime::health::WorkerFatalReason;
 use crate::runtime::operators::operator::operator_config_requires_checkpoint;
@@ -516,10 +515,7 @@ impl WorkerServer {
     }
 
     pub async fn register_with_master(&mut self) -> anyhow::Result<()> {
-        let max_retries = runtime_consts().u64(WORKER_REGISTER_MAX_RETRIES) as u32;
-        let retry_delay = runtime_consts().duration(WORKER_REGISTER_RETRY_DELAY);
-        let rpc_timeout = runtime_consts().duration(WORKER_REGISTER_RPC_TIMEOUT);
-        let cfg = worker_register_config();
+        let policy = worker_register_policy();
 
         let master_addr = self.orchestrator.get_master_service_addr().await;
         if master_addr.is_empty() {
@@ -534,15 +530,15 @@ impl WorkerServer {
             self.worker_id, master_addr
         );
         let mut last_err: Option<anyhow::Error> = None;
-        for attempt in 0..max_retries {
+        for attempt in 0..policy.retry.max_attempts {
             let req = crate::runtime::master::server::master_service::RegisterWorkerRequest {
                 worker_id: self.worker_id.clone(),
                 ..Default::default()
             };
 
-            match master_client(&master_addr, &cfg).await {
+            match master_client(&master_addr, &policy.dial).await {
                 Ok(mut client) => match tokio::time::timeout(
-                    rpc_timeout,
+                    policy.rpc_timeout,
                     client.register_worker(tonic::Request::new(req)),
                 )
                 .await
@@ -572,7 +568,7 @@ impl WorkerServer {
                         last_err = Some(anyhow::anyhow!(
                             "register_worker RPC timeout on attempt {} after {:?}: {}",
                             attempt + 1,
-                            rpc_timeout,
+                            policy.rpc_timeout,
                             e
                         ));
                     }
@@ -586,14 +582,14 @@ impl WorkerServer {
                 }
             }
 
-            if attempt + 1 < max_retries {
+            if attempt + 1 < policy.retry.max_attempts {
                 println!(
                     "[WORKER_SERVER] Registration retry: worker_id={} attempt={}/{}",
                     self.worker_id,
                     attempt + 1,
-                    max_retries
+                    policy.retry.max_attempts
                 );
-                tokio::time::sleep(retry_delay.saturating_mul(attempt as u32 + 1)).await;
+                tokio::time::sleep(policy.retry.delay_for_attempt(attempt)).await;
             }
         }
 

--- a/src/runtime/worker_server.rs
+++ b/src/runtime/worker_server.rs
@@ -8,11 +8,11 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
-use crate::common::grpc::master::{master_client, worker_register_policy};
+use crate::common::grpc::master::{master_client, worker_register};
 use crate::common::grpc::server_builder;
 use crate::common::grpc::spawn_with_shutdown;
 use crate::common::grpc::worker::worker_server;
-use crate::common::grpc::{GrpcConfig, GrpcServeHandle};
+use crate::common::grpc::GrpcServeHandle;
 use crate::common::types::PipelineId;
 use crate::orchestrator::orchestrator::WorkerOrchestrator;
 use crate::runtime::checkpoint::{SerializedRestore, TaskKey};
@@ -506,16 +506,18 @@ impl WorkerServer {
 
         println!("[WORKER_SERVER] Starting WorkerService server on {}", addr);
 
-        let cfg = GrpcConfig::default_limits();
         self.serve = Some(spawn_with_shutdown(
             addr,
-            server_builder(&cfg).add_service(service),
+            server_builder().add_service(service),
         ));
         Ok(())
     }
 
     pub async fn register_with_master(&mut self) -> anyhow::Result<()> {
-        let policy = worker_register_policy();
+        let cfg = worker_register();
+        let rpc_timeout = cfg
+            .rpc_timeout
+            .expect("worker_register config sets rpc_timeout");
 
         let master_addr = self.orchestrator.get_master_service_addr().await;
         if master_addr.is_empty() {
@@ -530,15 +532,18 @@ impl WorkerServer {
             self.worker_id, master_addr
         );
         let mut last_err: Option<anyhow::Error> = None;
-        for attempt in 0..policy.retry.max_attempts {
+        for attempt in 0..cfg.max_attempts {
             let req = crate::runtime::master::server::master_service::RegisterWorkerRequest {
                 worker_id: self.worker_id.clone(),
                 ..Default::default()
             };
 
-            match master_client(&master_addr, &policy.dial).await {
+            // Single dial attempt per outer loop iteration (connect_timeout from cfg).
+            let mut dial = cfg.clone();
+            dial.max_attempts = 1;
+            match master_client(&master_addr, &dial).await {
                 Ok(mut client) => match tokio::time::timeout(
-                    policy.rpc_timeout,
+                    rpc_timeout,
                     client.register_worker(tonic::Request::new(req)),
                 )
                 .await
@@ -568,7 +573,7 @@ impl WorkerServer {
                         last_err = Some(anyhow::anyhow!(
                             "register_worker RPC timeout on attempt {} after {:?}: {}",
                             attempt + 1,
-                            policy.rpc_timeout,
+                            rpc_timeout,
                             e
                         ));
                     }
@@ -582,14 +587,14 @@ impl WorkerServer {
                 }
             }
 
-            if attempt + 1 < policy.retry.max_attempts {
+            if attempt + 1 < cfg.max_attempts {
                 println!(
                     "[WORKER_SERVER] Registration retry: worker_id={} attempt={}/{}",
                     self.worker_id,
                     attempt + 1,
-                    policy.retry.max_attempts
+                    cfg.max_attempts
                 );
-                tokio::time::sleep(policy.retry.delay_for_attempt(attempt)).await;
+                tokio::time::sleep(cfg.retry_delay).await;
             }
         }
 

--- a/src/runtime/worker_server.rs
+++ b/src/runtime/worker_server.rs
@@ -1,43 +1,44 @@
-use tonic::{Request, Response, Status};
-use tonic::transport::Endpoint;
-use std::sync::Arc;
-use std::pin::Pin;
 use std::collections::{HashMap, HashSet};
-use tokio::sync::Mutex;
+use std::pin::Pin;
+use std::sync::Arc;
+
 use tokio::sync::oneshot;
+use tokio::sync::Mutex;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
 
-use crate::orchestrator::orchestrator::WorkerOrchestrator;
+use crate::common::grpc::master::{master_client, worker_register_config};
+use crate::common::grpc::server_builder;
+use crate::common::grpc::spawn_with_shutdown;
+use crate::common::grpc::worker::worker_server;
+use crate::common::grpc::{GrpcConfig, GrpcServeHandle};
 use crate::common::types::PipelineId;
+use crate::orchestrator::orchestrator::WorkerOrchestrator;
 use crate::runtime::checkpoint::{SerializedRestore, TaskKey};
 use crate::runtime::consts::{
     runtime_consts, WORKER_HEARTBEAT_MASTER_SILENCE_TIMEOUT, WORKER_HEARTBEAT_SEND_INTERVAL,
-    WORKER_REGISTER_CONNECT_TIMEOUT, WORKER_REGISTER_MAX_RETRIES, WORKER_REGISTER_RETRY_DELAY,
-    WORKER_REGISTER_RPC_TIMEOUT,
+    WORKER_REGISTER_MAX_RETRIES, WORKER_REGISTER_RETRY_DELAY, WORKER_REGISTER_RPC_TIMEOUT,
 };
 use crate::runtime::health::WorkerFatalReason;
-use crate::runtime::master::server::master_service::master_service_client::MasterServiceClient;
 use crate::runtime::operators::operator::operator_config_requires_checkpoint;
-use crate::runtime::worker_config_utils::{build_execution_graph, resolve_num_threads_per_task, resolve_transport_backend_type, WorkerInitPayload};
 use crate::runtime::worker::{Worker, WorkerConfig};
+use crate::runtime::worker_config_utils::{
+    build_execution_graph, resolve_num_threads_per_task, resolve_transport_backend_type,
+    WorkerInitPayload,
+};
 
-pub mod worker_service {
-    tonic::include_proto!("worker_service");
-}
+/// Re-export generated stubs (single include lives in `common::grpc::stubs`).
+pub use crate::common::grpc::stubs::worker_service;
 
 use worker_service::{
-    worker_service_server::WorkerService,
-    ConfigureWorkerRequest, ConfigureWorkerResponse,
-    GetWorkerStateRequest, GetWorkerStateResponse,
-    StartWorkerRequest, StartWorkerResponse,
-    RunWorkerTasksRequest, RunWorkerTasksResponse,
-    CloseWorkerTasksRequest, CloseWorkerTasksResponse,
-    ResetWorkerRequest, ResetWorkerResponse, ShutdownWorkerRequest, ShutdownWorkerResponse,
-    TriggerCheckpointBarrierRequest, TriggerCheckpointBarrierResponse,
-    StopSourcesRequest, StopSourcesResponse,
-    MasterHeartbeatMessage, WorkerHeartbeatMessage,
-    WorkerFatalReason as WorkerFatalReasonProto,
+    worker_service_server::WorkerService, CloseWorkerTasksRequest, CloseWorkerTasksResponse,
+    ConfigureWorkerRequest, ConfigureWorkerResponse, GetWorkerStateRequest, GetWorkerStateResponse,
+    MasterHeartbeatMessage, ResetWorkerRequest, ResetWorkerResponse, RunWorkerTasksRequest,
+    RunWorkerTasksResponse, ShutdownWorkerRequest, ShutdownWorkerResponse, StartWorkerRequest,
+    StartWorkerResponse, StopSourcesRequest, StopSourcesResponse, TriggerCheckpointBarrierRequest,
+    TriggerCheckpointBarrierResponse, WorkerFatalReason as WorkerFatalReasonProto,
+    WorkerHeartbeatMessage,
 };
 
 /// Server implementation of the WorkerService
@@ -477,7 +478,7 @@ impl WorkerService for WorkerServiceImpl {
 /// Server that hosts the WorkerService
 pub struct WorkerServer {
     service: WorkerServiceImpl,
-    server_handle: Option<tokio::task::JoinHandle<()>>,
+    serve: Option<GrpcServeHandle>,
     close_worker_rx: Option<oneshot::Receiver<()>>,
     worker_id: String,
     orchestrator: Arc<dyn WorkerOrchestrator>,
@@ -493,7 +494,7 @@ impl WorkerServer {
                 orchestrator.clone(),
                 close_worker_notify,
             ),
-            server_handle: None,
+            serve: None,
             close_worker_rx: Some(close_worker_rx),
             worker_id,
             orchestrator,
@@ -502,31 +503,23 @@ impl WorkerServer {
 
     pub async fn start(&mut self, addr: &str) -> anyhow::Result<()> {
         let addr = addr.parse()?;
-        let service = worker_service::worker_service_server::WorkerServiceServer::new(
-            self.service.clone()
-        )
-        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
+        let service = worker_server(self.service.clone());
 
         println!("[WORKER_SERVER] Starting WorkerService server on {}", addr);
-        
-        let server_handle = tokio::spawn(async move {
-            tonic::transport::Server::builder()
-                .add_service(service)
-                .serve(addr)
-                .await
-                .unwrap();
-        });
 
-        self.server_handle = Some(server_handle);
+        let cfg = GrpcConfig::default_limits();
+        self.serve = Some(spawn_with_shutdown(
+            addr,
+            server_builder(&cfg).add_service(service),
+        ));
         Ok(())
     }
 
     pub async fn register_with_master(&mut self) -> anyhow::Result<()> {
         let max_retries = runtime_consts().u64(WORKER_REGISTER_MAX_RETRIES) as u32;
         let retry_delay = runtime_consts().duration(WORKER_REGISTER_RETRY_DELAY);
-        let connect_timeout = runtime_consts().duration(WORKER_REGISTER_CONNECT_TIMEOUT);
         let rpc_timeout = runtime_consts().duration(WORKER_REGISTER_RPC_TIMEOUT);
+        let cfg = worker_register_config();
 
         let master_addr = self.orchestrator.get_master_service_addr().await;
         if master_addr.is_empty() {
@@ -540,8 +533,6 @@ impl WorkerServer {
             "[WORKER_SERVER] Registering with master: worker_id={} master_addr={}",
             self.worker_id, master_addr
         );
-        let endpoint = format!("http://{}", master_addr);
-        let endpoint = Endpoint::from_shared(endpoint)?.connect_timeout(connect_timeout);
         let mut last_err: Option<anyhow::Error> = None;
         for attempt in 0..max_retries {
             let req = crate::runtime::master::server::master_service::RegisterWorkerRequest {
@@ -549,13 +540,10 @@ impl WorkerServer {
                 ..Default::default()
             };
 
-            match endpoint.clone().connect().await {
-                Ok(channel) => match tokio::time::timeout(
+            match master_client(&master_addr, &cfg).await {
+                Ok(mut client) => match tokio::time::timeout(
                     rpc_timeout,
-                    MasterServiceClient::new(channel)
-                        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-                        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-                        .register_worker(tonic::Request::new(req)),
+                    client.register_worker(tonic::Request::new(req)),
                 )
                 .await
                 {
@@ -609,11 +597,13 @@ impl WorkerServer {
             }
         }
 
-        Err(last_err.unwrap_or_else(|| anyhow::anyhow!(
-            "Failed to register worker {} to master {} for unknown reason",
-            self.worker_id,
-            master_addr
-        )))
+        Err(last_err.unwrap_or_else(|| {
+            anyhow::anyhow!(
+                "Failed to register worker {} to master {} for unknown reason",
+                self.worker_id,
+                master_addr
+            )
+        }))
     }
 
     pub async fn wait_for_close_request(&mut self) {
@@ -632,9 +622,8 @@ impl WorkerServer {
             let mut worker_guard = self.service.worker.lock().await;
             worker_guard.close();
         }
-        if let Some(handle) = self.server_handle.take() {
-            handle.abort();
-            let _ = handle.await;
+        if let Some(mut serve) = self.serve.take() {
+            serve.stop().await;
         }
         println!("[WORKER_SERVER] WorkerService server stopped");
     }
@@ -661,9 +650,8 @@ impl WorkerServer {
                 .health()
                 .report_fatal(WorkerFatalReason::Panic, "local test worker crash");
         }
-        if let Some(handle) = self.server_handle.take() {
-            handle.abort();
-            let _ = handle.await;
+        if let Some(mut serve) = self.serve.take() {
+            serve.abort();
         }
         let mut worker = self.service.worker.lock().await;
         worker.close();
@@ -672,8 +660,8 @@ impl WorkerServer {
 
 impl Drop for WorkerServer {
     fn drop(&mut self) {
-        if let Some(handle) = self.server_handle.take() {
-            handle.abort();
+        if let Some(mut serve) = self.serve.take() {
+            serve.abort();
         }
     }
 }

--- a/src/runtime/worker_server.rs
+++ b/src/runtime/worker_server.rs
@@ -504,7 +504,9 @@ impl WorkerServer {
         let addr = addr.parse()?;
         let service = worker_service::worker_service_server::WorkerServiceServer::new(
             self.service.clone()
-        );
+        )
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[WORKER_SERVER] Starting WorkerService server on {}", addr);
         
@@ -550,7 +552,10 @@ impl WorkerServer {
             match endpoint.clone().connect().await {
                 Ok(channel) => match tokio::time::timeout(
                     rpc_timeout,
-                    MasterServiceClient::new(channel).register_worker(tonic::Request::new(req)),
+                    MasterServiceClient::new(channel)
+                        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .register_worker(tonic::Request::new(req)),
                 )
                 .await
                 {

--- a/src/storage/in_memory_storage_grpc_client.rs
+++ b/src/storage/in_memory_storage_grpc_client.rs
@@ -40,8 +40,8 @@ impl InMemoryStorageClient {
                 Ok(client) => {
                     println!("[IN_MEMORY_STORAGE_CLIENT] Successfully connected to {} on attempt {}", addr, attempt + 1);
                     let client = client
-                        .max_decoding_message_size(12*1024*1024)
-                        .max_encoding_message_size(12*1024*1024); // 12 MB
+                        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
                     
                     return Ok(Self { client });
                 }

--- a/src/storage/in_memory_storage_grpc_client.rs
+++ b/src/storage/in_memory_storage_grpc_client.rs
@@ -1,24 +1,19 @@
-use tonic::transport::Channel;
 use std::collections::HashMap;
-use crate::common::message::Message;
-use super::in_memory_storage_snapshot::InMemoryStorageSnapshot;
-use anyhow::Result;
-use tokio::time::{Duration, sleep};
 
-pub mod in_memory_storage_service {
-    tonic::include_proto!("in_memory_storage_service");
-}
+use anyhow::Result;
+use tonic::transport::Channel;
+
+use crate::common::grpc::storage::storage_client;
+use crate::common::message::Message;
+
+use super::in_memory_storage_snapshot::InMemoryStorageSnapshot;
+
+pub use crate::common::grpc::stubs::in_memory_storage_service;
 
 use in_memory_storage_service::{
-    in_memory_storage_service_client::InMemoryStorageServiceClient,
-    AppendRequest,
-    AppendManyRequest,
-    InsertRequest,
-    InsertKeyedManyRequest,
-    GetVectorRequest,
-    GetMapRequest,
-    DrainVectorRequest,
-    DrainMapRequest,
+    in_memory_storage_service_client::InMemoryStorageServiceClient, AppendManyRequest,
+    AppendRequest, DrainMapRequest, DrainVectorRequest, GetMapRequest, GetVectorRequest,
+    InsertKeyedManyRequest, InsertRequest,
 };
 
 /// Client for the InMemoryStorageService
@@ -30,39 +25,11 @@ pub struct InMemoryStorageClient {
 impl InMemoryStorageClient {
     /// Create a new client connected to the specified address with retry logic
     pub async fn new(addr: String) -> Result<Self> {
-        const MAX_RETRIES: u32 = 5;
-        const RETRY_DELAY_MS: u64 = 1000;
-        
-        let mut last_error = None;
-        
-        for attempt in 0..MAX_RETRIES {
-            match InMemoryStorageServiceClient::connect(addr.clone()).await {
-                Ok(client) => {
-                    println!("[IN_MEMORY_STORAGE_CLIENT] Successfully connected to {} on attempt {}", addr, attempt + 1);
-                    let client = client
-                        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-                        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
-                    
-                    return Ok(Self { client });
-                }
-                Err(e) => {
-                    last_error = Some(e.to_string());
-                    println!("[IN_MEMORY_STORAGE_CLIENT] Connection attempt {} failed: {}", attempt + 1, e);
-                    
-                    // Don't sleep on the last attempt
-                    if attempt < MAX_RETRIES - 1 {
-                        sleep(Duration::from_millis(RETRY_DELAY_MS * (attempt + 1) as u64)).await;
-                    }
-                }
-            }
-        }
-        
-        Err(anyhow::anyhow!(
-            "Failed to connect to {} after {} attempts. Last error: {:?}", 
-            addr, 
-            MAX_RETRIES, 
-            last_error
-        ))
+        let client = storage_client(&addr).await.map_err(|e| {
+            anyhow::anyhow!("Failed to connect to in-memory storage at {addr}: {e}")
+        })?;
+        println!("[IN_MEMORY_STORAGE_CLIENT] Successfully connected to {addr}");
+        Ok(Self { client })
     }
 
     /// Append a single message to vector storage

--- a/src/storage/in_memory_storage_grpc_server.rs
+++ b/src/storage/in_memory_storage_grpc_server.rs
@@ -1,23 +1,22 @@
-use tonic::{Request, Response, Status};
 use std::collections::HashMap;
 use std::sync::Arc;
+
 use tokio::sync::Mutex;
+use tonic::{Request, Response, Status};
+
+use crate::common::grpc::server_builder;
+use crate::common::grpc::spawn_with_shutdown;
+use crate::common::grpc::storage::storage_server;
+use crate::common::grpc::{GrpcConfig, GrpcServeHandle};
 use crate::common::message::Message;
 
-pub mod in_memory_storage_service {
-    tonic::include_proto!("in_memory_storage_service");
-}
+pub use crate::common::grpc::stubs::in_memory_storage_service;
 
 use in_memory_storage_service::{
-    in_memory_storage_service_server::InMemoryStorageService,
-    AppendRequest, AppendResponse,
-    AppendManyRequest, AppendManyResponse,
-    InsertRequest, InsertResponse,
-    InsertKeyedManyRequest, InsertKeyedManyResponse,
-    GetVectorRequest, GetVectorResponse,
-    GetMapRequest, GetMapResponse,
-    DrainVectorRequest, DrainVectorResponse,
-    DrainMapRequest, DrainMapResponse,
+    in_memory_storage_service_server::InMemoryStorageService, AppendManyRequest, AppendManyResponse,
+    AppendRequest, AppendResponse, DrainMapRequest, DrainMapResponse, DrainVectorRequest,
+    DrainVectorResponse, GetMapRequest, GetMapResponse, GetVectorRequest, GetVectorResponse,
+    InsertKeyedManyRequest, InsertKeyedManyResponse, InsertRequest, InsertResponse,
 };
 
 /// Server implementation of the InMemoryStorageService
@@ -198,75 +197,46 @@ impl InMemoryStorageService for InMemoryStorageServiceImpl {
 /// Server that hosts the InMemoryStorageService
 pub struct InMemoryStorageServer {
     service: InMemoryStorageServiceImpl,
-    server_handle: Option<tokio::task::JoinHandle<()>>,
-    shutdown_sender: Option<tokio::sync::oneshot::Sender<()>>,
+    serve: Option<GrpcServeHandle>,
 }
 
 impl InMemoryStorageServer {
     pub fn new() -> Self {
         Self {
             service: InMemoryStorageServiceImpl::new(),
-            server_handle: None,
-            shutdown_sender: None,
+            serve: None,
         }
     }
 
     /// Start the gRPC server on the specified address
     pub async fn start(&mut self, addr: &str) -> anyhow::Result<()> {
         let addr = addr.parse()?;
-        let service = in_memory_storage_service::in_memory_storage_service_server::InMemoryStorageServiceServer::new(
-            self.service.clone()
-        )
-        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
+        let service = storage_server(self.service.clone());
 
-        println!("[IN_MEMORY_STORAGE_SERVER] Starting InMemoryStorageService server on {}", addr);
-        
-        // Create shutdown channel
-        let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel::<()>();
-        
-        let server_handle = tokio::spawn(async move {
-            match tonic::transport::Server::builder()
-                .max_frame_size(Some(crate::common::GRPC_MAX_MESSAGE_BYTES as u32))
-                .add_service(service)
-                .serve_with_shutdown(addr, async {
-                    shutdown_receiver.await.ok();
-                    println!("[IN_MEMORY_STORAGE_SERVER] Received shutdown signal");
-                })
-                .await {
-                Ok(_) => println!("[IN_MEMORY_STORAGE_SERVER] Server shutdown gracefully"),
-                Err(e) => eprintln!("[IN_MEMORY_STORAGE_SERVER] Server error: {}", e),
-            }
-        });
+        println!("[IN_MEMORY_STORAGE_SERVER] Starting InMemoryStorageService server on {addr}");
 
-        self.server_handle = Some(server_handle);
-        self.shutdown_sender = Some(shutdown_sender);
+        let cfg = GrpcConfig::default_limits();
+        self.serve = Some(spawn_with_shutdown(
+            addr,
+            server_builder(&cfg).add_service(service),
+        ));
         Ok(())
     }
 
     /// Stop the gRPC server gracefully
     pub async fn stop(&mut self) {
-        // First, send shutdown signal for graceful shutdown
-        if let Some(shutdown_sender) = self.shutdown_sender.take() {
+        if let Some(mut serve) = self.serve.take() {
             println!("[IN_MEMORY_STORAGE_SERVER] Sending graceful shutdown signal...");
-            let _ = shutdown_sender.send(());
-        }
-        
-        // Then wait for the server to finish
-        if let Some(handle) = self.server_handle.take() {
-            match handle.await {
-                Ok(_) => println!("[IN_MEMORY_STORAGE_SERVER] Server stopped gracefully"),
-                Err(e) if e.is_cancelled() => println!("[IN_MEMORY_STORAGE_SERVER] Server stopped (cancelled)"),
-                Err(e) => eprintln!("[IN_MEMORY_STORAGE_SERVER] Server stopped with error: {}", e),
-            }
+            serve.stop().await;
+            println!("[IN_MEMORY_STORAGE_SERVER] Server stopped gracefully");
         }
     }
 }
 
 impl Drop for InMemoryStorageServer {
     fn drop(&mut self) {
-        if let Some(handle) = self.server_handle.take() {
-            handle.abort();
+        if let Some(mut serve) = self.serve.take() {
+            serve.abort();
         }
     }
 }

--- a/src/storage/in_memory_storage_grpc_server.rs
+++ b/src/storage/in_memory_storage_grpc_server.rs
@@ -7,7 +7,7 @@ use tonic::{Request, Response, Status};
 use crate::common::grpc::server_builder;
 use crate::common::grpc::spawn_with_shutdown;
 use crate::common::grpc::storage::storage_server;
-use crate::common::grpc::{GrpcConfig, GrpcServeHandle};
+use crate::common::grpc::GrpcServeHandle;
 use crate::common::message::Message;
 
 pub use crate::common::grpc::stubs::in_memory_storage_service;
@@ -215,10 +215,9 @@ impl InMemoryStorageServer {
 
         println!("[IN_MEMORY_STORAGE_SERVER] Starting InMemoryStorageService server on {addr}");
 
-        let cfg = GrpcConfig::default_limits();
         self.serve = Some(spawn_with_shutdown(
             addr,
-            server_builder(&cfg).add_service(service),
+            server_builder().add_service(service),
         ));
         Ok(())
     }

--- a/src/storage/in_memory_storage_grpc_server.rs
+++ b/src/storage/in_memory_storage_grpc_server.rs
@@ -216,7 +216,9 @@ impl InMemoryStorageServer {
         let addr = addr.parse()?;
         let service = in_memory_storage_service::in_memory_storage_service_server::InMemoryStorageServiceServer::new(
             self.service.clone()
-        );
+        )
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
         println!("[IN_MEMORY_STORAGE_SERVER] Starting InMemoryStorageService server on {}", addr);
         
@@ -225,7 +227,7 @@ impl InMemoryStorageServer {
         
         let server_handle = tokio::spawn(async move {
             match tonic::transport::Server::builder()
-                .max_frame_size(Some(12 * 1024 * 1024)) // 12MB
+                .max_frame_size(Some(crate::common::GRPC_MAX_MESSAGE_BYTES as u32))
                 .add_service(service)
                 .serve_with_shutdown(addr, async {
                     shutdown_receiver.await.ok();

--- a/src/tests/inprocess/transport/grpc_streaming.rs
+++ b/src/tests/inprocess/transport/grpc_streaming.rs
@@ -20,7 +20,9 @@ pub async fn start_server(
     println!("[SERVER] Starting gRPC server on {}", addr);
     let addr = addr.parse()?;
     let service = MessageStreamServiceImpl::new(tx);
-    let svc = MessageStreamServiceServer::new(service);
+    let svc = MessageStreamServiceServer::new(service)
+        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
     println!("[SERVER] gRPC server listening on {}", addr);
     let router = Server::builder().add_service(svc);

--- a/src/tests/inprocess/transport/grpc_streaming.rs
+++ b/src/tests/inprocess/transport/grpc_streaming.rs
@@ -1,6 +1,6 @@
 use crate::common::grpc::server_builder;
 use crate::common::grpc::serve_with_shutdown;
-use crate::common::grpc::transport::{message_stream_server, transport_config};
+use crate::common::grpc::transport::message_stream_server;
 use crate::common::key::Key;
 use crate::common::message::Message;
 use crate::transport::grpc::grpc_streaming_service::{MessageStreamClient, MessageStreamServiceImpl};
@@ -22,8 +22,7 @@ pub async fn start_server(
     let svc = message_stream_server(service);
 
     println!("[SERVER] gRPC server listening on {}", addr);
-    let cfg = transport_config();
-    let router = server_builder(&cfg).add_service(svc);
+    let router = server_builder().add_service(svc);
     serve_with_shutdown(addr, router, async {
         let _ = shutdown.await;
         println!("[SERVER] Received shutdown signal");

--- a/src/tests/inprocess/transport/grpc_streaming.rs
+++ b/src/tests/inprocess/transport/grpc_streaming.rs
@@ -1,15 +1,14 @@
-use crate::common::message::Message;
+use crate::common::grpc::server_builder;
+use crate::common::grpc::serve_with_shutdown;
+use crate::common::grpc::transport::{message_stream_server, transport_config};
 use crate::common::key::Key;
-use crate::transport::grpc::grpc_streaming_service::{
-    MessageStreamClient, MessageStreamServiceImpl,
-    message_stream::message_stream_service_server::MessageStreamServiceServer,
-};
-use arrow::array::{StringArray, Int64Array};
-use arrow::datatypes::{Schema, Field, DataType};
-use tonic::transport::Server;
+use crate::common::message::Message;
+use crate::transport::grpc::grpc_streaming_service::{MessageStreamClient, MessageStreamServiceImpl};
+use arrow::array::{Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use std::collections::HashMap;
 
 /// Start the gRPC server with custom shutdown signal
 pub async fn start_server(
@@ -20,20 +19,16 @@ pub async fn start_server(
     println!("[SERVER] Starting gRPC server on {}", addr);
     let addr = addr.parse()?;
     let service = MessageStreamServiceImpl::new(tx);
-    let svc = MessageStreamServiceServer::new(service)
-        .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-        .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
+    let svc = message_stream_server(service);
 
     println!("[SERVER] gRPC server listening on {}", addr);
-    let router = Server::builder().add_service(svc);
-
-    // Graceful shutdown on custom signal
-    router
-        .serve_with_shutdown(addr, async {
-            let _ = shutdown.await;
-            println!("[SERVER] Received shutdown signal");
-        })
-        .await?;
+    let cfg = transport_config();
+    let router = server_builder(&cfg).add_service(svc);
+    serve_with_shutdown(addr, router, async {
+        let _ = shutdown.await;
+        println!("[SERVER] Received shutdown signal");
+    })
+    .await?;
 
     println!("[SERVER] Server stopped");
     Ok(())

--- a/src/tests/support/cluster_harness/resources/docker.rs
+++ b/src/tests/support/cluster_harness/resources/docker.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use uuid::Uuid;
 
-use crate::common::grpc::master::{control_plane_config, master_client_with_retry};
-use crate::common::grpc::RetryPolicy;
+use crate::common::grpc::master::master_client;
+use crate::common::grpc::GrpcConfig;
 use crate::common::ports::gen_unique_grpc_port;
 use crate::runtime::master::server::master_service::master_service_client::MasterServiceClient;
 use crate::runtime::master::server::master_service::GetLatestPipelineSnapshotRequest;
@@ -292,9 +292,9 @@ impl DockerClusterResources {
 
 async fn connect_master(port: u16) -> Result<MasterServiceClient<tonic::transport::Channel>> {
     let addr = format!("127.0.0.1:{port}");
-    // Harness-local poll (not runtime_consts): same as prior loop of connect every 500ms up to ~20s.
-    let retry = RetryPolicy::fixed(40, Duration::from_millis(500));
-    master_client_with_retry(&addr, &control_plane_config(), &retry)
+    // Harness-local poll: connect every 500ms up to ~20s.
+    let cfg = GrpcConfig::new().with_retries(40, Duration::from_millis(500));
+    master_client(&addr, &cfg)
         .await
         .map_err(|error| anyhow!("failed to connect to master: {error}"))
 }

--- a/src/tests/support/cluster_harness/resources/docker.rs
+++ b/src/tests/support/cluster_harness/resources/docker.rs
@@ -6,6 +6,8 @@ use std::time::Duration;
 use anyhow::{anyhow, Context, Result};
 use uuid::Uuid;
 
+use crate::common::grpc::master::{control_plane_config, master_client_with_retry};
+use crate::common::grpc::RetryPolicy;
 use crate::common::ports::gen_unique_grpc_port;
 use crate::runtime::master::server::master_service::master_service_client::MasterServiceClient;
 use crate::runtime::master::server::master_service::GetLatestPipelineSnapshotRequest;
@@ -289,17 +291,12 @@ impl DockerClusterResources {
 }
 
 async fn connect_master(port: u16) -> Result<MasterServiceClient<tonic::transport::Channel>> {
-    let endpoint = format!("http://127.0.0.1:{port}");
-    let start = tokio::time::Instant::now();
-    loop {
-        match MasterServiceClient::connect(endpoint.clone()).await {
-            Ok(client) => return Ok(client),
-            Err(error) if start.elapsed() > Duration::from_secs(20) => {
-                return Err(anyhow!("failed to connect to master: {error}"));
-            }
-            Err(_) => tokio::time::sleep(Duration::from_millis(500)).await,
-        }
-    }
+    let addr = format!("127.0.0.1:{port}");
+    // Harness-local poll (not runtime_consts): same as prior loop of connect every 500ms up to ~20s.
+    let retry = RetryPolicy::fixed(40, Duration::from_millis(500));
+    master_client_with_retry(&addr, &control_plane_config(), &retry)
+        .await
+        .map_err(|error| anyhow!("failed to connect to master: {error}"))
 }
 
 async fn fetch_lifecycle_events(

--- a/src/tests/support/cluster_harness/resources/kube.rs
+++ b/src/tests/support/cluster_harness/resources/kube.rs
@@ -15,7 +15,7 @@ use crate::tests::support::cluster_harness::FaultAction;
 use crate::storage::InMemoryStorageSnapshot;
 use crate::runtime::master::LifecycleEvent;
 use crate::runtime::master::LifecycleEventRecord;
-use crate::runtime::master::server::master_service::master_service_client::MasterServiceClient;
+use crate::common::grpc::master::{control_plane_config, master_client};
 use crate::runtime::master::server::master_service::GetLifecycleEventsRequest;
 use crate::storage::InMemoryStorageClient;
 use async_trait::async_trait;
@@ -462,8 +462,11 @@ async fn fetch_lifecycle_events(
     master_port: u16,
     sequence: u64,
 ) -> Result<Vec<LifecycleEventRecord>> {
-    let mut client =
-        MasterServiceClient::connect(format!("http://127.0.0.1:{master_port}")).await?;
+    let mut client = master_client(
+        &format!("127.0.0.1:{master_port}"),
+        &control_plane_config(),
+    )
+    .await?;
     client
         .get_lifecycle_events(tonic::Request::new(GetLifecycleEventsRequest {
             after_sequence: sequence,
@@ -492,8 +495,11 @@ async fn fetch_lifecycle_events(
 async fn master_latest_pipeline_snapshot(
     master_port: u16,
 ) -> Result<Option<crate::runtime::observability::PipelineSnapshot>> {
-    let mut client =
-        MasterServiceClient::connect(format!("http://127.0.0.1:{master_port}")).await?;
+    let mut client = master_client(
+        &format!("127.0.0.1:{master_port}"),
+        &control_plane_config(),
+    )
+    .await?;
     let response = client
         .get_latest_pipeline_snapshot(tonic::Request::new(
             crate::runtime::master::server::master_service::GetLatestPipelineSnapshotRequest {},
@@ -507,8 +513,11 @@ async fn master_latest_pipeline_snapshot(
 }
 
 async fn master_stop_sources(master_port: u16) -> Result<()> {
-    let mut client =
-        MasterServiceClient::connect(format!("http://127.0.0.1:{master_port}")).await?;
+    let mut client = master_client(
+        &format!("127.0.0.1:{master_port}"),
+        &control_plane_config(),
+    )
+    .await?;
     let response = client
         .stop_sources(tonic::Request::new(
             crate::runtime::master::server::master_service::StopSourcesRequest {},

--- a/src/tests/support/cluster_harness/resources/kube.rs
+++ b/src/tests/support/cluster_harness/resources/kube.rs
@@ -15,7 +15,8 @@ use crate::tests::support::cluster_harness::FaultAction;
 use crate::storage::InMemoryStorageSnapshot;
 use crate::runtime::master::LifecycleEvent;
 use crate::runtime::master::LifecycleEventRecord;
-use crate::common::grpc::master::{control_plane_config, master_client};
+use crate::common::grpc::master::master_client;
+use crate::common::grpc::GrpcConfig;
 use crate::runtime::master::server::master_service::GetLifecycleEventsRequest;
 use crate::storage::InMemoryStorageClient;
 use async_trait::async_trait;
@@ -462,11 +463,8 @@ async fn fetch_lifecycle_events(
     master_port: u16,
     sequence: u64,
 ) -> Result<Vec<LifecycleEventRecord>> {
-    let mut client = master_client(
-        &format!("127.0.0.1:{master_port}"),
-        &control_plane_config(),
-    )
-    .await?;
+    let mut client =
+        master_client(&format!("127.0.0.1:{master_port}"), &GrpcConfig::new()).await?;
     client
         .get_lifecycle_events(tonic::Request::new(GetLifecycleEventsRequest {
             after_sequence: sequence,
@@ -495,11 +493,8 @@ async fn fetch_lifecycle_events(
 async fn master_latest_pipeline_snapshot(
     master_port: u16,
 ) -> Result<Option<crate::runtime::observability::PipelineSnapshot>> {
-    let mut client = master_client(
-        &format!("127.0.0.1:{master_port}"),
-        &control_plane_config(),
-    )
-    .await?;
+    let mut client =
+        master_client(&format!("127.0.0.1:{master_port}"), &GrpcConfig::new()).await?;
     let response = client
         .get_latest_pipeline_snapshot(tonic::Request::new(
             crate::runtime::master::server::master_service::GetLatestPipelineSnapshotRequest {},
@@ -513,11 +508,8 @@ async fn master_latest_pipeline_snapshot(
 }
 
 async fn master_stop_sources(master_port: u16) -> Result<()> {
-    let mut client = master_client(
-        &format!("127.0.0.1:{master_port}"),
-        &control_plane_config(),
-    )
-    .await?;
+    let mut client =
+        master_client(&format!("127.0.0.1:{master_port}"), &GrpcConfig::new()).await?;
     let response = client
         .stop_sources(tonic::Request::new(
             crate::runtime::master::server::master_service::StopSourcesRequest {},

--- a/src/transport/grpc/grpc_streaming_service.rs
+++ b/src/transport/grpc/grpc_streaming_service.rs
@@ -1,6 +1,7 @@
 use tonic::{Request, Response, Status};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, Duration};
+use crate::common::grpc::GRPC_MAX_MESSAGE_BYTES;
 use crate::common::message::Message;
 use crate::runtime::consts::{
     runtime_consts, TRANSPORT_GRPC_CONNECT_MAX_RETRIES, TRANSPORT_GRPC_CONNECT_RETRY_DELAY,
@@ -81,6 +82,9 @@ impl MessageStreamClient {
         for attempt in 0..=max_retries {
             match MessageStreamServiceClient::connect(addr.clone()).await {
                 Ok(client) => {
+                    let client = client
+                        .max_decoding_message_size(GRPC_MAX_MESSAGE_BYTES)
+                        .max_encoding_message_size(GRPC_MAX_MESSAGE_BYTES);
                     println!("[GRPC_CLIENT] Successfully connected to {} after {} attempts", addr, attempt + 1);
                     return Ok(Self { client });
                 }

--- a/src/transport/grpc/grpc_streaming_service.rs
+++ b/src/transport/grpc/grpc_streaming_service.rs
@@ -1,21 +1,16 @@
-use tonic::{Request, Response, Status};
 use tokio::sync::mpsc;
-use tokio::time::{sleep, Duration};
-use crate::common::grpc::GRPC_MAX_MESSAGE_BYTES;
-use crate::common::message::Message;
-use crate::runtime::consts::{
-    runtime_consts, TRANSPORT_GRPC_CONNECT_MAX_RETRIES, TRANSPORT_GRPC_CONNECT_RETRY_DELAY,
-};
+use tonic::{Request, Response, Status};
 
-pub mod message_stream {
-    tonic::include_proto!("message_stream");
-}
+use crate::common::grpc::transport::message_stream_client as connect_message_stream_client;
+use crate::common::message::Message;
+
+/// Re-export generated stubs (single include lives in `common::grpc::stubs`).
+pub use crate::common::grpc::stubs::message_stream;
 
 use message_stream::{
-    message_stream_service_server::MessageStreamService, GrpcMessage, EmptyResponse,
+    message_stream_service_client::MessageStreamServiceClient,
+    message_stream_service_server::MessageStreamService, EmptyResponse, GrpcMessage,
 };
-
-use crate::transport::grpc::grpc_streaming_service::message_stream::message_stream_service_client::MessageStreamServiceClient;
 
 /// Server implementation of the MessageStreamService
 #[derive(Default)]
@@ -26,9 +21,7 @@ pub struct MessageStreamServiceImpl {
 
 impl MessageStreamServiceImpl {
     pub fn new(tx: mpsc::Sender<(Message, String)>) -> Self {
-        Self {
-            tx: Some(tx),
-        }
+        Self { tx: Some(tx) }
     }
 }
 
@@ -45,10 +38,10 @@ impl MessageStreamService for MessageStreamServiceImpl {
         while let Some(message) = stream.message().await? {
             let message_data = message.message_data;
             let channel_id = message.channel_id;
-            
+
             // Deserialize the message
             let deserialized_message = Message::from_bytes(&message_data);
-            
+
             // Send to application via channel
             if let Err(e) = tx.send((deserialized_message, channel_id)).await {
                 eprintln!("[SERVER] Failed to send message to application: {}", e);
@@ -67,40 +60,9 @@ pub struct MessageStreamClient {
 
 impl MessageStreamClient {
     pub async fn connect(addr: String) -> Result<Self, Box<dyn std::error::Error>> {
-        let max_retries = runtime_consts().u64(TRANSPORT_GRPC_CONNECT_MAX_RETRIES) as u32;
-        let delay = runtime_consts().duration(TRANSPORT_GRPC_CONNECT_RETRY_DELAY);
-        Self::connect_with_retry(addr, max_retries, delay).await
-    }
-
-    pub async fn connect_with_retry(
-        addr: String, 
-        max_retries: u32, 
-        delay: Duration
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let mut last_error = None;
-
-        for attempt in 0..=max_retries {
-            match MessageStreamServiceClient::connect(addr.clone()).await {
-                Ok(client) => {
-                    let client = client
-                        .max_decoding_message_size(GRPC_MAX_MESSAGE_BYTES)
-                        .max_encoding_message_size(GRPC_MAX_MESSAGE_BYTES);
-                    println!("[GRPC_CLIENT] Successfully connected to {} after {} attempts", addr, attempt + 1);
-                    return Ok(Self { client });
-                }
-                Err(e) => {
-                    last_error = Some(e);
-                    if attempt < max_retries {
-                        println!("[GRPC_CLIENT] Connection attempt {} failed for {}: {}. Retrying in {:?}...", 
-                                attempt + 1, addr, last_error.as_ref().unwrap(), delay);
-                        sleep(delay).await;
-                    }
-                }
-            }
-        }
-
-        Err(format!("Failed to connect to {} after {} attempts. Last error: {}", 
-                   addr, max_retries + 1, last_error.unwrap()).into())
+        let client = connect_message_stream_client(&addr).await?;
+        println!("[GRPC_CLIENT] Successfully connected to {addr}");
+        Ok(Self { client })
     }
 
     pub async fn stream_messages(
@@ -116,12 +78,11 @@ impl MessageStreamClient {
                     message_data,
                     channel_id,
                 }
-            }
+            },
         );
 
         let request = Request::new(stream);
         let _response = self.client.stream_messages(request).await?;
-        
         Ok(())
     }
 }

--- a/src/transport/transport_backend.rs
+++ b/src/transport/transport_backend.rs
@@ -193,7 +193,9 @@ impl TransportBackend {
                 .parse()
                 .expect("[GRPC_BACKEND] invalid listen address");
             let service = MessageStreamServiceImpl::new(server_tx);
-            let svc = MessageStreamServiceServer::new(service);
+            let svc = MessageStreamServiceServer::new(service)
+                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
+                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
 
             println!("[GRPC_BACKEND] Starting gRPC server on {}", addr);
 

--- a/src/transport/transport_backend.rs
+++ b/src/transport/transport_backend.rs
@@ -195,8 +195,7 @@ impl TransportBackend {
 
             println!("[GRPC_BACKEND] Starting gRPC server on {}", addr);
 
-            let cfg = crate::common::grpc::transport::transport_config();
-            let router = crate::common::grpc::server_builder(&cfg).add_service(svc);
+            let router = crate::common::grpc::server_builder().add_service(svc);
             crate::common::grpc::serve_with_shutdown(addr, router, async {
                 let _ = shutdown_rx.await;
                 println!("[SERVER] Received shutdown signal");

--- a/src/transport/transport_backend.rs
+++ b/src/transport/transport_backend.rs
@@ -11,11 +11,9 @@ use crate::transport::batch_channel::{batch_bounded_channel, BatchReceiver, Batc
 use crate::transport::channel::Channel;
 use crate::transport::grpc::grpc_streaming_service::{
     MessageStreamClient, MessageStreamServiceImpl,
-    message_stream::message_stream_service_server::MessageStreamServiceServer,
 };
 use crate::transport::TransportBackendTrait;
 use async_trait::async_trait;
-use tonic::transport::Server;
 use std::sync::Arc;
 use tokio::sync::oneshot;
 
@@ -193,20 +191,18 @@ impl TransportBackend {
                 .parse()
                 .expect("[GRPC_BACKEND] invalid listen address");
             let service = MessageStreamServiceImpl::new(server_tx);
-            let svc = MessageStreamServiceServer::new(service)
-                .max_decoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES)
-                .max_encoding_message_size(crate::common::GRPC_MAX_MESSAGE_BYTES);
+            let svc = crate::common::grpc::transport::message_stream_server(service);
 
             println!("[GRPC_BACKEND] Starting gRPC server on {}", addr);
 
-            Server::builder()
-                .add_service(svc)
-                .serve_with_shutdown(addr, async {
-                    let _ = shutdown_rx.await;
-                    println!("[SERVER] Received shutdown signal");
-                })
-                .await
-                .expect("[GRPC_BACKEND] gRPC server failed");
+            let cfg = crate::common::grpc::transport::transport_config();
+            let router = crate::common::grpc::server_builder(&cfg).add_service(svc);
+            crate::common::grpc::serve_with_shutdown(addr, router, async {
+                let _ = shutdown_rx.await;
+                println!("[SERVER] Received shutdown signal");
+            })
+            .await
+            .expect("[GRPC_BACKEND] gRPC server failed");
         });
         self.server_handle = Some(server_handle);
 


### PR DESCRIPTION
## Summary
- Land the gRPC/inmem work from #181 onto `master` (it was previously merged only into the WM branch after WM had already landed)
- Raise inmem window checkpoint inline limit and gRPC max message size
- Centralize client/server construction under `common::grpc` with a single `GrpcConfig`

## Test plan
- [ ] default-tests green
- [ ] Unblocks rebasing #195 so it only contains drain/attempt-actor changes


Made with [Cursor](https://cursor.com)