### PR TITLE
Make stress cancel promptly on SIGTERM/SIGINT

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -282,7 +282,8 @@ jobs:
               --shards "$shards" \
               --fresh-cluster
           fi
-      - if: always()
+      # Skip on cancelled so "Cancel workflow" is not blocked by 15× artifact upload.
+      - if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: kube-stress-logs-machine-${{ matrix.machine }}
@@ -345,7 +346,8 @@ jobs:
             --test "$test_name" \
             --runs-per-shard "$runs" \
             --shards "$shards"
-      - if: always()
+      # Skip on cancelled so "Cancel workflow" is not blocked by 15× artifact upload.
+      - if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: inproc-stress-logs-machine-${{ matrix.machine }}

--- a/scripts/stress-test
+++ b/scripts/stress-test
@@ -144,7 +144,31 @@ run_shard() {
   done
 }
 
+# Job control: each background shard gets its own process group (pgid == pid) so
+# CI "Cancel workflow" (SIGTERM) and local Ctrl+C can kill nextest/cargo trees.
+set -m
+
 pids=()
+
+kill_shards() {
+  local sig="${1:-TERM}"
+  local pid
+  for pid in "${pids[@]:-}"; do
+    kill "-${sig}" -- "-${pid}" 2>/dev/null || kill "-${sig}" "${pid}" 2>/dev/null || true
+  done
+}
+
+on_cancel() {
+  echo "Stress cancelled; stopping shards..." >&2
+  touch "$FAILURE_MARKER"
+  kill_shards TERM
+  sleep 1
+  kill_shards KILL
+  echo "Stress logs: $LOG_DIR" >&2
+  exit 130
+}
+trap on_cancel INT TERM
+
 for ((shard = 1; shard <= SHARDS; shard++)); do
   run_shard "$shard" &
   pids+=("$!")
@@ -154,8 +178,17 @@ failed=0
 for pid in "${pids[@]}"; do
   if ! wait "$pid"; then
     failed=1
+    touch "$FAILURE_MARKER"
+    # First shard failure: stop siblings instead of waiting for their remaining runs.
+    kill_shards TERM
+    sleep 1
+    kill_shards KILL
+    wait 2>/dev/null || true
+    break
   fi
 done
+
+trap - INT TERM
 
 echo "Stress logs: $LOG_DIR"
 if [[ "$failed" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Run stress shards in their own process groups and trap TERM/INT so GitHub **Cancel workflow** (and local Ctrl+C) kill nextest/cargo trees instead of leaving them running
- On first shard failure, stop sibling shards instead of waiting for remaining runs
- Skip stress artifact upload when the job was cancelled (`success() || failure()`)

## Test plan
- [ ] `scripts/test stress --env local --test test_local_multi_worker_window_checkpoint_restore --runs-per-shard 2 --shards 1` then Ctrl+C mid-run — process tree dies
- [ ] Dispatch inproc-stress, cancel from Actions UI — matrix jobs stop without finishing all runs / artifact upload


Made with [Cursor](https://cursor.com)