### PR TITLE
Make CI Cancel stop stress runs promptly

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -270,14 +270,16 @@ jobs:
           test_name="${{ inputs.stress_test }}"
           echo "kube-stress machine=${{ matrix.machine }} shards_per_machine=$shards runs_per_shard=$runs"
           # Schedule / unset / inproc-default → full kube suite. On-demand can pin a test_kube_*.
+          # exec: stress-test must be the step main process so Cancel (SIGINT/SIGTERM)
+          # hits its trap. A wrapper bash exiting leaves set -m shards immune to SIGINT.
           if [[ "${{ github.event_name }}" != "schedule" && -n "$test_name" && "$test_name" == test_kube_* ]]; then
             echo "kube-stress test=$test_name"
-            scripts/test stress --env kube --test "$test_name" \
+            exec scripts/test stress --env kube --test "$test_name" \
               --runs-per-shard "$runs" \
               --shards "$shards" \
               --fresh-cluster
           else
-            scripts/test stress --env kube --all \
+            exec scripts/test stress --env kube --all \
               --runs-per-shard "$runs" \
               --shards "$shards" \
               --fresh-cluster
@@ -342,7 +344,9 @@ jobs:
             exit 2
           fi
           echo "inproc-stress machine=${{ matrix.machine }} test=$test_name shards_per_machine=$shards runs_per_shard=$runs"
-          scripts/test stress --env local \
+          # exec: stress-test must be the step main process so Cancel (SIGINT/SIGTERM)
+          # hits its trap. A wrapper bash exiting leaves set -m shards immune to SIGINT.
+          exec scripts/test stress --env local \
             --test "$test_name" \
             --runs-per-shard "$runs" \
             --shards "$shards"

--- a/scripts/stress-test
+++ b/scripts/stress-test
@@ -145,7 +145,9 @@ run_shard() {
 }
 
 # Job control: each background shard gets its own process group (pgid == pid) so
-# CI "Cancel workflow" (SIGTERM) and local Ctrl+C can kill nextest/cargo trees.
+# Cancel/Ctrl+C can kill nextest/cargo trees. Background jobs ignore SIGINT under
+# monitor mode — the parent trap must receive the signal (CI steps should `exec`
+# this script) and forward TERM/KILL.
 set -m
 
 pids=()
@@ -159,15 +161,17 @@ kill_shards() {
 }
 
 on_cancel() {
+  # Prevent re-entry while we tear down.
+  trap - INT TERM HUP
   echo "Stress cancelled; stopping shards..." >&2
   touch "$FAILURE_MARKER"
   kill_shards TERM
-  sleep 1
+  sleep 0.2
   kill_shards KILL
   echo "Stress logs: $LOG_DIR" >&2
   exit 130
 }
-trap on_cancel INT TERM
+trap on_cancel INT TERM HUP
 
 for ((shard = 1; shard <= SHARDS; shard++)); do
   run_shard "$shard" &
@@ -181,14 +185,14 @@ for pid in "${pids[@]}"; do
     touch "$FAILURE_MARKER"
     # First shard failure: stop siblings instead of waiting for their remaining runs.
     kill_shards TERM
-    sleep 1
+    sleep 0.2
     kill_shards KILL
     wait 2>/dev/null || true
     break
   fi
 done
 
-trap - INT TERM
+trap - INT TERM HUP
 
 echo "Stress logs: $LOG_DIR"
 if [[ "$failed" -ne 0 ]]; then


### PR DESCRIPTION
## Summary
- Prior stress-cancel fix trapped SIGINT/SIGTERM in `scripts/stress-test`, but CI invoked it from a wrapper bash. Cancel hit the wrapper; monitor-mode background shards ignore SIGINT, so the run loop could continue to `--runs-per-shard`.
- `exec` the stress runner in kube/inproc stress steps so Cancel signals reach the trap.
- Harden cancel trap (HUP, faster TERM→KILL).

## Test plan
- [ ] Merge to master
- [ ] Dispatch a short `inproc-stress` (e.g. 2 machines × 100 runs), press Cancel mid-run, confirm jobs stop within seconds (not after remaining iterations)
- [ ] Confirm artifact upload still skipped on cancel (`success() || failure()`)


Made with [Cursor](https://cursor.com)