### PR TITLE
Metrics: rename latency to path latency (recv − ingest)

### DIFF
--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -101,9 +101,6 @@ pub struct MessageMetadata {
     pub upstream_vertex_id: Option<String>,
     pub ingest_timestamp: Option<u64>,
     pub extras: Option<HashMap<String, String>>,
-    /// Local task recv wall time (ms); not serialized — dwell is per-task only.
-    #[serde(skip)]
-    pub recv_timestamp: Option<u64>,
 }
 
 impl MessageMetadata {
@@ -116,7 +113,6 @@ impl MessageMetadata {
             upstream_vertex_id,
             ingest_timestamp,
             extras,
-            recv_timestamp: None,
         }
     }
 
@@ -354,26 +350,6 @@ impl Message {
             Message::Keyed(message) => message.base.set_ingest_timestamp(ingest_timestamp),
             Message::Watermark(message) => message.set_ingest_timestamp(ingest_timestamp),
             Message::CheckpointBarrier(message) => message.set_ingest_timestamp(ingest_timestamp),
-        }
-    }
-
-    pub fn recv_timestamp(&self) -> Option<u64> {
-        match self {
-            Message::Regular(message) => message.metadata.recv_timestamp,
-            Message::Keyed(message) => message.base.metadata.recv_timestamp,
-            Message::Watermark(message) => message.metadata.recv_timestamp,
-            Message::CheckpointBarrier(message) => message.metadata.recv_timestamp,
-        }
-    }
-
-    pub fn set_recv_timestamp(&mut self, recv_timestamp: u64) {
-        match self {
-            Message::Regular(message) => message.metadata.recv_timestamp = Some(recv_timestamp),
-            Message::Keyed(message) => message.base.metadata.recv_timestamp = Some(recv_timestamp),
-            Message::Watermark(message) => message.metadata.recv_timestamp = Some(recv_timestamp),
-            Message::CheckpointBarrier(message) => {
-                message.metadata.recv_timestamp = Some(recv_timestamp)
-            }
         }
     }
 

--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -16,7 +16,7 @@ impl BaseMessage {
     pub fn new(upstream_vertex_id: Option<String>, record_batch: RecordBatch, ingest_timestamp: Option<u64>, extras: Option<HashMap<String, String>>) -> Self {
         Self {
             record_batch,
-            metadata: MessageMetadata { upstream_vertex_id, ingest_timestamp, extras }
+            metadata: MessageMetadata::new(upstream_vertex_id, ingest_timestamp, extras),
         }
     }
 
@@ -101,9 +101,25 @@ pub struct MessageMetadata {
     pub upstream_vertex_id: Option<String>,
     pub ingest_timestamp: Option<u64>,
     pub extras: Option<HashMap<String, String>>,
+    /// Local task recv wall time (ms); not serialized — dwell is per-task only.
+    #[serde(skip)]
+    pub recv_timestamp: Option<u64>,
 }
 
 impl MessageMetadata {
+    pub fn new(
+        upstream_vertex_id: Option<String>,
+        ingest_timestamp: Option<u64>,
+        extras: Option<HashMap<String, String>>,
+    ) -> Self {
+        Self {
+            upstream_vertex_id,
+            ingest_timestamp,
+            extras,
+            recv_timestamp: None,
+        }
+    }
+
     pub fn get_memory_size(&self) -> usize {
         // Option<u64> = 8 bytes, Option<String> = 24 bytes + string length
         let mut len = 0;
@@ -119,7 +135,7 @@ impl MessageMetadata {
             }
         }
         
-        8 + 24 + 24 + len // u64 + Option<String> + Option<HashMap> + content
+        8 + 24 + 24 + len // ingest u64 + Option<String> + Option<HashMap> + content
     }
 }
 
@@ -202,11 +218,7 @@ impl WatermarkMessage {
     pub fn new(upstream_vertex_id: String, watermark_value: u64, ingest_timestamp: Option<u64>) -> Self {
         Self {
             watermark_value,
-            metadata: MessageMetadata {
-                upstream_vertex_id: Some(upstream_vertex_id),
-                ingest_timestamp,
-                extras: None
-            }
+            metadata: MessageMetadata::new(Some(upstream_vertex_id), ingest_timestamp, None),
         }
     }
 
@@ -253,11 +265,7 @@ impl CheckpointBarrierMessage {
         Self {
             checkpoint_id,
             execution_attempt_id,
-            metadata: MessageMetadata {
-                upstream_vertex_id: Some(upstream_vertex_id),
-                ingest_timestamp,
-                extras: None,
-            },
+            metadata: MessageMetadata::new(Some(upstream_vertex_id), ingest_timestamp, None),
         }
     }
 
@@ -346,6 +354,26 @@ impl Message {
             Message::Keyed(message) => message.base.set_ingest_timestamp(ingest_timestamp),
             Message::Watermark(message) => message.set_ingest_timestamp(ingest_timestamp),
             Message::CheckpointBarrier(message) => message.set_ingest_timestamp(ingest_timestamp),
+        }
+    }
+
+    pub fn recv_timestamp(&self) -> Option<u64> {
+        match self {
+            Message::Regular(message) => message.metadata.recv_timestamp,
+            Message::Keyed(message) => message.base.metadata.recv_timestamp,
+            Message::Watermark(message) => message.metadata.recv_timestamp,
+            Message::CheckpointBarrier(message) => message.metadata.recv_timestamp,
+        }
+    }
+
+    pub fn set_recv_timestamp(&mut self, recv_timestamp: u64) {
+        match self {
+            Message::Regular(message) => message.metadata.recv_timestamp = Some(recv_timestamp),
+            Message::Keyed(message) => message.base.metadata.recv_timestamp = Some(recv_timestamp),
+            Message::Watermark(message) => message.metadata.recv_timestamp = Some(recv_timestamp),
+            Message::CheckpointBarrier(message) => {
+                message.metadata.recv_timestamp = Some(recv_timestamp)
+            }
         }
     }
 

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -94,11 +94,6 @@ pub fn print_pipeline_state(
                     println!("      P95: {:.2}ms", operator_metrics.path_latency.p95);
                     println!("      P50: {:.2}ms", operator_metrics.path_latency.p50);
                     println!("      Avg: {:.2}ms", operator_metrics.path_latency.avg);
-                    println!("    Dwell:");
-                    println!("      P99: {:.2}ms", operator_metrics.dwell.p99);
-                    println!("      P95: {:.2}ms", operator_metrics.dwell.p95);
-                    println!("      P50: {:.2}ms", operator_metrics.dwell.p50);
-                    println!("      Avg: {:.2}ms", operator_metrics.dwell.avg);
                     has_operator_metrics = true;
                 }
             }
@@ -139,11 +134,6 @@ pub fn print_pipeline_state(
                     println!("      P95: {:.2}ms", task_metrics.path_latency.p95);
                     println!("      P50: {:.2}ms", task_metrics.path_latency.p50);
                     println!("      Avg: {:.2}ms", task_metrics.path_latency.avg);
-                    println!("    Dwell:");
-                    println!("      P99: {:.2}ms", task_metrics.dwell.p99);
-                    println!("      P95: {:.2}ms", task_metrics.dwell.p95);
-                    println!("      P50: {:.2}ms", task_metrics.dwell.p50);
-                    println!("      Avg: {:.2}ms", task_metrics.dwell.avg);
                     if !task_metrics.backpressure_per_peer.is_empty() {
                         println!("    Backpressure per Peer:");
                         for (peer_id, ratio) in &task_metrics.backpressure_per_peer {

--- a/src/common/test_utils.rs
+++ b/src/common/test_utils.rs
@@ -89,11 +89,16 @@ pub fn print_pipeline_state(
                     println!("      Records Recv: {} (total)", operator_metrics.throughput_metrics.records_recv);
                     println!("      Bytes Sent: {} (total)", operator_metrics.throughput_metrics.bytes_sent);
                     println!("      Bytes Recv: {} (total)", operator_metrics.throughput_metrics.bytes_recv);
-                    println!("    Latency:");
-                    println!("      P99: {:.2}ms", operator_metrics.latency_metrics.p99);
-                    println!("      P95: {:.2}ms", operator_metrics.latency_metrics.p95);
-                    println!("      P50: {:.2}ms", operator_metrics.latency_metrics.p50);
-                    println!("      Avg: {:.2}ms", operator_metrics.latency_metrics.avg);
+                    println!("    Path latency:");
+                    println!("      P99: {:.2}ms", operator_metrics.path_latency.p99);
+                    println!("      P95: {:.2}ms", operator_metrics.path_latency.p95);
+                    println!("      P50: {:.2}ms", operator_metrics.path_latency.p50);
+                    println!("      Avg: {:.2}ms", operator_metrics.path_latency.avg);
+                    println!("    Dwell:");
+                    println!("      P99: {:.2}ms", operator_metrics.dwell.p99);
+                    println!("      P95: {:.2}ms", operator_metrics.dwell.p95);
+                    println!("      P50: {:.2}ms", operator_metrics.dwell.p50);
+                    println!("      Avg: {:.2}ms", operator_metrics.dwell.avg);
                     has_operator_metrics = true;
                 }
             }
@@ -129,11 +134,16 @@ pub fn print_pipeline_state(
                         }
                     }
                     
-                    println!("    Latency:");
-                    println!("      P99: {:.2}ms", task_metrics.latency_stats.p99);
-                    println!("      P95: {:.2}ms", task_metrics.latency_stats.p95);
-                    println!("      P50: {:.2}ms", task_metrics.latency_stats.p50);
-                    println!("      Avg: {:.2}ms", task_metrics.latency_stats.avg);
+                    println!("    Path latency:");
+                    println!("      P99: {:.2}ms", task_metrics.path_latency.p99);
+                    println!("      P95: {:.2}ms", task_metrics.path_latency.p95);
+                    println!("      P50: {:.2}ms", task_metrics.path_latency.p50);
+                    println!("      Avg: {:.2}ms", task_metrics.path_latency.avg);
+                    println!("    Dwell:");
+                    println!("      P99: {:.2}ms", task_metrics.dwell.p99);
+                    println!("      P95: {:.2}ms", task_metrics.dwell.p95);
+                    println!("      P50: {:.2}ms", task_metrics.dwell.p50);
+                    println!("      Avg: {:.2}ms", task_metrics.dwell.avg);
                     if !task_metrics.backpressure_per_peer.is_empty() {
                         println!("    Backpressure per Peer:");
                         for (peer_id, ratio) in &task_metrics.backpressure_per_peer {

--- a/src/runtime/observability/metrics/mod.rs
+++ b/src/runtime/observability/metrics/mod.rs
@@ -27,11 +27,18 @@ pub const METRIC_STREAM_TASK_RECORDS_SENT: &str = "volga_stream_task_records_sen
 pub const METRIC_STREAM_TASK_RECORDS_RECV: &str = "volga_stream_task_records_recv";
 pub const METRIC_STREAM_TASK_BYTES_SENT: &str = "volga_stream_task_bytes_sent";
 pub const METRIC_STREAM_TASK_BYTES_RECV: &str = "volga_stream_task_bytes_recv";
-pub const METRIC_STREAM_TASK_LATENCY: &str = "volga_stream_task_latency";
-pub const METRIC_STREAM_TASK_LATENCY_99: &str = "volga_stream_task_latency_99";
-pub const METRIC_STREAM_TASK_LATENCY_95: &str = "volga_stream_task_latency_95";
-pub const METRIC_STREAM_TASK_LATENCY_50: &str = "volga_stream_task_latency_50";
-pub const METRIC_STREAM_TASK_LATENCY_AVG: &str = "volga_stream_task_latency_avg";
+/// Path latency histogram: `recv − ingest` (ms). Omit when ingest is absent.
+pub const METRIC_STREAM_TASK_PATH_LATENCY: &str = "volga_stream_task_path_latency";
+pub const METRIC_STREAM_TASK_PATH_LATENCY_99: &str = "volga_stream_task_path_latency_99";
+pub const METRIC_STREAM_TASK_PATH_LATENCY_95: &str = "volga_stream_task_path_latency_95";
+pub const METRIC_STREAM_TASK_PATH_LATENCY_50: &str = "volga_stream_task_path_latency_50";
+pub const METRIC_STREAM_TASK_PATH_LATENCY_AVG: &str = "volga_stream_task_path_latency_avg";
+/// Task dwell histogram: `send − recv` (ms). Omit when this task did not stamp recv.
+pub const METRIC_STREAM_TASK_DWELL: &str = "volga_stream_task_dwell";
+pub const METRIC_STREAM_TASK_DWELL_99: &str = "volga_stream_task_dwell_99";
+pub const METRIC_STREAM_TASK_DWELL_95: &str = "volga_stream_task_dwell_95";
+pub const METRIC_STREAM_TASK_DWELL_50: &str = "volga_stream_task_dwell_50";
+pub const METRIC_STREAM_TASK_DWELL_AVG: &str = "volga_stream_task_dwell_avg";
 pub const METRIC_STREAM_TASK_TX_QUEUE_SIZE: &str = "volga_stream_task_tx_queue_size";
 pub const METRIC_STREAM_TASK_TX_QUEUE_REM: &str = "volga_stream_task_tx_queue_rem";
 pub const METRIC_STREAM_TASK_BACKPRESSURE_RATIO: &str = "volga_stream_task_backpressure_ratio";
@@ -47,10 +54,14 @@ pub const METRIC_OPERATOR_RECORDS_SENT: &str = "volga_operator_records_sent";
 pub const METRIC_OPERATOR_RECORDS_RECV: &str = "volga_operator_records_recv";
 pub const METRIC_OPERATOR_BYTES_SENT: &str = "volga_operator_bytes_sent";
 pub const METRIC_OPERATOR_BYTES_RECV: &str = "volga_operator_bytes_recv";
-pub const METRIC_OPERATOR_LATENCY_99: &str = "volga_operator_latency_99";
-pub const METRIC_OPERATOR_LATENCY_95: &str = "volga_operator_latency_95";
-pub const METRIC_OPERATOR_LATENCY_50: &str = "volga_operator_latency_50";
-pub const METRIC_OPERATOR_LATENCY_AVG: &str = "volga_operator_latency_avg";
+pub const METRIC_OPERATOR_PATH_LATENCY_99: &str = "volga_operator_path_latency_99";
+pub const METRIC_OPERATOR_PATH_LATENCY_95: &str = "volga_operator_path_latency_95";
+pub const METRIC_OPERATOR_PATH_LATENCY_50: &str = "volga_operator_path_latency_50";
+pub const METRIC_OPERATOR_PATH_LATENCY_AVG: &str = "volga_operator_path_latency_avg";
+pub const METRIC_OPERATOR_DWELL_99: &str = "volga_operator_dwell_99";
+pub const METRIC_OPERATOR_DWELL_95: &str = "volga_operator_dwell_95";
+pub const METRIC_OPERATOR_DWELL_50: &str = "volga_operator_dwell_50";
+pub const METRIC_OPERATOR_DWELL_AVG: &str = "volga_operator_dwell_avg";
 
 // Label constants
 pub const LABEL_VERTEX_ID: &str = "vertex_id";
@@ -88,7 +99,8 @@ pub const LATENCY_HISTOGRAM_LEN: usize = LATENCY_BUCKET_BOUNDARIES.len() + 1;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LatencyMetrics {
-    pub latency_histogram: Vec<u64>, // latency is calculated from ingestion time to this task
+    /// Cumulative hist buckets (finite bounds + trailing +Inf count).
+    pub latency_histogram: Vec<u64>,
     pub p99: f64,
     pub p95: f64,
     pub p50: f64,
@@ -244,7 +256,8 @@ impl ThroughputMetrics {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskMetrics {
     pub vertex_id: String,
-    pub latency_stats: LatencyMetrics,
+    pub path_latency: LatencyMetrics,
+    pub dwell: LatencyMetrics,
     pub throughput_stast: ThroughputMetrics,
     pub backpressure_per_peer: HashMap<String, f64>,
 }
@@ -253,7 +266,8 @@ impl TaskMetrics {
     pub fn empty(vertex_id: impl Into<String>) -> Self {
         Self {
             vertex_id: vertex_id.into(),
-            latency_stats: LatencyMetrics::new(vec![0u64; LATENCY_HISTOGRAM_LEN]),
+            path_latency: LatencyMetrics::new(vec![0u64; LATENCY_HISTOGRAM_LEN]),
+            dwell: LatencyMetrics::new(vec![0u64; LATENCY_HISTOGRAM_LEN]),
             throughput_stast: ThroughputMetrics::new(0, 0, 0, 0, 0, 0),
             backpressure_per_peer: HashMap::new(),
         }
@@ -264,18 +278,23 @@ impl TaskMetrics {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OperatorAggregateMetrics {
     pub operator_id: String,
-    pub latency_metrics: LatencyMetrics,
+    pub path_latency: LatencyMetrics,
+    pub dwell: LatencyMetrics,
     pub throughput_metrics: ThroughputMetrics,
 }
 
 impl OperatorAggregateMetrics {
     pub fn new(operator_id: String, task_metrics: Vec<TaskMetrics>) -> Self {
-        let latency_stats = LatencyMetrics::merge(task_metrics.iter().map(|m| &m.latency_stats).collect());
-        let throughput_stats = ThroughputMetrics::merge(task_metrics.iter().map(|m| &m.throughput_stast).collect());
+        let path_latency =
+            LatencyMetrics::merge(task_metrics.iter().map(|m| &m.path_latency).collect());
+        let dwell = LatencyMetrics::merge(task_metrics.iter().map(|m| &m.dwell).collect());
+        let throughput_stats =
+            ThroughputMetrics::merge(task_metrics.iter().map(|m| &m.throughput_stast).collect());
 
         OperatorAggregateMetrics {
             operator_id,
-            latency_metrics: latency_stats,
+            path_latency,
+            dwell,
             throughput_metrics: throughput_stats,
         }
     }
@@ -368,59 +387,105 @@ impl WorkerAggregateMetrics {
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
             ).set(throughput.bytes_recv as f64);
             
-            // Record latency metrics
             gauge!(
-                METRIC_OPERATOR_LATENCY_99,
+                METRIC_OPERATOR_PATH_LATENCY_99,
                 LABEL_OPERATOR_ID => operator_id.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(operator_metrics.latency_metrics.p99);
+            ).set(operator_metrics.path_latency.p99);
             gauge!(
-                METRIC_OPERATOR_LATENCY_95,
+                METRIC_OPERATOR_PATH_LATENCY_95,
                 LABEL_OPERATOR_ID => operator_id.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(operator_metrics.latency_metrics.p95);
+            ).set(operator_metrics.path_latency.p95);
             gauge!(
-                METRIC_OPERATOR_LATENCY_50,
+                METRIC_OPERATOR_PATH_LATENCY_50,
                 LABEL_OPERATOR_ID => operator_id.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(operator_metrics.latency_metrics.p50);
+            ).set(operator_metrics.path_latency.p50);
             gauge!(
-                METRIC_OPERATOR_LATENCY_AVG,
+                METRIC_OPERATOR_PATH_LATENCY_AVG,
                 LABEL_OPERATOR_ID => operator_id.clone(),
-                LABEL_WORKER_ID => self.worker_id.clone(),  
+                LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(operator_metrics.latency_metrics.avg);
+            ).set(operator_metrics.path_latency.avg);
+            gauge!(
+                METRIC_OPERATOR_DWELL_99,
+                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_WORKER_ID => self.worker_id.clone(),
+                LABEL_PIPELINE_ID => pipeline_id.clone(),
+            ).set(operator_metrics.dwell.p99);
+            gauge!(
+                METRIC_OPERATOR_DWELL_95,
+                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_WORKER_ID => self.worker_id.clone(),
+                LABEL_PIPELINE_ID => pipeline_id.clone(),
+            ).set(operator_metrics.dwell.p95);
+            gauge!(
+                METRIC_OPERATOR_DWELL_50,
+                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_WORKER_ID => self.worker_id.clone(),
+                LABEL_PIPELINE_ID => pipeline_id.clone(),
+            ).set(operator_metrics.dwell.p50);
+            gauge!(
+                METRIC_OPERATOR_DWELL_AVG,
+                LABEL_OPERATOR_ID => operator_id.clone(),
+                LABEL_WORKER_ID => self.worker_id.clone(),
+                LABEL_PIPELINE_ID => pipeline_id.clone(),
+            ).set(operator_metrics.dwell.avg);
         }
-        
-        // Record stream task latency metrics
+
         for (vertex_id, task_metrics) in self.tasks_metrics.iter() {
             gauge!(
-                METRIC_STREAM_TASK_LATENCY_99,
+                METRIC_STREAM_TASK_PATH_LATENCY_99,
                 LABEL_VERTEX_ID => vertex_id.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(task_metrics.latency_stats.p99);
+            ).set(task_metrics.path_latency.p99);
             gauge!(
-                METRIC_STREAM_TASK_LATENCY_95,
+                METRIC_STREAM_TASK_PATH_LATENCY_95,
                 LABEL_VERTEX_ID => vertex_id.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(task_metrics.latency_stats.p95);
+            ).set(task_metrics.path_latency.p95);
             gauge!(
-                METRIC_STREAM_TASK_LATENCY_50,
+                METRIC_STREAM_TASK_PATH_LATENCY_50,
                 LABEL_VERTEX_ID => vertex_id.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(task_metrics.latency_stats.p50);
+            ).set(task_metrics.path_latency.p50);
             gauge!(
-                METRIC_STREAM_TASK_LATENCY_AVG,
+                METRIC_STREAM_TASK_PATH_LATENCY_AVG,
                 LABEL_VERTEX_ID => vertex_id.clone(),
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(task_metrics.latency_stats.avg);
+            ).set(task_metrics.path_latency.avg);
+            gauge!(
+                METRIC_STREAM_TASK_DWELL_99,
+                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_WORKER_ID => self.worker_id.clone(),
+                LABEL_PIPELINE_ID => pipeline_id.clone(),
+            ).set(task_metrics.dwell.p99);
+            gauge!(
+                METRIC_STREAM_TASK_DWELL_95,
+                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_WORKER_ID => self.worker_id.clone(),
+                LABEL_PIPELINE_ID => pipeline_id.clone(),
+            ).set(task_metrics.dwell.p95);
+            gauge!(
+                METRIC_STREAM_TASK_DWELL_50,
+                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_WORKER_ID => self.worker_id.clone(),
+                LABEL_PIPELINE_ID => pipeline_id.clone(),
+            ).set(task_metrics.dwell.p50);
+            gauge!(
+                METRIC_STREAM_TASK_DWELL_AVG,
+                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_WORKER_ID => self.worker_id.clone(),
+                LABEL_PIPELINE_ID => pipeline_id.clone(),
+            ).set(task_metrics.dwell.avg);
         }
     }
 }
@@ -747,25 +812,23 @@ impl PipelineStateHistory {
             });
         }
         
-        // Aggregate latency histograms per task across all samples
-        let mut latency_histograms_per_task: HashMap<String, Vec<&LatencyMetrics>> = HashMap::new();
+        // Aggregate path-latency histograms per task across all samples
+        let mut path_latency_hists_per_task: HashMap<String, Vec<&LatencyMetrics>> = HashMap::new();
         
         for (_timestamp, pipeline_state) in &self.samples {
             for (_worker_id, worker_state) in &pipeline_state.worker_states {
                 if let Some(worker_metrics) = &worker_state.worker_metrics {
                     for (vertex_id, task_metrics) in &worker_metrics.tasks_metrics {
-                        latency_histograms_per_task.entry(vertex_id.clone())
+                        path_latency_hists_per_task.entry(vertex_id.clone())
                             .or_insert_with(Vec::new)
-                            .push(&task_metrics.latency_stats);
+                            .push(&task_metrics.path_latency);
                     }
                 }
             }
         }
         
-        // Merge histograms and calculate stats for each task
-        for (vertex_id, latency_metrics_vec) in latency_histograms_per_task {
-            let merged_latency = LatencyMetrics::merge(latency_metrics_vec);
-            latency_per_task.insert(vertex_id, merged_latency);
+        for (vertex_id, hist_vec) in path_latency_hists_per_task {
+            latency_per_task.insert(vertex_id, LatencyMetrics::merge(hist_vec));
         }
         
         FinalStats {
@@ -891,7 +954,8 @@ fn parse_all_stream_task_metrics(
         records_recv: u64,
         bytes_sent: u64,
         bytes_recv: u64,
-        latency_histogram: Option<Vec<u64>>,
+        path_latency_histogram: Option<Vec<u64>>,
+        dwell_histogram: Option<Vec<u64>>,
         backpressure_per_peer: HashMap<String, f64>,
     }
 
@@ -923,12 +987,17 @@ fn parse_all_stream_task_metrics(
                 METRIC_STREAM_TASK_BYTES_RECV => acc.bytes_recv = value as u64,
                 _ => {}
             },
-            Value::Histogram(histogram_counts) => {
-                if sample.metric == METRIC_STREAM_TASK_LATENCY {
-                    acc.latency_histogram =
+            Value::Histogram(histogram_counts) => match sample.metric.as_str() {
+                METRIC_STREAM_TASK_PATH_LATENCY => {
+                    acc.path_latency_histogram =
                         Some(convert_histogram_counts_to_buckets(&histogram_counts));
                 }
-            }
+                METRIC_STREAM_TASK_DWELL => {
+                    acc.dwell_histogram =
+                        Some(convert_histogram_counts_to_buckets(&histogram_counts));
+                }
+                _ => {}
+            },
             Value::Gauge(value) => {
                 if sample.metric == METRIC_STREAM_TASK_BACKPRESSURE_RATIO {
                     if let Some(peer_vertex_id) = sample.labels.get(LABEL_TARGET_VERTEX_ID) {
@@ -944,14 +1013,15 @@ fn parse_all_stream_task_metrics(
     by_vertex
         .into_iter()
         .map(|(vertex_id, acc)| {
-            let latency_histogram = acc
-                .latency_histogram
-                .unwrap_or_else(|| vec![0u64; LATENCY_HISTOGRAM_LEN]);
+            let empty_hist = || vec![0u64; LATENCY_HISTOGRAM_LEN];
             (
                 vertex_id.clone(),
                 TaskMetrics {
                     vertex_id,
-                    latency_stats: LatencyMetrics::new(latency_histogram),
+                    path_latency: LatencyMetrics::new(
+                        acc.path_latency_histogram.unwrap_or_else(empty_hist),
+                    ),
+                    dwell: LatencyMetrics::new(acc.dwell_histogram.unwrap_or_else(empty_hist)),
                     throughput_stast: ThroughputMetrics::new(
                         acc.messages_sent,
                         acc.messages_recv,
@@ -1060,25 +1130,32 @@ mod tests {
             LABEL_WORKER_ID => labels.worker_id.clone()
         ).increment(512);
         
-        // Define latency measurements to record
-        let latency_measurements = [5.0, 25.0, 150.0, 2.5, 75.0];
-        
-        // Record latencies using metrics
-        for &latency in &latency_measurements {
+        let path_measurements = [5.0, 25.0, 150.0, 2.5, 75.0];
+        let dwell_measurements = [1.0, 3.0, 8.0];
+        for &latency in &path_measurements {
             histogram!(
-                METRIC_STREAM_TASK_LATENCY,
+                METRIC_STREAM_TASK_PATH_LATENCY,
                 LABEL_VERTEX_ID => vertex_id.clone(),
                 LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                 LABEL_WORKER_ID => labels.worker_id.clone()
-            ).record(latency);
+            )
+            .record(latency);
         }
-        
-        // Build expected histogram manually
-        let expected_histogram = build_expected_histogram(&latency_measurements, &LATENCY_BUCKET_BOUNDARIES);
-        
+        for &dwell in &dwell_measurements {
+            histogram!(
+                METRIC_STREAM_TASK_DWELL,
+                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                LABEL_WORKER_ID => labels.worker_id.clone()
+            )
+            .record(dwell);
+        }
+
+        let expected_path = build_expected_histogram(&path_measurements, &LATENCY_BUCKET_BOUNDARIES);
+        let expected_dwell = build_expected_histogram(&dwell_measurements, &LATENCY_BUCKET_BOUNDARIES);
+
         let parsed_metrics = get_stream_task_metrics(Arc::<str>::from(vertex_id.clone()), Some(&labels));
-        
-        // Verify the parsed stream task metrics
+
         assert_eq!(parsed_metrics.vertex_id, vertex_id);
         assert_eq!(parsed_metrics.throughput_stast.messages_sent, 5);
         assert_eq!(parsed_metrics.throughput_stast.messages_recv, 3);
@@ -1086,68 +1163,45 @@ mod tests {
         assert_eq!(parsed_metrics.throughput_stast.records_recv, 15);
         assert_eq!(parsed_metrics.throughput_stast.bytes_sent, 1024);
         assert_eq!(parsed_metrics.throughput_stast.bytes_recv, 512);
-        
-        // Verify histogram has data
-        assert!(!parsed_metrics.latency_stats.latency_histogram.is_empty(), "Histogram should not be empty");
-        
-        // Verify exact match between expected and parsed histogram (finite + +Inf)
+
+        assert_eq!(parsed_metrics.path_latency.latency_histogram, expected_path);
+        assert_eq!(parsed_metrics.dwell.latency_histogram, expected_dwell);
         assert_eq!(
-            parsed_metrics.latency_stats.latency_histogram.len(), 
-            expected_histogram.len(),
-            "Histogram should have finite buckets plus +Inf"
+            *parsed_metrics.path_latency.latency_histogram.last().unwrap(),
+            path_measurements.len() as u64
         );
         assert_eq!(
-            parsed_metrics.latency_stats.latency_histogram.len(),
-            LATENCY_HISTOGRAM_LEN
+            *parsed_metrics.dwell.latency_histogram.last().unwrap(),
+            dwell_measurements.len() as u64
         );
-        
-        for (i, (&expected, &actual)) in expected_histogram.iter().zip(parsed_metrics.latency_stats.latency_histogram.iter()).enumerate() {
-            let boundary_label = if i < LATENCY_BUCKET_BOUNDARIES.len() {
-                format!("{}ms", LATENCY_BUCKET_BOUNDARIES[i])
-            } else {
-                "+Inf".to_string()
-            };
-            assert_eq!(
-                actual, expected,
-                "Bucket {} mismatch: expected {}, got {} (boundary: {})", 
-                i, expected, actual, boundary_label
-            );
-        }
-        
-        // Verify we recorded all latency values (+Inf cumulative)
-        let total_count = parsed_metrics.latency_stats.latency_histogram.last().unwrap_or(&0);
-        assert_eq!(*total_count, latency_measurements.len() as u64, 
-                   "Should have recorded {} latency measurements", latency_measurements.len());
-        
-        // Test vertex isolation with a second vertex
+
         let vertex_b = "task_b".to_string();
         counter!(
             METRIC_STREAM_TASK_MESSAGES_SENT,
             LABEL_VERTEX_ID => vertex_b.clone(),
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_WORKER_ID => labels.worker_id.clone()
-        ).increment(1);
+        )
+        .increment(1);
         counter!(
             METRIC_STREAM_TASK_RECORDS_SENT,
             LABEL_VERTEX_ID => vertex_b.clone(),
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_WORKER_ID => labels.worker_id.clone()
-        ).increment(50);
-        
+        )
+        .increment(50);
+
         let metrics_b = get_stream_task_metrics(Arc::<str>::from(vertex_b.clone()), Some(&labels));
-        
-        // Verify isolation - vertex B should only see its own metrics
+
         assert_eq!(metrics_b.vertex_id, vertex_b);
         assert_eq!(metrics_b.throughput_stast.messages_sent, 1);
         assert_eq!(metrics_b.throughput_stast.records_sent, 50);
-        assert_eq!(metrics_b.throughput_stast.messages_recv, 0); // Not set for vertex B
-        
-        // Verify original vertex still has correct metrics
+        assert_eq!(metrics_b.throughput_stast.messages_recv, 0);
+
         let metrics_a_again = get_stream_task_metrics(Arc::<str>::from(vertex_id.clone()), Some(&labels));
         assert_eq!(metrics_a_again.throughput_stast.messages_sent, 5);
         assert_eq!(metrics_a_again.throughput_stast.records_sent, 25);
 
-        // One scrape returns both vertices
         let all = scrape_stream_task_metrics(Some(&labels));
         assert_eq!(all.get(&vertex_id).unwrap().throughput_stast.messages_sent, 5);
         assert_eq!(all.get(&vertex_b).unwrap().throughput_stast.messages_sent, 1);
@@ -1167,7 +1221,7 @@ mod tests {
         let latency_measurements = [10.0, 10_000.0];
         for &latency in &latency_measurements {
             histogram!(
-                METRIC_STREAM_TASK_LATENCY,
+                METRIC_STREAM_TASK_PATH_LATENCY,
                 LABEL_VERTEX_ID => vertex_id.clone(),
                 LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
                 LABEL_WORKER_ID => labels.worker_id.clone()
@@ -1178,11 +1232,11 @@ mod tests {
         let expected = build_expected_histogram(&latency_measurements, &LATENCY_BUCKET_BOUNDARIES);
         let parsed = get_stream_task_metrics(Arc::<str>::from(vertex_id), Some(&labels));
 
-        assert_eq!(parsed.latency_stats.latency_histogram, expected);
-        assert_eq!(*parsed.latency_stats.latency_histogram.last().unwrap(), 2);
+        assert_eq!(parsed.path_latency.latency_histogram, expected);
+        assert_eq!(*parsed.path_latency.latency_histogram.last().unwrap(), 2);
         // Last finite cumulative count should be 1 (only the 10ms sample)
         assert_eq!(
-            parsed.latency_stats.latency_histogram[LATENCY_BUCKET_BOUNDARIES.len() - 1],
+            parsed.path_latency.latency_histogram[LATENCY_BUCKET_BOUNDARIES.len() - 1],
             1
         );
 

--- a/src/runtime/observability/metrics/mod.rs
+++ b/src/runtime/observability/metrics/mod.rs
@@ -33,12 +33,6 @@ pub const METRIC_STREAM_TASK_PATH_LATENCY_99: &str = "volga_stream_task_path_lat
 pub const METRIC_STREAM_TASK_PATH_LATENCY_95: &str = "volga_stream_task_path_latency_95";
 pub const METRIC_STREAM_TASK_PATH_LATENCY_50: &str = "volga_stream_task_path_latency_50";
 pub const METRIC_STREAM_TASK_PATH_LATENCY_AVG: &str = "volga_stream_task_path_latency_avg";
-/// Task dwell histogram: `send − recv` (ms). Omit when this task did not stamp recv.
-pub const METRIC_STREAM_TASK_DWELL: &str = "volga_stream_task_dwell";
-pub const METRIC_STREAM_TASK_DWELL_99: &str = "volga_stream_task_dwell_99";
-pub const METRIC_STREAM_TASK_DWELL_95: &str = "volga_stream_task_dwell_95";
-pub const METRIC_STREAM_TASK_DWELL_50: &str = "volga_stream_task_dwell_50";
-pub const METRIC_STREAM_TASK_DWELL_AVG: &str = "volga_stream_task_dwell_avg";
 pub const METRIC_STREAM_TASK_TX_QUEUE_SIZE: &str = "volga_stream_task_tx_queue_size";
 pub const METRIC_STREAM_TASK_TX_QUEUE_REM: &str = "volga_stream_task_tx_queue_rem";
 pub const METRIC_STREAM_TASK_BACKPRESSURE_RATIO: &str = "volga_stream_task_backpressure_ratio";
@@ -58,10 +52,6 @@ pub const METRIC_OPERATOR_PATH_LATENCY_99: &str = "volga_operator_path_latency_9
 pub const METRIC_OPERATOR_PATH_LATENCY_95: &str = "volga_operator_path_latency_95";
 pub const METRIC_OPERATOR_PATH_LATENCY_50: &str = "volga_operator_path_latency_50";
 pub const METRIC_OPERATOR_PATH_LATENCY_AVG: &str = "volga_operator_path_latency_avg";
-pub const METRIC_OPERATOR_DWELL_99: &str = "volga_operator_dwell_99";
-pub const METRIC_OPERATOR_DWELL_95: &str = "volga_operator_dwell_95";
-pub const METRIC_OPERATOR_DWELL_50: &str = "volga_operator_dwell_50";
-pub const METRIC_OPERATOR_DWELL_AVG: &str = "volga_operator_dwell_avg";
 
 // Label constants
 pub const LABEL_VERTEX_ID: &str = "vertex_id";
@@ -257,7 +247,6 @@ impl ThroughputMetrics {
 pub struct TaskMetrics {
     pub vertex_id: String,
     pub path_latency: LatencyMetrics,
-    pub dwell: LatencyMetrics,
     pub throughput_stast: ThroughputMetrics,
     pub backpressure_per_peer: HashMap<String, f64>,
 }
@@ -267,7 +256,6 @@ impl TaskMetrics {
         Self {
             vertex_id: vertex_id.into(),
             path_latency: LatencyMetrics::new(vec![0u64; LATENCY_HISTOGRAM_LEN]),
-            dwell: LatencyMetrics::new(vec![0u64; LATENCY_HISTOGRAM_LEN]),
             throughput_stast: ThroughputMetrics::new(0, 0, 0, 0, 0, 0),
             backpressure_per_peer: HashMap::new(),
         }
@@ -279,7 +267,6 @@ impl TaskMetrics {
 pub struct OperatorAggregateMetrics {
     pub operator_id: String,
     pub path_latency: LatencyMetrics,
-    pub dwell: LatencyMetrics,
     pub throughput_metrics: ThroughputMetrics,
 }
 
@@ -287,14 +274,12 @@ impl OperatorAggregateMetrics {
     pub fn new(operator_id: String, task_metrics: Vec<TaskMetrics>) -> Self {
         let path_latency =
             LatencyMetrics::merge(task_metrics.iter().map(|m| &m.path_latency).collect());
-        let dwell = LatencyMetrics::merge(task_metrics.iter().map(|m| &m.dwell).collect());
         let throughput_stats =
             ThroughputMetrics::merge(task_metrics.iter().map(|m| &m.throughput_stast).collect());
 
         OperatorAggregateMetrics {
             operator_id,
             path_latency,
-            dwell,
             throughput_metrics: throughput_stats,
         }
     }
@@ -411,30 +396,6 @@ impl WorkerAggregateMetrics {
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
             ).set(operator_metrics.path_latency.avg);
-            gauge!(
-                METRIC_OPERATOR_DWELL_99,
-                LABEL_OPERATOR_ID => operator_id.clone(),
-                LABEL_WORKER_ID => self.worker_id.clone(),
-                LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(operator_metrics.dwell.p99);
-            gauge!(
-                METRIC_OPERATOR_DWELL_95,
-                LABEL_OPERATOR_ID => operator_id.clone(),
-                LABEL_WORKER_ID => self.worker_id.clone(),
-                LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(operator_metrics.dwell.p95);
-            gauge!(
-                METRIC_OPERATOR_DWELL_50,
-                LABEL_OPERATOR_ID => operator_id.clone(),
-                LABEL_WORKER_ID => self.worker_id.clone(),
-                LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(operator_metrics.dwell.p50);
-            gauge!(
-                METRIC_OPERATOR_DWELL_AVG,
-                LABEL_OPERATOR_ID => operator_id.clone(),
-                LABEL_WORKER_ID => self.worker_id.clone(),
-                LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(operator_metrics.dwell.avg);
         }
 
         for (vertex_id, task_metrics) in self.tasks_metrics.iter() {
@@ -462,30 +423,6 @@ impl WorkerAggregateMetrics {
                 LABEL_WORKER_ID => self.worker_id.clone(),
                 LABEL_PIPELINE_ID => pipeline_id.clone(),
             ).set(task_metrics.path_latency.avg);
-            gauge!(
-                METRIC_STREAM_TASK_DWELL_99,
-                LABEL_VERTEX_ID => vertex_id.clone(),
-                LABEL_WORKER_ID => self.worker_id.clone(),
-                LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(task_metrics.dwell.p99);
-            gauge!(
-                METRIC_STREAM_TASK_DWELL_95,
-                LABEL_VERTEX_ID => vertex_id.clone(),
-                LABEL_WORKER_ID => self.worker_id.clone(),
-                LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(task_metrics.dwell.p95);
-            gauge!(
-                METRIC_STREAM_TASK_DWELL_50,
-                LABEL_VERTEX_ID => vertex_id.clone(),
-                LABEL_WORKER_ID => self.worker_id.clone(),
-                LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(task_metrics.dwell.p50);
-            gauge!(
-                METRIC_STREAM_TASK_DWELL_AVG,
-                LABEL_VERTEX_ID => vertex_id.clone(),
-                LABEL_WORKER_ID => self.worker_id.clone(),
-                LABEL_PIPELINE_ID => pipeline_id.clone(),
-            ).set(task_metrics.dwell.avg);
         }
     }
 }
@@ -955,7 +892,6 @@ fn parse_all_stream_task_metrics(
         bytes_sent: u64,
         bytes_recv: u64,
         path_latency_histogram: Option<Vec<u64>>,
-        dwell_histogram: Option<Vec<u64>>,
         backpressure_per_peer: HashMap<String, f64>,
     }
 
@@ -987,17 +923,12 @@ fn parse_all_stream_task_metrics(
                 METRIC_STREAM_TASK_BYTES_RECV => acc.bytes_recv = value as u64,
                 _ => {}
             },
-            Value::Histogram(histogram_counts) => match sample.metric.as_str() {
-                METRIC_STREAM_TASK_PATH_LATENCY => {
+            Value::Histogram(histogram_counts) => {
+                if sample.metric == METRIC_STREAM_TASK_PATH_LATENCY {
                     acc.path_latency_histogram =
                         Some(convert_histogram_counts_to_buckets(&histogram_counts));
                 }
-                METRIC_STREAM_TASK_DWELL => {
-                    acc.dwell_histogram =
-                        Some(convert_histogram_counts_to_buckets(&histogram_counts));
-                }
-                _ => {}
-            },
+            }
             Value::Gauge(value) => {
                 if sample.metric == METRIC_STREAM_TASK_BACKPRESSURE_RATIO {
                     if let Some(peer_vertex_id) = sample.labels.get(LABEL_TARGET_VERTEX_ID) {
@@ -1013,15 +944,14 @@ fn parse_all_stream_task_metrics(
     by_vertex
         .into_iter()
         .map(|(vertex_id, acc)| {
-            let empty_hist = || vec![0u64; LATENCY_HISTOGRAM_LEN];
             (
                 vertex_id.clone(),
                 TaskMetrics {
                     vertex_id,
                     path_latency: LatencyMetrics::new(
-                        acc.path_latency_histogram.unwrap_or_else(empty_hist),
+                        acc.path_latency_histogram
+                            .unwrap_or_else(|| vec![0u64; LATENCY_HISTOGRAM_LEN]),
                     ),
-                    dwell: LatencyMetrics::new(acc.dwell_histogram.unwrap_or_else(empty_hist)),
                     throughput_stast: ThroughputMetrics::new(
                         acc.messages_sent,
                         acc.messages_recv,
@@ -1131,7 +1061,6 @@ mod tests {
         ).increment(512);
         
         let path_measurements = [5.0, 25.0, 150.0, 2.5, 75.0];
-        let dwell_measurements = [1.0, 3.0, 8.0];
         for &latency in &path_measurements {
             histogram!(
                 METRIC_STREAM_TASK_PATH_LATENCY,
@@ -1141,18 +1070,8 @@ mod tests {
             )
             .record(latency);
         }
-        for &dwell in &dwell_measurements {
-            histogram!(
-                METRIC_STREAM_TASK_DWELL,
-                LABEL_VERTEX_ID => vertex_id.clone(),
-                LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                LABEL_WORKER_ID => labels.worker_id.clone()
-            )
-            .record(dwell);
-        }
 
         let expected_path = build_expected_histogram(&path_measurements, &LATENCY_BUCKET_BOUNDARIES);
-        let expected_dwell = build_expected_histogram(&dwell_measurements, &LATENCY_BUCKET_BOUNDARIES);
 
         let parsed_metrics = get_stream_task_metrics(Arc::<str>::from(vertex_id.clone()), Some(&labels));
 
@@ -1165,14 +1084,9 @@ mod tests {
         assert_eq!(parsed_metrics.throughput_stast.bytes_recv, 512);
 
         assert_eq!(parsed_metrics.path_latency.latency_histogram, expected_path);
-        assert_eq!(parsed_metrics.dwell.latency_histogram, expected_dwell);
         assert_eq!(
             *parsed_metrics.path_latency.latency_histogram.last().unwrap(),
             path_measurements.len() as u64
-        );
-        assert_eq!(
-            *parsed_metrics.dwell.latency_histogram.last().unwrap(),
-            dwell_measurements.len() as u64
         );
 
         let vertex_b = "task_b".to_string();

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -8,9 +8,9 @@ use crate::{
         metrics::{
             init_metrics, MetricsLabels, LABEL_PIPELINE_ID, LABEL_VERTEX_ID, LABEL_WORKER_ID,
             METRIC_STREAM_TASK_BYTES_RECV, METRIC_STREAM_TASK_BYTES_SENT,
-            METRIC_STREAM_TASK_DWELL, METRIC_STREAM_TASK_MESSAGES_RECV,
-            METRIC_STREAM_TASK_MESSAGES_SENT, METRIC_STREAM_TASK_PATH_LATENCY,
-            METRIC_STREAM_TASK_RECORDS_RECV, METRIC_STREAM_TASK_RECORDS_SENT,
+            METRIC_STREAM_TASK_MESSAGES_RECV, METRIC_STREAM_TASK_MESSAGES_SENT,
+            METRIC_STREAM_TASK_PATH_LATENCY, METRIC_STREAM_TASK_RECORDS_RECV,
+            METRIC_STREAM_TASK_RECORDS_SENT,
         },
         observability::{TaskMetadata, TaskSnapshot, StreamTaskStatus},
         operators::operator::{
@@ -347,17 +347,6 @@ impl StreamTask {
                 counter!(METRIC_STREAM_TASK_BYTES_SENT, LABEL_VERTEX_ID => vertex_id.clone())
                     .increment(message.get_memory_size() as u64);
             }
-
-            // Task dwell: send − recv (only when this task stamped recv on the message).
-            if let Some(recv_timestamp) = message.recv_timestamp() {
-                let dwell = Self::now_ms().saturating_sub(recv_timestamp);
-                Self::record_histogram(
-                    METRIC_STREAM_TASK_DWELL,
-                    dwell as f64,
-                    &vertex_id,
-                    labels,
-                );
-            }
         }
     }
 
@@ -383,14 +372,7 @@ impl StreamTask {
                 upstream_watermarks.clone(),
                 current_watermark.clone(),
             );
-            while let Some(mut message) = input_stream.next().await {
-                let is_control = matches!(
-                    message,
-                    Message::Watermark(_) | Message::CheckpointBarrier(_)
-                );
-                if !is_control {
-                    message.set_recv_timestamp(Self::now_ms());
-                }
+            while let Some(message) = input_stream.next().await {
                 Self::record_metrics(vertex_id.clone(), &message, true, labels.as_ref());
 
                 match &message {

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -7,8 +7,9 @@ use crate::{
         health::{WorkerFatalReason, WorkerHealth},
         metrics::{
             init_metrics, MetricsLabels, LABEL_PIPELINE_ID, LABEL_VERTEX_ID, LABEL_WORKER_ID,
-            METRIC_STREAM_TASK_BYTES_RECV, METRIC_STREAM_TASK_BYTES_SENT, METRIC_STREAM_TASK_LATENCY,
-            METRIC_STREAM_TASK_MESSAGES_RECV, METRIC_STREAM_TASK_MESSAGES_SENT,
+            METRIC_STREAM_TASK_BYTES_RECV, METRIC_STREAM_TASK_BYTES_SENT,
+            METRIC_STREAM_TASK_DWELL, METRIC_STREAM_TASK_MESSAGES_RECV,
+            METRIC_STREAM_TASK_MESSAGES_SENT, METRIC_STREAM_TASK_PATH_LATENCY,
             METRIC_STREAM_TASK_RECORDS_RECV, METRIC_STREAM_TASK_RECORDS_SENT,
         },
         observability::{TaskMetadata, TaskSnapshot, StreamTaskStatus},
@@ -234,86 +235,128 @@ impl StreamTask {
         Ok(())
     }
 
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64
+    }
+
+    fn record_histogram(
+        name: &'static str,
+        value_ms: f64,
+        vertex_id: &VertexId,
+        labels: Option<&MetricsLabels>,
+    ) {
+        if let Some(labels) = labels {
+            histogram!(
+                name,
+                LABEL_VERTEX_ID => vertex_id.clone(),
+                LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                LABEL_WORKER_ID => labels.worker_id.clone()
+            )
+            .record(value_ms);
+        } else {
+            histogram!(name, LABEL_VERTEX_ID => vertex_id.clone()).record(value_ms);
+        }
+    }
+
     fn record_metrics(
         vertex_id: VertexId,
         message: &Message,
         recv_or_send: bool,
         labels: Option<&MetricsLabels>,
     ) {
-        let is_control_message = matches!(message, Message::Watermark(_) | Message::CheckpointBarrier(_));
-        
-        if !is_control_message {
-            if recv_or_send {
-                if let Some(labels) = labels {
-                    counter!(
-                        METRIC_STREAM_TASK_MESSAGES_RECV,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
-                        LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                        LABEL_WORKER_ID => labels.worker_id.clone()
-                    ).increment(1);
-                    counter!(
-                        METRIC_STREAM_TASK_RECORDS_RECV,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
-                        LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                        LABEL_WORKER_ID => labels.worker_id.clone()
-                    ).increment(message.num_records() as u64);
-                    counter!(
-                        METRIC_STREAM_TASK_BYTES_RECV,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
-                        LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                        LABEL_WORKER_ID => labels.worker_id.clone()
-                    ).increment(message.get_memory_size() as u64);
-                } else {
-                    counter!(METRIC_STREAM_TASK_MESSAGES_RECV, LABEL_VERTEX_ID => vertex_id.clone()).increment(1);
-                    counter!(METRIC_STREAM_TASK_RECORDS_RECV, LABEL_VERTEX_ID => vertex_id.clone()).increment(message.num_records() as u64);
-                    counter!(METRIC_STREAM_TASK_BYTES_RECV, LABEL_VERTEX_ID => vertex_id.clone()).increment(message.get_memory_size() as u64);
-                }
-                
-                if let Some(ingest_timestamp) = message.ingest_timestamp() {
-                    let current_time = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis() as u64;
-                    let latency = current_time.saturating_sub(ingest_timestamp);
-                    if let Some(labels) = labels {
-                        histogram!(
-                            METRIC_STREAM_TASK_LATENCY,
-                            LABEL_VERTEX_ID => vertex_id.clone(),
-                            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                            LABEL_WORKER_ID => labels.worker_id.clone()
-                        )
-                        .record(latency as f64);
-                    } else {
-                        histogram!(METRIC_STREAM_TASK_LATENCY, LABEL_VERTEX_ID => vertex_id.clone())
-                            .record(latency as f64);
-                    }
-                }
+        let is_control_message =
+            matches!(message, Message::Watermark(_) | Message::CheckpointBarrier(_));
 
+        if is_control_message {
+            return;
+        }
+
+        if recv_or_send {
+            if let Some(labels) = labels {
+                counter!(
+                    METRIC_STREAM_TASK_MESSAGES_RECV,
+                    LABEL_VERTEX_ID => vertex_id.clone(),
+                    LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                    LABEL_WORKER_ID => labels.worker_id.clone()
+                )
+                .increment(1);
+                counter!(
+                    METRIC_STREAM_TASK_RECORDS_RECV,
+                    LABEL_VERTEX_ID => vertex_id.clone(),
+                    LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                    LABEL_WORKER_ID => labels.worker_id.clone()
+                )
+                .increment(message.num_records() as u64);
+                counter!(
+                    METRIC_STREAM_TASK_BYTES_RECV,
+                    LABEL_VERTEX_ID => vertex_id.clone(),
+                    LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                    LABEL_WORKER_ID => labels.worker_id.clone()
+                )
+                .increment(message.get_memory_size() as u64);
             } else {
-                if let Some(labels) = labels {
-                    counter!(
-                        METRIC_STREAM_TASK_MESSAGES_SENT,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
-                        LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                        LABEL_WORKER_ID => labels.worker_id.clone()
-                    ).increment(1);
-                    counter!(
-                        METRIC_STREAM_TASK_RECORDS_SENT,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
-                        LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                        LABEL_WORKER_ID => labels.worker_id.clone()
-                    ).increment(message.num_records() as u64);
-                    counter!(
-                        METRIC_STREAM_TASK_BYTES_SENT,
-                        LABEL_VERTEX_ID => vertex_id.clone(),
-                        LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                        LABEL_WORKER_ID => labels.worker_id.clone()
-                    ).increment(message.get_memory_size() as u64);
-                } else {
-                    counter!(METRIC_STREAM_TASK_MESSAGES_SENT, LABEL_VERTEX_ID => vertex_id.clone()).increment(1);
-                    counter!(METRIC_STREAM_TASK_RECORDS_SENT, LABEL_VERTEX_ID => vertex_id.clone()).increment(message.num_records() as u64);
-                    counter!(METRIC_STREAM_TASK_BYTES_SENT, LABEL_VERTEX_ID => vertex_id.clone()).increment(message.get_memory_size() as u64);
-                }
+                counter!(METRIC_STREAM_TASK_MESSAGES_RECV, LABEL_VERTEX_ID => vertex_id.clone())
+                    .increment(1);
+                counter!(METRIC_STREAM_TASK_RECORDS_RECV, LABEL_VERTEX_ID => vertex_id.clone())
+                    .increment(message.num_records() as u64);
+                counter!(METRIC_STREAM_TASK_BYTES_RECV, LABEL_VERTEX_ID => vertex_id.clone())
+                    .increment(message.get_memory_size() as u64);
+            }
+
+            // Path latency: recv − source ingest (omit when ingest absent, e.g. WO outputs).
+            if let Some(ingest_timestamp) = message.ingest_timestamp() {
+                let path_latency = Self::now_ms().saturating_sub(ingest_timestamp);
+                Self::record_histogram(
+                    METRIC_STREAM_TASK_PATH_LATENCY,
+                    path_latency as f64,
+                    &vertex_id,
+                    labels,
+                );
+            }
+        } else {
+            if let Some(labels) = labels {
+                counter!(
+                    METRIC_STREAM_TASK_MESSAGES_SENT,
+                    LABEL_VERTEX_ID => vertex_id.clone(),
+                    LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                    LABEL_WORKER_ID => labels.worker_id.clone()
+                )
+                .increment(1);
+                counter!(
+                    METRIC_STREAM_TASK_RECORDS_SENT,
+                    LABEL_VERTEX_ID => vertex_id.clone(),
+                    LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                    LABEL_WORKER_ID => labels.worker_id.clone()
+                )
+                .increment(message.num_records() as u64);
+                counter!(
+                    METRIC_STREAM_TASK_BYTES_SENT,
+                    LABEL_VERTEX_ID => vertex_id.clone(),
+                    LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                    LABEL_WORKER_ID => labels.worker_id.clone()
+                )
+                .increment(message.get_memory_size() as u64);
+            } else {
+                counter!(METRIC_STREAM_TASK_MESSAGES_SENT, LABEL_VERTEX_ID => vertex_id.clone())
+                    .increment(1);
+                counter!(METRIC_STREAM_TASK_RECORDS_SENT, LABEL_VERTEX_ID => vertex_id.clone())
+                    .increment(message.num_records() as u64);
+                counter!(METRIC_STREAM_TASK_BYTES_SENT, LABEL_VERTEX_ID => vertex_id.clone())
+                    .increment(message.get_memory_size() as u64);
+            }
+
+            // Task dwell: send − recv (only when this task stamped recv on the message).
+            if let Some(recv_timestamp) = message.recv_timestamp() {
+                let dwell = Self::now_ms().saturating_sub(recv_timestamp);
+                Self::record_histogram(
+                    METRIC_STREAM_TASK_DWELL,
+                    dwell as f64,
+                    &vertex_id,
+                    labels,
+                );
             }
         }
     }
@@ -340,7 +383,14 @@ impl StreamTask {
                 upstream_watermarks.clone(),
                 current_watermark.clone(),
             );
-            while let Some(message) = input_stream.next().await {
+            while let Some(mut message) = input_stream.next().await {
+                let is_control = matches!(
+                    message,
+                    Message::Watermark(_) | Message::CheckpointBarrier(_)
+                );
+                if !is_control {
+                    message.set_recv_timestamp(Self::now_ms());
+                }
                 Self::record_metrics(vertex_id.clone(), &message, true, labels.as_ref());
 
                 match &message {

--- a/src/tests/benchmark/window_operator_benchmark.rs
+++ b/src/tests/benchmark/window_operator_benchmark.rs
@@ -565,7 +565,7 @@ pub fn print_benchmark_results(config: &WindowBenchmarkConfig, metrics: &Benchma
     }
 
     if !final_stats.latency_per_task.is_empty() {
-        println!("\nLatency Statistics (per task, merged histogram over all history):");
+        println!("\nPath latency (per task, merged histogram over all history):");
         for (task_id, latency_stats) in &final_stats.latency_per_task {
             println!("  Task: {}", task_id);
             println!("    Avg: {:.2} ms", latency_stats.avg);

--- a/src/tests/benchmark/window_request_operator_benchmark.rs
+++ b/src/tests/benchmark/window_request_operator_benchmark.rs
@@ -393,7 +393,7 @@ async fn test_window_request_benchmark() -> Result<()> {
     }
 
     if !final_stats.latency_per_task.is_empty() {
-        println!("\nLatency Statistics (per task, merged histogram over all history):");
+        println!("\nPath latency (per task, merged histogram over all history):");
         for (task_id, latency_stats) in &final_stats.latency_per_task {
             println!("  Task: {}", task_id);
             println!("    Avg: {:.2} ms", latency_stats.avg);

--- a/src/tests/benchmark/word_count_benchmark.rs
+++ b/src/tests/benchmark/word_count_benchmark.rs
@@ -159,7 +159,7 @@ async fn poll_pipeline_state_updates(
             let records_per_sec = records_diff as f64 / time_diff;
 
             // Calculate average latency from histogram
-            let latency_ms = sink_operator_metrics.latency_metrics.avg;
+            let latency_ms = sink_operator_metrics.path_latency.avg;
 
             benchmark_metrics.add_sample(messages_per_sec, records_per_sec, latency_ms);
         }


### PR DESCRIPTION
## Summary
- Rename generic latency to **path latency**: `volga_stream_task_path_latency` = `recv − ingest` (omit when ingest absent, e.g. WO outputs)
- Op/task percentile gauges → `path_latency_*`; hist merge stays per-operator only
- **No task dwell** — sojourn-style `send − recv` is misleading under async (wall clock, mixed waits/work, missing on new messages); leave a better busy/send-wait metric for later

Fixes #207 (scoped to path latency rename/clarify).

## Test plan
- [x] `cargo test --lib moved_metrics::tests` (pre-dwell-drop; re-run after)
- [ ] Confirm scrape has `volga_stream_task_path_latency*`, no `volga_stream_task_latency*` / `dwell*`
- [ ] WO/result messages without ingest omit path latency