### PR TITLE
obs: checkpoint duration, align wait, payload, outcome (#211/#148)

### DIFF
--- a/src/runtime/master/checkpoint/actor.rs
+++ b/src/runtime/master/checkpoint/actor.rs
@@ -85,7 +85,7 @@ impl Message<StartCheckpoint> for CheckpointCoordinator {
 }
 
 impl Message<AbortInFlightCheckpoint> for CheckpointCoordinator {
-    type Reply = Option<u64>;
+    type Reply = Option<(u64, u64)>;
 
     async fn handle(
         &mut self,

--- a/src/runtime/master/checkpoint/mod.rs
+++ b/src/runtime/master/checkpoint/mod.rs
@@ -33,7 +33,10 @@ pub enum CheckpointAckOutcome {
     /// Progress recorded; still waiting for state acks and/or barrier aligns.
     Pending,
     /// Expected state acks and barrier aligns both satisfied; newly completed.
-    Completed,
+    Completed {
+        /// Wall ms from checkpoint start to completion.
+        duration_ms: u64,
+    },
     /// Ignored / rejected without completing.
     Rejected(CheckpointAckReject),
 }
@@ -99,10 +102,10 @@ impl Checkpoints {
             .start(&self.expected_acks, &self.expected_aligns)
     }
 
-    pub fn abort_in_flight(&mut self) -> Option<u64> {
-        let checkpoint_id = self.protocol.abort_in_flight()?;
+    pub fn abort_in_flight(&mut self) -> Option<(u64, u64)> {
+        let (checkpoint_id, duration_ms) = self.protocol.abort_in_flight()?;
         self.pending.remove(&checkpoint_id);
-        Some(checkpoint_id)
+        Some((checkpoint_id, duration_ms))
     }
 
     pub fn in_flight_id(&self) -> Option<u64> {
@@ -175,7 +178,7 @@ impl Checkpoints {
         checkpoint_id: u64,
         outcome: CheckpointAckOutcome,
     ) -> anyhow::Result<CheckpointAckOutcome> {
-        if !matches!(outcome, CheckpointAckOutcome::Completed) {
+        if !matches!(outcome, CheckpointAckOutcome::Completed { .. }) {
             return Ok(outcome);
         }
         let tasks = self.pending.remove(&checkpoint_id).unwrap_or_default();
@@ -246,10 +249,10 @@ mod tests {
                 .unwrap(),
             CheckpointAckOutcome::Pending
         );
-        assert_eq!(
+        assert!(matches!(
             cps.note_barrier_progress(id, task("a", 0)).await.unwrap(),
-            CheckpointAckOutcome::Completed
-        );
+            CheckpointAckOutcome::Completed { .. }
+        ));
         id
     }
 
@@ -287,7 +290,7 @@ mod tests {
             CheckpointAckOutcome::Pending
         );
         assert!(cps.load(id).await.is_err());
-        assert_eq!(cps.abort_in_flight(), Some(id));
+        assert_eq!(cps.abort_in_flight().map(|(cid, _)| cid), Some(id));
         assert!(cps.load(id).await.is_err());
     }
 
@@ -310,11 +313,11 @@ mod tests {
                 .unwrap(),
             CheckpointAckOutcome::Pending
         );
-        assert_eq!(
+        assert!(matches!(
             cps.note_barrier_progress(id, task("sink", 0))
                 .await
                 .unwrap(),
-            CheckpointAckOutcome::Completed
-        );
+            CheckpointAckOutcome::Completed { .. }
+        ));
     }
 }

--- a/src/runtime/master/checkpoint/protocol.rs
+++ b/src/runtime/master/checkpoint/protocol.rs
@@ -63,8 +63,14 @@ impl CheckpointProtocol {
         Ok(checkpoint_id)
     }
 
-    pub(super) fn abort_in_flight(&mut self) -> Option<u64> {
-        self.in_flight.take().map(|c| c.checkpoint_id)
+    /// Returns `(checkpoint_id, duration_ms)` when an in-flight checkpoint is aborted.
+    pub(super) fn abort_in_flight(&mut self) -> Option<(u64, u64)> {
+        self.in_flight.take().map(|c| {
+            (
+                c.checkpoint_id,
+                c.started_at.elapsed().as_millis() as u64,
+            )
+        })
     }
 
     /// Record a state ack. Completes only when acks and aligns both match expected sets.
@@ -129,9 +135,10 @@ impl CheckpointProtocol {
         }
 
         if in_flight.acks == *expected_acks && in_flight.aligns == *expected_aligns {
+            let duration_ms = in_flight.started_at.elapsed().as_millis() as u64;
             self.in_flight = None;
             self.completed.insert(checkpoint_id);
-            CheckpointAckOutcome::Completed
+            CheckpointAckOutcome::Completed { duration_ms }
         } else {
             CheckpointAckOutcome::Pending
         }
@@ -179,10 +186,10 @@ mod tests {
     ) -> u64 {
         let id = protocol.start(acks, aligns).unwrap();
         assert_eq!(protocol.ack(id, t.clone(), acks, aligns), CheckpointAckOutcome::Pending);
-        assert_eq!(
+        assert!(matches!(
             protocol.align(id, t, acks, aligns),
-            CheckpointAckOutcome::Completed
-        );
+            CheckpointAckOutcome::Completed { .. }
+        ));
         id
     }
 
@@ -201,10 +208,10 @@ mod tests {
             protocol.align(id, task("src", 0), &acks, &aligns),
             CheckpointAckOutcome::Pending
         );
-        assert_eq!(
+        assert!(matches!(
             protocol.align(id, task("sink", 0), &acks, &aligns),
-            CheckpointAckOutcome::Completed
-        );
+            CheckpointAckOutcome::Completed { .. }
+        ));
         assert_eq!(protocol.latest_complete(), Some(id));
         assert!(protocol.in_flight_id().is_none());
     }
@@ -223,10 +230,10 @@ mod tests {
             protocol.ack(id, task("a", 0), &acks, &aligns),
             CheckpointAckOutcome::Pending
         );
-        assert_eq!(
+        assert!(matches!(
             protocol.align(id, task("a", 0), &acks, &aligns),
-            CheckpointAckOutcome::Completed
-        );
+            CheckpointAckOutcome::Completed { .. }
+        ));
         assert!(matches!(
             protocol.ack(id, task("a", 0), &acks, &aligns),
             CheckpointAckOutcome::Rejected(CheckpointAckReject::AlreadyComplete)

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -17,6 +17,10 @@ use crate::runtime::consts::{
     runtime_consts, MASTER_CHECKPOINT_RETENTION, MASTER_REGISTRY_WAIT_TICK,
 };
 use crate::runtime::execution_graph::ExecutionGraph;
+use crate::runtime::metrics::{
+    increment_pipeline_counter, record_pipeline_histogram, METRIC_CHECKPOINT_COMPLETED,
+    METRIC_CHECKPOINT_DURATION_MS, METRIC_CHECKPOINT_FAILED,
+};
 use crate::runtime::observability::snapshot_types::PipelineSnapshot;
 use crate::runtime::operators::operator::operator_config_requires_checkpoint;
 
@@ -314,20 +318,29 @@ impl MasterState {
         attempt_id: u64,
         detail: String,
     ) -> Result<Option<u64>, String> {
-        let checkpoint_id = self
+        let aborted = self
             .checkpoints
             .ask(AbortInFlightCheckpoint)
             .await
             .map_err(|error| format!("checkpoint coordinator: {error}"))?;
-        if let Some(checkpoint_id) = checkpoint_id {
+        if let Some((checkpoint_id, duration_ms)) = aborted {
+            let pipeline_id = self.orchestrator.get_pipeline_id().await;
+            record_pipeline_histogram(
+                METRIC_CHECKPOINT_DURATION_MS,
+                duration_ms as f64,
+                &pipeline_id,
+            );
+            increment_pipeline_counter(METRIC_CHECKPOINT_FAILED, 1, &pipeline_id);
             self.record_lifecycle_event(LifecycleEvent::CheckpointFailed {
                 checkpoint_id,
                 attempt_id,
                 detail,
             })
             .await;
+            Ok(Some(checkpoint_id))
+        } else {
+            Ok(None)
         }
-        Ok(checkpoint_id)
     }
 
     pub(super) async fn in_flight_checkpoint_timed_out(&self, timeout: Duration) -> Option<u64> {
@@ -381,7 +394,14 @@ impl MasterState {
         })
         .await;
 
-        if matches!(outcome, CheckpointAckOutcome::Completed) {
+        if let CheckpointAckOutcome::Completed { duration_ms } = outcome {
+            let pipeline_id = self.orchestrator.get_pipeline_id().await;
+            record_pipeline_histogram(
+                METRIC_CHECKPOINT_DURATION_MS,
+                duration_ms as f64,
+                &pipeline_id,
+            );
+            increment_pipeline_counter(METRIC_CHECKPOINT_COMPLETED, 1, &pipeline_id);
             self.record_lifecycle_event(LifecycleEvent::CheckpointCompleted { checkpoint_id })
                 .await;
         }
@@ -436,7 +456,14 @@ impl MasterState {
             .map_err(|error| format!("failed to update checkpoint store: {error}"))?;
 
         match outcome {
-            CheckpointAckOutcome::Completed => {
+            CheckpointAckOutcome::Completed { duration_ms } => {
+                let pipeline_id = self.orchestrator.get_pipeline_id().await;
+                record_pipeline_histogram(
+                    METRIC_CHECKPOINT_DURATION_MS,
+                    duration_ms as f64,
+                    &pipeline_id,
+                );
+                increment_pipeline_counter(METRIC_CHECKPOINT_COMPLETED, 1, &pipeline_id);
                 self.record_lifecycle_event(LifecycleEvent::CheckpointCompleted { checkpoint_id })
                     .await;
                 Ok(())

--- a/src/runtime/observability/metrics/mod.rs
+++ b/src/runtime/observability/metrics/mod.rs
@@ -43,6 +43,21 @@ pub const METRIC_STREAM_TASK_WM_PROPAGATION_MS: &str = "volga_stream_task_wm_pro
 /// Hop delay for checkpoint barriers: `recv − create_stamp`.
 pub const METRIC_STREAM_TASK_BARRIER_PROPAGATION_MS: &str =
     "volga_stream_task_barrier_propagation_ms";
+/// Wait from first barrier seen to full upstream alignment (non-sources).
+pub const METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS: &str =
+    "volga_stream_task_checkpoint_align_wait_ms";
+/// Local snapshot + report RPC wall time.
+pub const METRIC_STREAM_TASK_CHECKPOINT_DURATION_MS: &str =
+    "volga_stream_task_checkpoint_duration_ms";
+pub const METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES: &str =
+    "volga_stream_task_checkpoint_payload_bytes";
+pub const METRIC_STREAM_TASK_CHECKPOINT_SUCCESS: &str = "volga_stream_task_checkpoint_success";
+pub const METRIC_STREAM_TASK_CHECKPOINT_FAIL: &str = "volga_stream_task_checkpoint_fail";
+
+/// Job-level checkpoint wall time (master `started_at` → complete/fail).
+pub const METRIC_CHECKPOINT_DURATION_MS: &str = "volga_checkpoint_duration_ms";
+pub const METRIC_CHECKPOINT_COMPLETED: &str = "volga_checkpoint_completed";
+pub const METRIC_CHECKPOINT_FAILED: &str = "volga_checkpoint_failed";
 
 // Worker-derived (poll-time) metrics
 pub const METRIC_WORKER_BACKPRESSURE_MAX: &str = "volga_worker_backpressure_max";
@@ -138,6 +153,19 @@ pub fn set_vertex_gauge(
     } else {
         gauge!(name, LABEL_VERTEX_ID => vertex).set(value);
     }
+}
+
+/// Record a pipeline-scoped histogram sample (master / job-level).
+pub fn record_pipeline_histogram(name: &'static str, value_ms: f64, pipeline_id: &str) {
+    histogram!(name, LABEL_PIPELINE_ID => pipeline_id.to_string()).record(value_ms);
+}
+
+/// Increment a pipeline-scoped counter (master / job-level).
+pub fn increment_pipeline_counter(name: &'static str, delta: u64, pipeline_id: &str) {
+    if delta == 0 {
+        return;
+    }
+    counter!(name, LABEL_PIPELINE_ID => pipeline_id.to_string()).increment(delta);
 }
 
 // Histogram bucket boundaries, milliseconds (Prometheus also emits a trailing +Inf bucket).

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -6,13 +6,16 @@ use crate::{
         execution_graph::ExecutionGraph,
         health::{WorkerFatalReason, WorkerHealth},
         metrics::{
-            init_metrics, record_vertex_histogram, set_vertex_gauge, MetricsLabels,
-            LABEL_PIPELINE_ID, LABEL_VERTEX_ID, LABEL_WORKER_ID,
+            increment_vertex_counter, init_metrics, record_vertex_histogram, set_vertex_gauge,
+            MetricsLabels, LABEL_PIPELINE_ID, LABEL_VERTEX_ID, LABEL_WORKER_ID,
             METRIC_STREAM_TASK_BARRIER_PROPAGATION_MS, METRIC_STREAM_TASK_BYTES_RECV,
-            METRIC_STREAM_TASK_BYTES_SENT, METRIC_STREAM_TASK_MESSAGES_RECV,
-            METRIC_STREAM_TASK_MESSAGES_SENT, METRIC_STREAM_TASK_PATH_LATENCY,
-            METRIC_STREAM_TASK_RECORDS_RECV, METRIC_STREAM_TASK_RECORDS_SENT,
-            METRIC_STREAM_TASK_WATERMARK_LAG_MS, METRIC_STREAM_TASK_WM_PROPAGATION_MS,
+            METRIC_STREAM_TASK_BYTES_SENT, METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS,
+            METRIC_STREAM_TASK_CHECKPOINT_DURATION_MS, METRIC_STREAM_TASK_CHECKPOINT_FAIL,
+            METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES, METRIC_STREAM_TASK_CHECKPOINT_SUCCESS,
+            METRIC_STREAM_TASK_MESSAGES_RECV, METRIC_STREAM_TASK_MESSAGES_SENT,
+            METRIC_STREAM_TASK_PATH_LATENCY, METRIC_STREAM_TASK_RECORDS_RECV,
+            METRIC_STREAM_TASK_RECORDS_SENT, METRIC_STREAM_TASK_WATERMARK_LAG_MS,
+            METRIC_STREAM_TASK_WM_PROPAGATION_MS,
         },
         observability::{TaskMetadata, TaskSnapshot, StreamTaskStatus},
         operators::operator::{
@@ -32,7 +35,7 @@ use crate::transport::transport_client::DataReaderControl;
 use std::collections::HashSet;
 use crate::transport::transport_client::TransportClient;
 use crate::common::message::{Message, WatermarkMessage};
-use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, Arc}, time::{Duration, SystemTime, UNIX_EPOCH}};
+use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, Arc}, time::{Duration, Instant, SystemTime, UNIX_EPOCH}};
 // serde imports removed; this module does not define serializable DTOs directly.
 use crate::common::grpc::master::master_client as connect_master_client;
 use crate::common::grpc::GrpcConfig;
@@ -53,6 +56,7 @@ pub(crate) struct CheckpointAligner {
     seen_upstreams: HashSet<String>,
     /// Earliest create stamp among barriers for the current checkpoint (for propagation).
     inject_stamp: Option<u64>,
+    align_started: Option<Instant>,
     reader_control: DataReaderControl,
 }
 
@@ -63,16 +67,17 @@ impl CheckpointAligner {
             current_checkpoint: None,
             seen_upstreams: HashSet::new(),
             inject_stamp: None,
+            align_started: None,
             reader_control,
         }
     }
 
-    /// Returns `Some((checkpoint_id, inject_stamp))` when fully aligned.
+    /// Returns `Some((checkpoint_id, inject_stamp, align_wait_ms))` when fully aligned.
     fn on_barrier(
         &mut self,
         barrier: &crate::common::message::CheckpointBarrierMessage,
         expected_attempt_id: u64,
-    ) -> Result<Option<(u64, Option<u64>)>, String> {
+    ) -> Result<Option<(u64, Option<u64>, f64)>, String> {
         if barrier.execution_attempt_id != expected_attempt_id {
             // Orphan from a previous attempt — drop without failing the new attempt.
             println!(
@@ -93,6 +98,7 @@ impl CheckpointAligner {
         if self.current_checkpoint.is_none() {
             self.current_checkpoint = Some(checkpoint_id);
             self.inject_stamp = barrier.metadata.ingest_timestamp;
+            self.align_started = Some(Instant::now());
         } else if let (Some(existing), Some(stamp)) =
             (self.inject_stamp, barrier.metadata.ingest_timestamp)
         {
@@ -112,9 +118,14 @@ impl CheckpointAligner {
 
         if self.seen_upstreams.len() == self.upstream_count {
             let stamp = self.inject_stamp.take();
+            let align_wait_ms = self
+                .align_started
+                .take()
+                .map(|t| t.elapsed().as_secs_f64() * 1000.0)
+                .unwrap_or(0.0);
             self.current_checkpoint = None;
             self.seen_upstreams.clear();
-            return Ok(Some((checkpoint_id, stamp)));
+            return Ok(Some((checkpoint_id, stamp, align_wait_ms)));
         }
         Ok(None)
     }
@@ -426,7 +437,13 @@ impl StreamTask {
                     }
                     Message::CheckpointBarrier(barrier) => {
                         match aligner.on_barrier(barrier, execution_attempt_id) {
-                            Ok(Some((checkpoint_id, inject_stamp))) => {
+                            Ok(Some((checkpoint_id, inject_stamp, align_wait_ms))) => {
+                                Self::record_histogram(
+                                    METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS,
+                                    align_wait_ms,
+                                    &vertex_id,
+                                    labels.as_ref(),
+                                );
                                 // Once fully aligned, yield a single barrier; preserve inject stamp.
                                 yield Message::CheckpointBarrier(
                                     crate::common::message::CheckpointBarrierMessage::new(
@@ -771,34 +788,73 @@ impl StreamTask {
                                     "[CHECKPOINT] {} checkpointing checkpoint_id={}",
                                     vertex_id, checkpoint_id
                                 );
-                                let checkpoint: SerializedCheckpoint =
-                                    operator.checkpoint(checkpoint_id).await?;
-                                let checkpoint_data = checkpoint.into_bytes();
+                                let started = Instant::now();
+                                let checkpoint_result = async {
+                                    let checkpoint: SerializedCheckpoint =
+                                        operator.checkpoint(checkpoint_id).await?;
+                                    let checkpoint_data = checkpoint.into_bytes();
+                                    let payload_len = checkpoint_data.len() as u64;
 
-                                let report_resp = master_client
-                                    .as_mut()
-                                    .expect("Master client not initialized")
-                                    .report_checkpoint(tonic::Request::new(
-                                        crate::runtime::master::server::master_service::ReportCheckpointRequest {
-                                            checkpoint_id,
-                                            vertex_id: vertex_id.as_ref().to_string(),
-                                            task_index: runtime_context.task_index(),
-                                            checkpoint_data,
-                                            execution_attempt_id,
-                                        },
-                                    ))
-                                    .await?
-                                    .into_inner();
-                                if !report_resp.success {
-                                    return Err(anyhow::anyhow!(
-                                        "report_checkpoint rejected: {}",
-                                        report_resp.error_message
-                                    ));
+                                    let report_resp = master_client
+                                        .as_mut()
+                                        .expect("Master client not initialized")
+                                        .report_checkpoint(tonic::Request::new(
+                                            crate::runtime::master::server::master_service::ReportCheckpointRequest {
+                                                checkpoint_id,
+                                                vertex_id: vertex_id.as_ref().to_string(),
+                                                task_index: runtime_context.task_index(),
+                                                checkpoint_data,
+                                                execution_attempt_id,
+                                            },
+                                        ))
+                                        .await?
+                                        .into_inner();
+                                    if !report_resp.success {
+                                        return Err(anyhow::anyhow!(
+                                            "report_checkpoint rejected: {}",
+                                            report_resp.error_message
+                                        ));
+                                    }
+                                    Ok::<u64, anyhow::Error>(payload_len)
                                 }
-                                println!(
-                                    "[CHECKPOINT] {} reported checkpoint_id={}",
-                                    vertex_id, checkpoint_id
-                                );
+                                .await;
+
+                                let duration_ms = started.elapsed().as_secs_f64() * 1000.0;
+                                match checkpoint_result {
+                                    Ok(payload_len) => {
+                                        Self::record_histogram(
+                                            METRIC_STREAM_TASK_CHECKPOINT_DURATION_MS,
+                                            duration_ms,
+                                            &vertex_id,
+                                            metrics_labels.as_ref(),
+                                        );
+                                        increment_vertex_counter(
+                                            METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES,
+                                            payload_len,
+                                            vertex_id.as_ref(),
+                                            metrics_labels.as_ref(),
+                                        );
+                                        increment_vertex_counter(
+                                            METRIC_STREAM_TASK_CHECKPOINT_SUCCESS,
+                                            1,
+                                            vertex_id.as_ref(),
+                                            metrics_labels.as_ref(),
+                                        );
+                                        println!(
+                                            "[CHECKPOINT] {} reported checkpoint_id={}",
+                                            vertex_id, checkpoint_id
+                                        );
+                                    }
+                                    Err(error) => {
+                                        increment_vertex_counter(
+                                            METRIC_STREAM_TASK_CHECKPOINT_FAIL,
+                                            1,
+                                            vertex_id.as_ref(),
+                                            metrics_labels.as_ref(),
+                                        );
+                                        return Err(error);
+                                    }
+                                }
                             }
 
                             // Resume input after checkpointing


### PR DESCRIPTION
## Summary
- Task: `checkpoint_align_wait_ms`, `checkpoint_duration_ms`, `payload_bytes`, `success` / `fail`
- Job (master): `volga_checkpoint_duration_ms`, `completed`, `failed` from protocol `started_at`
- `CheckpointAckOutcome::Completed` now carries `duration_ms`

Stacked on #214. Part of #211 (PR 4/5); advances #148.

## Test plan
- [x] `cargo test --lib runtime::master::checkpoint`
- [x] `cargo test --lib runtime::watermark`
- [ ] CI green


Made with [Cursor](https://cursor.com)