### PR TITLE
Make MasterLifecycle an actor with Finish intent

### DIFF
--- a/src/runtime/master/attempt/execute.rs
+++ b/src/runtime/master/attempt/execute.rs
@@ -103,7 +103,8 @@ impl ExecutionAttempt {
             let Some(slot) = self.run.as_mut() else {
                 return;
             };
-            if slot.aggregating.is_some() || slot.poll_in_flight {
+            // Aggregation must not freeze observation; only one poll batch at a time.
+            if slot.poll_in_flight {
                 return;
             }
             slot.poll_in_flight = true;
@@ -123,12 +124,30 @@ impl ExecutionAttempt {
                 return;
             };
             slot.poll_in_flight = false;
-            if slot.aggregating.is_some() {
-                return;
+        }
+
+        // FailureAggregation owns Recover: fold poll failures into the window.
+        if self.phase == AttemptPhase::FailureAggregation {
+            for (worker_id, error) in state_poll.failures {
+                let failure = FailureEvent {
+                    worker_id,
+                    kind: FailureKind::StatePollFailure,
+                    detail: error.to_string(),
+                };
+                self.record_failure(&failure).await;
+                if let Some(events) = self
+                    .run
+                    .as_mut()
+                    .and_then(|slot| slot.failure_events.as_mut())
+                {
+                    events.push(failure);
+                }
             }
+            return;
         }
 
         let checkpoint_timeout = runtime_consts().duration(MASTER_CHECKPOINT_TIMEOUT);
+        let draining = self.phase == AttemptPhase::Draining;
         if !state_poll.failures.is_empty() {
             for (worker_id, error) in &state_poll.failures {
                 self.record_failure(&FailureEvent {
@@ -138,14 +157,17 @@ impl ExecutionAttempt {
                 })
                 .await;
             }
-            self.abort_in_flight("state poll failure").await;
-            let replace = state_poll
-                .failures
-                .iter()
-                .map(|(worker_id, _)| worker_id.clone())
-                .collect();
-            self.complete_run(Ok(AttemptOutcome::Recover(replace)));
-            return;
+            // Draining owns Finish: do not divert into Recover.
+            if !draining {
+                self.abort_in_flight("state poll failure").await;
+                let replace = state_poll
+                    .failures
+                    .iter()
+                    .map(|(worker_id, _)| worker_id.clone())
+                    .collect();
+                self.complete_run(Ok(AttemptOutcome::Recover(replace)));
+                return;
+            }
         }
         if all_workers(&state_poll.states, self.sessions.keys(), |s| {
             s.all_tasks_in(&[StreamTaskStatus::Finished, StreamTaskStatus::Closed])
@@ -166,6 +188,9 @@ impl ExecutionAttempt {
                 "[MASTER] Checkpoint timeout attempt={} checkpoint_id={}",
                 self.id, checkpoint_id
             );
+            if draining {
+                return;
+            }
             self.complete_run(Ok(AttemptOutcome::Recover(HashSet::new())));
             return;
         }
@@ -177,11 +202,7 @@ impl ExecutionAttempt {
     }
 
     pub(super) async fn on_checkpoint_tick(&mut self, actor_ref: ActorRef<Self>) {
-        match self.run.as_ref() {
-            Some(slot) if slot.aggregating.is_none() => {}
-            _ => return,
-        }
-        if self.phase != AttemptPhase::Running {
+        if self.run.is_none() || self.phase != AttemptPhase::Running {
             return;
         }
         let checkpoint_id = match self.state.begin_checkpoint(self.id).await {
@@ -251,16 +272,20 @@ impl ExecutionAttempt {
         failure: FailureEvent,
         actor_ref: ActorRef<Self>,
     ) {
-        let aggregating = match self.run.as_ref() {
-            Some(slot) => slot.aggregating.is_some(),
-            None => return,
-        };
-        if aggregating {
+        if self.run.is_none() {
+            return;
+        }
+        // Draining owns Finish; late fatals are recorded only.
+        if self.phase == AttemptPhase::Draining {
+            self.record_failure(&failure).await;
+            return;
+        }
+        if self.phase == AttemptPhase::FailureAggregation {
             self.record_failure(&failure).await;
             if let Some(events) = self
                 .run
                 .as_mut()
-                .and_then(|slot| slot.aggregating.as_mut())
+                .and_then(|slot| slot.failure_events.as_mut())
             {
                 events.push(failure);
             }
@@ -269,8 +294,9 @@ impl ExecutionAttempt {
 
         self.abort_in_flight("attempt failed").await;
         self.record_failure(&failure).await;
+        self.phase = AttemptPhase::FailureAggregation;
         if let Some(slot) = self.run.as_mut() {
-            slot.aggregating = Some(vec![failure]);
+            slot.failure_events = Some(vec![failure]);
         }
 
         let window = runtime_consts().duration(MASTER_FAILURE_AGGREGATION_WINDOW);
@@ -281,10 +307,13 @@ impl ExecutionAttempt {
     }
 
     pub(super) async fn on_agg_window_end(&mut self) {
+        if self.phase != AttemptPhase::FailureAggregation {
+            return;
+        }
         let Some(slot) = self.run.as_mut() else {
             return;
         };
-        let Some(events) = slot.aggregating.take() else {
+        let Some(events) = slot.failure_events.take() else {
             return;
         };
 

--- a/src/runtime/master/attempt/mod.rs
+++ b/src/runtime/master/attempt/mod.rs
@@ -11,7 +11,7 @@ use tokio::task::JoinHandle;
 
 use crate::common::failure::FailureEvent;
 use crate::orchestrator::orchestrator::WorkerHealthWatchHandle;
-use super::lifecycle::{AttemptRunArmed, MasterLifecycle};
+use super::lifecycle::{RunStarted, MasterLifecycle};
 use super::state::{MasterState, PipelineContext};
 
 mod execute;
@@ -179,7 +179,7 @@ impl Message<Run> for ExecutionAttempt {
             failure_events: None,
             poll_in_flight: false,
         });
-        let _ = self.lifecycle.tell(AttemptRunArmed).await;
+        let _ = self.lifecycle.tell(RunStarted).await;
         delegated
     }
 }

--- a/src/runtime/master/attempt/mod.rs
+++ b/src/runtime/master/attempt/mod.rs
@@ -11,7 +11,7 @@ use tokio::task::JoinHandle;
 
 use crate::common::failure::FailureEvent;
 use crate::orchestrator::orchestrator::WorkerHealthWatchHandle;
-use super::lifecycle::{RunStarted, MasterLifecycle};
+use super::lifecycle::{RunLoopStarted, MasterLifecycle};
 use super::state::{MasterState, PipelineContext};
 
 mod execute;
@@ -179,7 +179,7 @@ impl Message<Run> for ExecutionAttempt {
             failure_events: None,
             poll_in_flight: false,
         });
-        let _ = self.lifecycle.tell(RunStarted).await;
+        let _ = self.lifecycle.tell(RunLoopStarted).await;
         delegated
     }
 }

--- a/src/runtime/master/attempt/mod.rs
+++ b/src/runtime/master/attempt/mod.rs
@@ -11,6 +11,7 @@ use tokio::task::JoinHandle;
 
 use crate::common::failure::FailureEvent;
 use crate::orchestrator::orchestrator::WorkerHealthWatchHandle;
+use super::lifecycle::{AttemptRunArmed, MasterLifecycle};
 use super::state::{MasterState, PipelineContext};
 
 mod execute;
@@ -20,20 +21,25 @@ mod teardown;
 
 use session::WorkerSession;
 
-/// Current execution-attempt run phase. Owned by [`ExecutionAttempt`].
+/// Exclusive attempt phases. FailureAggregation and Draining never overlap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum AttemptPhase {
     Running,
     Checkpointing,
+    FailureAggregation,
     Draining,
 }
 
 impl AttemptPhase {
-    /// `Checkpointing` → `Running`; leave `Draining` alone.
+    /// `Checkpointing` → `Running`; leave terminal-ish phases alone.
     fn clear_checkpointing(&mut self) {
         if *self == Self::Checkpointing {
             *self = Self::Running;
         }
+    }
+
+    fn accepts_drain(self) -> bool {
+        matches!(self, Self::Running | Self::Checkpointing)
     }
 }
 
@@ -58,6 +64,7 @@ pub(super) struct ExecutionAttempt {
     restore_checkpoint_id: Option<u64>,
     state: Arc<MasterState>,
     pipeline: Arc<PipelineContext>,
+    lifecycle: ActorRef<MasterLifecycle>,
     phase: AttemptPhase,
     sessions: HashMap<String, ActorRef<WorkerSession>>,
     failure_tx: mpsc::Sender<FailureEvent>,
@@ -70,8 +77,8 @@ struct RunSlot {
     reply: ReplySender<Result<AttemptOutcome, String>>,
     run_loop: JoinHandle<()>,
     _health_poll: Option<WorkerHealthWatchHandle>,
-    /// Failures collected during the aggregation window after the first fatal.
-    aggregating: Option<Vec<FailureEvent>>,
+    /// Failures collected during [`AttemptPhase::FailureAggregation`].
+    failure_events: Option<Vec<FailureEvent>>,
     /// One outstanding poll RPC batch at a time (keeps mailbox free for `Drain`).
     poll_in_flight: bool,
 }
@@ -82,7 +89,7 @@ pub(super) struct Schedule;
 
 pub(super) struct Run;
 
-/// StopSources: enter draining, abort in-flight CP, stop sources on sessions.
+/// Enter draining when phase allows (`Running` / `Checkpointing` only).
 pub(super) struct Drain;
 
 pub(super) struct Finish;
@@ -107,6 +114,7 @@ impl ExecutionAttempt {
         restore_checkpoint_id: Option<u64>,
         state: Arc<MasterState>,
         pipeline: Arc<PipelineContext>,
+        lifecycle: ActorRef<MasterLifecycle>,
     ) -> ActorRef<Self> {
         let (failure_tx, failure_rx) = mpsc::channel(256);
         kameo::spawn(Self {
@@ -114,6 +122,7 @@ impl ExecutionAttempt {
             restore_checkpoint_id,
             state,
             pipeline,
+            lifecycle,
             phase: AttemptPhase::Running,
             sessions: HashMap::new(),
             failure_tx,
@@ -167,9 +176,10 @@ impl Message<Run> for ExecutionAttempt {
             reply,
             run_loop,
             _health_poll: health_poll,
-            aggregating: None,
+            failure_events: None,
             poll_in_flight: false,
         });
+        let _ = self.lifecycle.tell(AttemptRunArmed).await;
         delegated
     }
 }
@@ -182,6 +192,16 @@ impl Message<Drain> for ExecutionAttempt {
         _msg: Drain,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.run.is_none() {
+            return Err("no active run".to_string());
+        }
+        if self.phase == AttemptPhase::Draining {
+            return Ok(());
+        }
+        if !self.phase.accepts_drain() {
+            return Err(format!("attempt phase {:?} does not accept drain", self.phase));
+        }
+
         self.phase = AttemptPhase::Draining;
         let checkpoint_id = self
             .state

--- a/src/runtime/master/lifecycle.rs
+++ b/src/runtime/master/lifecycle.rs
@@ -43,8 +43,8 @@ pub(super) struct RequestFinish;
 
 struct RunFinished(Result<AttemptOutcome, String>);
 
-/// Attempt run loop is armed; safe to `Drain` if intent is `Finish`.
-pub(super) struct AttemptRunArmed;
+/// Attempt run loop has started; safe to `Drain` if intent is `Finish`.
+pub(super) struct RunStarted;
 
 impl MasterLifecycle {
     pub(super) fn spawn(state: Arc<MasterState>) -> ActorRef<Self> {
@@ -123,7 +123,7 @@ impl MasterLifecycle {
                     };
                     let _ = lifecycle.tell(RunFinished(result)).await;
                 });
-                // Drain runs on AttemptRunArmed (after Run arms the poll loop).
+                // Drain runs on RunStarted (after Run starts the poll loop).
                 Ok(())
             }
             Err(error) => match schedule_ask_error(error) {
@@ -300,12 +300,12 @@ impl Message<RunFinished> for MasterLifecycle {
     }
 }
 
-impl Message<AttemptRunArmed> for MasterLifecycle {
+impl Message<RunStarted> for MasterLifecycle {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _msg: AttemptRunArmed,
+        _msg: RunStarted,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         if self.intent == PipelineIntent::Finish {

--- a/src/runtime/master/lifecycle.rs
+++ b/src/runtime/master/lifecycle.rs
@@ -41,10 +41,10 @@ pub(super) struct Start(pub PipelineContext);
 /// Cooperative pipeline finish: set intent and drain when the attempt allows it.
 pub(super) struct RequestFinish;
 
-struct RunFinished(Result<AttemptOutcome, String>);
+struct RunComplete(Result<AttemptOutcome, String>);
 
 /// Attempt run loop has started; safe to `Drain` if intent is `Finish`.
-pub(super) struct RunStarted;
+pub(super) struct RunLoopStarted;
 
 impl MasterLifecycle {
     pub(super) fn spawn(state: Arc<MasterState>) -> ActorRef<Self> {
@@ -121,9 +121,9 @@ impl MasterLifecycle {
                         Ok(outcome) => Ok(outcome),
                         Err(error) => Err(error.to_string()),
                     };
-                    let _ = lifecycle.tell(RunFinished(result)).await;
+                    let _ = lifecycle.tell(RunComplete(result)).await;
                 });
-                // Drain runs on RunStarted (after Run starts the poll loop).
+                // Drain runs on RunLoopStarted (after Run sets up the poll loop).
                 Ok(())
             }
             Err(error) => match schedule_ask_error(error) {
@@ -145,7 +145,7 @@ impl MasterLifecycle {
                     );
                     // Bounce through the mailbox to avoid async recursion with handle_outcome.
                     let _ = self_ref
-                        .tell(RunFinished(Ok(AttemptOutcome::Recover(replace))))
+                        .tell(RunComplete(Ok(AttemptOutcome::Recover(replace))))
                         .await;
                     Ok(())
                 }
@@ -277,12 +277,12 @@ impl Message<RequestFinish> for MasterLifecycle {
     }
 }
 
-impl Message<RunFinished> for MasterLifecycle {
+impl Message<RunComplete> for MasterLifecycle {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        msg: RunFinished,
+        msg: RunComplete,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         if self.execute_reply.is_none() {
@@ -300,12 +300,12 @@ impl Message<RunFinished> for MasterLifecycle {
     }
 }
 
-impl Message<RunStarted> for MasterLifecycle {
+impl Message<RunLoopStarted> for MasterLifecycle {
     type Reply = ();
 
     async fn handle(
         &mut self,
-        _msg: RunStarted,
+        _msg: RunLoopStarted,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         if self.intent == PipelineIntent::Finish {

--- a/src/runtime/master/lifecycle.rs
+++ b/src/runtime/master/lifecycle.rs
@@ -1,141 +1,315 @@
-//! Pipeline lifecycle:
-//! schedule → run until finished or failed → recover if failed → repeat.
+//! Pipeline lifecycle actor: job intent + attempt supervision.
+//!
+//! `RequestFinish` sets intent=`Finish` and drains only when the current attempt
+//! is stably runnable. Recovering attempts are left alone; drain is retried after
+//! the next attempt reaches Running.
 
 use std::sync::Arc;
 
+use kameo::actor::ActorRef;
+use kameo::message::{Context, Message};
+use kameo::reply::{DelegatedReply, ReplySender};
+use kameo::Actor;
+
 use super::attempt::{
-    schedule_ask_error, AttemptOutcome, ExecutionAttempt, Finish, Recover, Run, Schedule,
+    schedule_ask_error, AttemptOutcome, Drain, ExecutionAttempt, Finish, Recover, Run, Schedule,
     ScheduleError,
 };
 use super::events::LifecycleEvent;
 use super::state::{MasterState, PipelineContext};
 use crate::runtime::consts::{runtime_consts, MASTER_RECOVERY_BUDGET};
 
-pub(super) struct MasterLifecycle {
-    state: Arc<MasterState>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum JobIntent {
+    Run,
+    Finish,
 }
 
+#[derive(Actor)]
+pub(super) struct MasterLifecycle {
+    state: Arc<MasterState>,
+    intent: JobIntent,
+    pipeline: Option<Arc<PipelineContext>>,
+    execute_reply: Option<ReplySender<Result<(), String>>>,
+    attempt_id: u64,
+    restore_checkpoint_id: Option<u64>,
+    current: Option<ActorRef<ExecutionAttempt>>,
+}
+
+pub(super) struct Start(pub PipelineContext);
+
+/// Cooperative job finish: set intent and drain when the attempt allows it.
+pub(super) struct RequestFinish;
+
+struct RunFinished(Result<AttemptOutcome, String>);
+
+/// Attempt run loop is armed; safe to `Drain` if intent is `Finish`.
+pub(super) struct AttemptRunArmed;
+
 impl MasterLifecycle {
-    pub(super) fn new(state: Arc<MasterState>) -> Self {
-        Self { state }
+    pub(super) fn spawn(state: Arc<MasterState>) -> ActorRef<Self> {
+        kameo::spawn(Self {
+            state,
+            intent: JobIntent::Run,
+            pipeline: None,
+            execute_reply: None,
+            attempt_id: 0,
+            restore_checkpoint_id: None,
+            current: None,
+        })
     }
 
-    pub(super) async fn run(&self, pipeline: PipelineContext) -> anyhow::Result<()> {
-        println!("[MASTER] Starting pipeline lifecycle");
-        let mut execution_attempt_id = 0;
-        let mut restore_checkpoint_id = None;
-        let pipeline = Arc::new(pipeline);
+    fn complete_execute(&mut self, result: Result<(), String>) {
+        if let Some(reply) = self.execute_reply.take() {
+            reply.send(result);
+        }
+        self.pipeline = None;
+        self.current = None;
+        self.intent = JobIntent::Run;
+    }
 
-        loop {
-            self.state
-                .record_lifecycle_event(LifecycleEvent::AttemptStarted {
-                    attempt_id: execution_attempt_id,
-                    restore_checkpoint_id,
-                })
-                .await;
-            self.state.set_current_attempt_id(execution_attempt_id);
-            let attempt = ExecutionAttempt::spawn(
-                execution_attempt_id,
-                restore_checkpoint_id,
-                self.state.clone(),
-                pipeline.clone(),
-            );
-            self.state.set_current_attempt(attempt.clone()).await;
+    async fn try_drain(&self) {
+        let Some(attempt) = self.current.as_ref() else {
+            return;
+        };
+        match attempt.ask(Drain).await {
+            Ok(()) => {
+                println!(
+                    "[MASTER] StopSources ok execution_attempt={}",
+                    self.attempt_id
+                );
+            }
+            Err(error) => {
+                println!(
+                    "[MASTER] Drain deferred attempt={}: {error}",
+                    self.attempt_id
+                );
+            }
+        }
+    }
 
-            let schedule_outcome = match attempt.ask(Schedule).await {
-                Ok(()) => {
-                    println!("[MASTER] Scheduling ok attempt={}", execution_attempt_id);
-                    match attempt.ask(Run).await {
-                        Ok(outcome) => outcome,
-                        Err(error) => {
-                            self.state.clear_current_attempt().await;
-                            let detail = error.to_string();
-                            self.state
-                                .record_lifecycle_event(LifecycleEvent::PipelineFailed {
-                                    detail: detail.clone(),
-                                })
-                                .await;
-                            let _ = attempt.stop_gracefully().await;
-                            return Err(anyhow::anyhow!(detail));
-                        }
-                    }
-                }
-                Err(error) => match schedule_ask_error(error) {
-                    ScheduleError::Terminal(detail) => {
-                        self.state.clear_current_attempt().await;
-                        self.state
-                            .record_lifecycle_event(LifecycleEvent::PipelineFailed {
-                                detail: detail.clone(),
-                            })
-                            .await;
-                        let _ = attempt.stop_gracefully().await;
-                        return Err(anyhow::anyhow!("terminal scheduling failure: {}", detail));
-                    }
-                    ScheduleError::Recoverable { replace, detail } => {
-                        println!(
-                            "[MASTER] Scheduling failed attempt={}: {} replace={:?}",
-                            execution_attempt_id, detail, replace
-                        );
-                        AttemptOutcome::Recover(replace)
-                    }
-                },
-            };
+    async fn start_attempt(&mut self, self_ref: ActorRef<Self>) -> Result<(), String> {
+        let pipeline = self
+            .pipeline
+            .clone()
+            .ok_or_else(|| "lifecycle has no pipeline".to_string())?;
 
-            match schedule_outcome {
-                AttemptOutcome::Finished => {
-                    if let Err(error) = attempt.ask(Finish).await {
-                        self.state.clear_current_attempt().await;
-                        let _ = attempt.stop_gracefully().await;
-                        return Err(anyhow::anyhow!("finish failed: {error}"));
-                    }
+        self.state
+            .record_lifecycle_event(LifecycleEvent::AttemptStarted {
+                attempt_id: self.attempt_id,
+                restore_checkpoint_id: self.restore_checkpoint_id,
+            })
+            .await;
+        self.state.set_current_attempt_id(self.attempt_id);
+        let attempt = ExecutionAttempt::spawn(
+            self.attempt_id,
+            self.restore_checkpoint_id,
+            self.state.clone(),
+            pipeline,
+            self_ref.clone(),
+        );
+        self.state.set_current_attempt(attempt.clone()).await;
+        self.current = Some(attempt.clone());
+
+        match attempt.ask(Schedule).await {
+            Ok(()) => {
+                println!("[MASTER] Scheduling ok attempt={}", self.attempt_id);
+                let lifecycle = self_ref.clone();
+                let run_attempt = attempt.clone();
+                tokio::spawn(async move {
+                    let result = match run_attempt.ask(Run).await {
+                        Ok(outcome) => Ok(outcome),
+                        Err(error) => Err(error.to_string()),
+                    };
+                    let _ = lifecycle.tell(RunFinished(result)).await;
+                });
+                // Drain runs on AttemptRunArmed (after Run arms the poll loop).
+                Ok(())
+            }
+            Err(error) => match schedule_ask_error(error) {
+                ScheduleError::Terminal(detail) => {
                     self.state.clear_current_attempt().await;
-                    let _ = attempt.stop_gracefully().await;
                     self.state
-                        .record_lifecycle_event(LifecycleEvent::PipelineFinished)
-                        .await;
-                    println!("[MASTER] Pipeline finished");
-                    return Ok(());
-                }
-                AttemptOutcome::Recover(replace) => {
-                    if execution_attempt_id >= runtime_consts().u64(MASTER_RECOVERY_BUDGET) {
-                        self.state.clear_current_attempt().await;
-                        let _ = attempt.stop_gracefully().await;
-                        return Err(anyhow::anyhow!(
-                            "recovery budget exhausted after {} attempts",
-                            runtime_consts().u64(MASTER_RECOVERY_BUDGET)
-                        ));
-                    }
-
-                    let replacement_worker_ids = replace.iter().cloned().collect();
-                    self.state
-                        .record_lifecycle_event(LifecycleEvent::RecoveryStarted {
-                            attempt_id: execution_attempt_id,
-                            replacement_worker_ids,
+                        .record_lifecycle_event(LifecycleEvent::PipelineFailed {
+                            detail: detail.clone(),
                         })
                         .await;
+                    let _ = attempt.stop_gracefully().await;
+                    self.current = None;
+                    Err(format!("terminal scheduling failure: {detail}"))
+                }
+                ScheduleError::Recoverable { replace, detail } => {
                     println!(
-                        "[MASTER] Recovering {}/{} after execution attempt {} replace={:?}",
-                        execution_attempt_id + 1,
-                        runtime_consts().u64(MASTER_RECOVERY_BUDGET),
-                        execution_attempt_id,
-                        replace
+                        "[MASTER] Scheduling failed attempt={}: {} replace={:?}",
+                        self.attempt_id, detail, replace
                     );
-                    if let Err(error) = attempt.ask(Recover(replace)).await {
-                        self.state.clear_current_attempt().await;
-                        let _ = attempt.stop_gracefully().await;
-                        return Err(anyhow::anyhow!(error));
-                    }
+                    // Bounce through the mailbox to avoid async recursion with handle_outcome.
+                    let _ = self_ref
+                        .tell(RunFinished(Ok(AttemptOutcome::Recover(replace))))
+                        .await;
+                    Ok(())
+                }
+            },
+        }
+    }
+
+    async fn handle_outcome(
+        &mut self,
+        result: Result<AttemptOutcome, String>,
+        self_ref: ActorRef<Self>,
+    ) -> Result<(), String> {
+        let Some(attempt) = self.current.take() else {
+            return Err("no current attempt for outcome".to_string());
+        };
+
+        match result {
+            Ok(AttemptOutcome::Finished) => {
+                if let Err(error) = attempt.ask(Finish).await {
                     self.state.clear_current_attempt().await;
                     let _ = attempt.stop_gracefully().await;
+                    return Err(format!("finish failed: {error}"));
+                }
+                self.state.clear_current_attempt().await;
+                let _ = attempt.stop_gracefully().await;
+                self.state
+                    .record_lifecycle_event(LifecycleEvent::PipelineFinished)
+                    .await;
+                println!("[MASTER] Pipeline finished");
+                Ok(())
+            }
+            Ok(AttemptOutcome::Recover(replace)) => {
+                if self.attempt_id >= runtime_consts().u64(MASTER_RECOVERY_BUDGET) {
+                    self.state.clear_current_attempt().await;
+                    let _ = attempt.stop_gracefully().await;
+                    return Err(format!(
+                        "recovery budget exhausted after {} attempts",
+                        runtime_consts().u64(MASTER_RECOVERY_BUDGET)
+                    ));
+                }
 
-                    execution_attempt_id += 1;
-                    restore_checkpoint_id = self.state.latest_complete_checkpoint().await;
-                    println!(
-                        "[MASTER] Starting execution attempt {} restore={:?}",
-                        execution_attempt_id, restore_checkpoint_id
-                    );
+                let replacement_worker_ids = replace.iter().cloned().collect();
+                self.state
+                    .record_lifecycle_event(LifecycleEvent::RecoveryStarted {
+                        attempt_id: self.attempt_id,
+                        replacement_worker_ids,
+                    })
+                    .await;
+                println!(
+                    "[MASTER] Recovering {}/{} after execution attempt {} replace={:?}",
+                    self.attempt_id + 1,
+                    runtime_consts().u64(MASTER_RECOVERY_BUDGET),
+                    self.attempt_id,
+                    replace
+                );
+                if let Err(error) = attempt.ask(Recover(replace)).await {
+                    self.state.clear_current_attempt().await;
+                    let _ = attempt.stop_gracefully().await;
+                    return Err(error.to_string());
+                }
+                self.state.clear_current_attempt().await;
+                let _ = attempt.stop_gracefully().await;
+
+                self.attempt_id += 1;
+                self.restore_checkpoint_id = self.state.latest_complete_checkpoint().await;
+                println!(
+                    "[MASTER] Starting execution attempt {} restore={:?}",
+                    self.attempt_id, self.restore_checkpoint_id
+                );
+                self.start_attempt(self_ref).await
+            }
+            Err(detail) => {
+                self.state.clear_current_attempt().await;
+                self.state
+                    .record_lifecycle_event(LifecycleEvent::PipelineFailed {
+                        detail: detail.clone(),
+                    })
+                    .await;
+                let _ = attempt.stop_gracefully().await;
+                Err(detail)
+            }
+        }
+    }
+}
+
+impl Message<Start> for MasterLifecycle {
+    type Reply = DelegatedReply<Result<(), String>>;
+
+    async fn handle(&mut self, msg: Start, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        let (delegated, reply) = ctx.reply_sender();
+        let Some(reply) = reply else {
+            return delegated;
+        };
+        if self.execute_reply.is_some() {
+            reply.send(Err("lifecycle already running".to_string()));
+            return delegated;
+        }
+
+        println!("[MASTER] Starting pipeline lifecycle");
+        self.intent = JobIntent::Run;
+        self.pipeline = Some(Arc::new(msg.0));
+        self.execute_reply = Some(reply);
+        self.attempt_id = 0;
+        self.restore_checkpoint_id = None;
+        self.current = None;
+
+        match self.start_attempt(ctx.actor_ref()).await {
+            Ok(()) => {}
+            Err(error) => self.complete_execute(Err(error)),
+        }
+        delegated
+    }
+}
+
+impl Message<RequestFinish> for MasterLifecycle {
+    type Reply = Result<(), String>;
+
+    async fn handle(
+        &mut self,
+        _msg: RequestFinish,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.execute_reply.is_none() {
+            return Err("lifecycle not started".to_string());
+        }
+        self.intent = JobIntent::Finish;
+        self.try_drain().await;
+        Ok(())
+    }
+}
+
+impl Message<RunFinished> for MasterLifecycle {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: RunFinished,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.execute_reply.is_none() {
+            return;
+        }
+        match self.handle_outcome(msg.0, ctx.actor_ref()).await {
+            Ok(()) => {
+                // Recover path may have started another attempt (execute_reply still set).
+                if self.current.is_none() {
+                    self.complete_execute(Ok(()));
                 }
             }
+            Err(error) => self.complete_execute(Err(error)),
+        }
+    }
+}
+
+impl Message<AttemptRunArmed> for MasterLifecycle {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: AttemptRunArmed,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.intent == JobIntent::Finish {
+            self.try_drain().await;
         }
     }
 }

--- a/src/runtime/master/lifecycle.rs
+++ b/src/runtime/master/lifecycle.rs
@@ -1,4 +1,4 @@
-//! Pipeline lifecycle actor: job intent + attempt supervision.
+//! Pipeline lifecycle actor: pipeline intent + attempt supervision.
 //!
 //! `RequestFinish` sets intent=`Finish` and drains only when the current attempt
 //! is stably runnable. Recovering attempts are left alone; drain is retried after
@@ -20,7 +20,7 @@ use super::state::{MasterState, PipelineContext};
 use crate::runtime::consts::{runtime_consts, MASTER_RECOVERY_BUDGET};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum JobIntent {
+enum PipelineIntent {
     Run,
     Finish,
 }
@@ -28,7 +28,7 @@ enum JobIntent {
 #[derive(Actor)]
 pub(super) struct MasterLifecycle {
     state: Arc<MasterState>,
-    intent: JobIntent,
+    intent: PipelineIntent,
     pipeline: Option<Arc<PipelineContext>>,
     execute_reply: Option<ReplySender<Result<(), String>>>,
     attempt_id: u64,
@@ -38,7 +38,7 @@ pub(super) struct MasterLifecycle {
 
 pub(super) struct Start(pub PipelineContext);
 
-/// Cooperative job finish: set intent and drain when the attempt allows it.
+/// Cooperative pipeline finish: set intent and drain when the attempt allows it.
 pub(super) struct RequestFinish;
 
 struct RunFinished(Result<AttemptOutcome, String>);
@@ -50,7 +50,7 @@ impl MasterLifecycle {
     pub(super) fn spawn(state: Arc<MasterState>) -> ActorRef<Self> {
         kameo::spawn(Self {
             state,
-            intent: JobIntent::Run,
+            intent: PipelineIntent::Run,
             pipeline: None,
             execute_reply: None,
             attempt_id: 0,
@@ -65,7 +65,7 @@ impl MasterLifecycle {
         }
         self.pipeline = None;
         self.current = None;
-        self.intent = JobIntent::Run;
+        self.intent = PipelineIntent::Run;
     }
 
     async fn try_drain(&self) {
@@ -245,7 +245,7 @@ impl Message<Start> for MasterLifecycle {
         }
 
         println!("[MASTER] Starting pipeline lifecycle");
-        self.intent = JobIntent::Run;
+        self.intent = PipelineIntent::Run;
         self.pipeline = Some(Arc::new(msg.0));
         self.execute_reply = Some(reply);
         self.attempt_id = 0;
@@ -271,7 +271,7 @@ impl Message<RequestFinish> for MasterLifecycle {
         if self.execute_reply.is_none() {
             return Err("lifecycle not started".to_string());
         }
-        self.intent = JobIntent::Finish;
+        self.intent = PipelineIntent::Finish;
         self.try_drain().await;
         Ok(())
     }
@@ -308,7 +308,7 @@ impl Message<AttemptRunArmed> for MasterLifecycle {
         _msg: AttemptRunArmed,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if self.intent == JobIntent::Finish {
+        if self.intent == PipelineIntent::Finish {
             self.try_drain().await;
         }
     }

--- a/src/runtime/master/mod.rs
+++ b/src/runtime/master/mod.rs
@@ -21,7 +21,7 @@ mod lifecycle;
 mod state;
 mod worker_client;
 
-use lifecycle::MasterLifecycle;
+use lifecycle::{MasterLifecycle, RequestFinish, Start};
 use state::MasterState;
 pub use events::{CheckpointPropagationPhase, LifecycleEvent, LifecycleEventRecord};
 
@@ -98,22 +98,17 @@ impl Master {
         self.state.latest_complete_checkpoint().await
     }
 
-    /// Cooperative source stop: attempt `Drain` (phase + abort CP + session stop_sources).
+    /// Cooperative job finish: lifecycle sets intent=`Finish` and drains when runnable.
     pub async fn stop_sources(&self) -> Result<(), String> {
-        let attempt = self
+        let lifecycle = self
             .state
-            .current_attempt()
+            .lifecycle()
             .await
-            .ok_or_else(|| "no current execution attempt".to_string())?;
-        attempt
-            .ask(attempt::Drain)
+            .ok_or_else(|| "lifecycle not started".to_string())?;
+        lifecycle
+            .ask(RequestFinish)
             .await
-            .map_err(|error| error.to_string())?;
-        println!(
-            "[MASTER] StopSources ok execution_attempt={}",
-            self.state.current_attempt_id()
-        );
-        Ok(())
+            .map_err(|error| error.to_string())
     }
 
     /// Begin a checkpoint without going through the run-loop.
@@ -150,6 +145,14 @@ impl Master {
     /// Run execution attempts until the pipeline finishes or recovery is exhausted.
     pub async fn execute(&self) -> anyhow::Result<()> {
         let pipeline = self.state.pipeline_context().await?;
-        MasterLifecycle::new(self.state.clone()).run(pipeline).await
+        let lifecycle = MasterLifecycle::spawn(self.state.clone());
+        self.state.set_lifecycle(lifecycle.clone()).await;
+        let result = lifecycle.ask(Start(pipeline)).await;
+        self.state.clear_lifecycle().await;
+        let _ = lifecycle.stop_gracefully().await;
+        match result {
+            Ok(()) => Ok(()),
+            Err(error) => Err(anyhow::anyhow!(error.to_string())),
+        }
     }
 }

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -27,6 +27,7 @@ use super::checkpoint::{
 use super::events::{
     CheckpointPropagationPhase, LifecycleEvent, LifecycleEventRecord, LifecycleJournal,
 };
+use super::lifecycle::MasterLifecycle;
 use super::MasterConfig;
 
 pub(super) struct PipelineContext {
@@ -160,8 +161,10 @@ pub(super) struct MasterState {
     lifecycle_events: Mutex<LifecycleJournal>,
     lifecycle_event_tx: broadcast::Sender<LifecycleEventRecord>,
     current_attempt_id: AtomicU64,
-    /// Handle to the live attempt actor (StopSources `ask`s `Drain` here).
+    /// Live attempt (lifecycle supervises; Drain goes through lifecycle intent).
     current_attempt: Mutex<Option<ActorRef<ExecutionAttempt>>>,
+    /// Job supervisor actor (`RequestFinish` / attempt loop).
+    lifecycle: Mutex<Option<ActorRef<MasterLifecycle>>>,
 }
 
 impl MasterState {
@@ -177,6 +180,7 @@ impl MasterState {
             lifecycle_event_tx,
             current_attempt_id: AtomicU64::new(0),
             current_attempt: Mutex::new(None),
+            lifecycle: Mutex::new(None),
         }
     }
 
@@ -190,6 +194,18 @@ impl MasterState {
 
     pub(super) async fn current_attempt(&self) -> Option<ActorRef<ExecutionAttempt>> {
         self.current_attempt.lock().await.clone()
+    }
+
+    pub(super) async fn set_lifecycle(&self, lifecycle: ActorRef<MasterLifecycle>) {
+        *self.lifecycle.lock().await = Some(lifecycle);
+    }
+
+    pub(super) async fn clear_lifecycle(&self) {
+        *self.lifecycle.lock().await = None;
+    }
+
+    pub(super) async fn lifecycle(&self) -> Option<ActorRef<MasterLifecycle>> {
+        self.lifecycle.lock().await.clone()
     }
 
     /// Assign the scheduled worker set to `execution_attempt_id` (registry SoT).

--- a/src/tests/support/checkpoint/support.rs
+++ b/src/tests/support/checkpoint/support.rs
@@ -200,6 +200,7 @@ pub(super) async fn harness_finish_pipeline(
     // Avoid StopSources during an in-flight CP (timeout → empty-replace recovery).
     wait_until_checkpoints_idle(&cluster.master(), checkpoint_idle_timeout(env)).await?;
 
+    // Sets lifecycle intent=Finish; drain runs now or after the next stable attempt.
     cluster.master().stop_sources().await?;
     LifecycleOracle::wait_for(
         &cluster.master(),


### PR DESCRIPTION
## Summary
- Make `MasterLifecycle` a kameo actor that owns job intent (`Run` | `Finish`) and supervises attempts
- `StopSources` → `RequestFinish` (sets Finish intent); drain only when the attempt is stably runnable, retried after recover via `AttemptRunArmed`
- Exclusive attempt phases: `Running` / `Checkpointing` / `FailureAggregation` / `Draining` (failure window and cooperative finish never overlap)

Base for worker actorification (**#193**).

## Test plan
- [ ] `scripts/test default`
- [ ] inprocess checkpoint / recovery finish paths