### PR TITLE
obs: WindowMetrics lifecycle Prom recording (#211)

### DIFF
--- a/src/runtime/observability/metrics/mod.rs
+++ b/src/runtime/observability/metrics/mod.rs
@@ -1,4 +1,4 @@
-use metrics::gauge;
+use metrics::{counter, gauge, histogram};
 use serde::{Deserialize, Serialize};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use metrics_exporter_tcp::TcpBuilder;
@@ -65,6 +65,72 @@ pub const LABEL_PIPELINE_ID: &str = "pipeline_id";
 pub struct MetricsLabels {
     pub pipeline_id: String,
     pub worker_id: String,
+}
+
+/// Record a per-vertex histogram sample (ms), with optional pipeline/worker labels.
+pub fn record_vertex_histogram(
+    name: &'static str,
+    value_ms: f64,
+    vertex_id: &str,
+    labels: Option<&MetricsLabels>,
+) {
+    let vertex = vertex_id.to_string();
+    if let Some(labels) = labels {
+        histogram!(
+            name,
+            LABEL_VERTEX_ID => vertex,
+            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => labels.worker_id.clone(),
+        )
+        .record(value_ms);
+    } else {
+        histogram!(name, LABEL_VERTEX_ID => vertex).record(value_ms);
+    }
+}
+
+/// Increment a per-vertex counter, with optional pipeline/worker labels.
+pub fn increment_vertex_counter(
+    name: &'static str,
+    delta: u64,
+    vertex_id: &str,
+    labels: Option<&MetricsLabels>,
+) {
+    if delta == 0 {
+        return;
+    }
+    let vertex = vertex_id.to_string();
+    if let Some(labels) = labels {
+        counter!(
+            name,
+            LABEL_VERTEX_ID => vertex,
+            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => labels.worker_id.clone(),
+        )
+        .increment(delta);
+    } else {
+        counter!(name, LABEL_VERTEX_ID => vertex).increment(delta);
+    }
+}
+
+/// Set a per-vertex gauge, with optional pipeline/worker labels.
+pub fn set_vertex_gauge(
+    name: &'static str,
+    value: f64,
+    vertex_id: &str,
+    labels: Option<&MetricsLabels>,
+) {
+    let vertex = vertex_id.to_string();
+    if let Some(labels) = labels {
+        gauge!(
+            name,
+            LABEL_VERTEX_ID => vertex,
+            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => labels.worker_id.clone(),
+        )
+        .set(value);
+    } else {
+        gauge!(name, LABEL_VERTEX_ID => vertex).set(value);
+    }
 }
 
 // Histogram bucket boundaries, milliseconds (Prometheus also emits a trailing +Inf bucket).

--- a/src/runtime/observability/snapshot_types.rs
+++ b/src/runtime/observability/snapshot_types.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::common::types::PipelineId;
-use crate::runtime::metrics::{MetricsLabels, WorkerAggregateMetrics};
+use crate::runtime::metrics::WorkerAggregateMetrics;
 use crate::runtime::operators::window::metrics::WindowOperatorMetrics;
 use crate::runtime::VertexId;
 use anyhow::Result;
@@ -39,23 +39,13 @@ pub struct TaskSnapshot {
     pub metadata: TaskMetadata,
 }
 
-/// Per-task operator metrics sampled on the worker poll path.
+/// Per-task operator metrics sampled on the worker poll path for the API snapshot.
 ///
-/// Built once via [`crate::runtime::state::OperatorTaskState::task_operator_metrics`], then
-/// published to both [`WorkerSnapshot`] (API) and [`TaskOperatorMetrics::emit`] (Prom).
-/// Operator-specific payloads live with the operator (e.g. window metrics).
+/// Prom recording happens inside the operator lifecycle; the worker only collects
+/// this payload into [`WorkerSnapshot`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TaskOperatorMetrics {
     Window(WindowOperatorMetrics),
-}
-
-impl TaskOperatorMetrics {
-    /// Dispatch Prom emission to the operator-owned implementation.
-    pub fn emit(&self, vertex_id: &str, labels: &MetricsLabels) {
-        match self {
-            TaskOperatorMetrics::Window(m) => m.emit(vertex_id, labels),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/runtime/operators/window/metrics.rs
+++ b/src/runtime/operators/window/metrics.rs
@@ -1,11 +1,23 @@
-//! Window-operator metrics: sampled snapshot type, Prom names, and emit helpers.
+//! Window-operator metrics: API snapshot + Prom recording helpers.
+//!
+//! Prom counters/histograms are recorded on the operator lifecycle path.
+//! [`WindowOperatorMetrics`] is the poll/API snapshot (store sizes); size gauges
+//! are published when that snapshot is taken (operator-owned, not worker `emit`).
 
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use arrow::array::TimestampMillisecondArray;
 use metrics::gauge;
 use serde::{Deserialize, Serialize};
 
 use crate::runtime::metrics::{
-    MetricsLabels, LABEL_PIPELINE_ID, LABEL_VERTEX_ID, LABEL_WORKER_ID,
+    increment_vertex_counter, record_vertex_histogram, MetricsLabels, LABEL_PIPELINE_ID,
+    LABEL_VERTEX_ID, LABEL_WORKER_ID,
 };
+use crate::runtime::runtime_context::RuntimeContext;
+use crate::runtime::VertexId;
 
 pub const METRIC_WO_STATE_RAW_COUNT: &str = "volga_wo_state_raw_count";
 pub const METRIC_WO_STATE_RAW_BYTES: &str = "volga_wo_state_raw_bytes";
@@ -16,7 +28,13 @@ pub const METRIC_WO_STATE_TRIGGERS_BYTES: &str = "volga_wo_state_triggers_bytes"
 pub const METRIC_WO_STATE_KEY_STATES_COUNT: &str = "volga_wo_state_key_states_count";
 pub const METRIC_WO_STATE_KEY_STATES_BYTES: &str = "volga_wo_state_key_states_bytes";
 
-/// Sampled WO metrics for API snapshots and Prom gauges (one task namespace).
+pub const METRIC_WO_WM_PROCESS_MS: &str = "volga_wo_wm_process_ms";
+pub const METRIC_WO_RESULT_FRESHNESS_MS: &str = "volga_wo_result_freshness_ms";
+pub const METRIC_WO_MAINTAIN_MS: &str = "volga_wo_maintain_ms";
+pub const METRIC_WO_MAINTAIN_PRUNED_ROWS: &str = "volga_wo_maintain_pruned_rows";
+pub const METRIC_WO_LATE_DROPPED_ROWS: &str = "volga_wo_late_dropped_rows";
+
+/// Sampled WO store sizes for API snapshots (one task namespace).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WindowOperatorMetrics {
     pub raw_count: u64,
@@ -27,67 +45,183 @@ pub struct WindowOperatorMetrics {
     pub triggers_bytes: u64,
     pub key_states_count: u64,
     pub key_states_bytes: u64,
+    /// Cumulative late-dropped rows since task open (API; Prom increments on ingest).
+    pub late_dropped_rows: u64,
+    /// Cumulative maintain-pruned rows since task open (API; Prom increments on maintain).
+    pub pruned_rows: u64,
 }
 
-impl WindowOperatorMetrics {
-    /// Emit Prom gauges (poll-time, set-to-current).
-    pub fn emit(&self, vertex_id: &str, labels: &MetricsLabels) {
-        let vertex = vertex_id.to_string();
+/// Per-task WO metrics handle: labels + hot-path Prom recording.
+#[derive(Debug)]
+pub struct WindowMetrics {
+    vertex_id: VertexId,
+    labels: MetricsLabels,
+    late_dropped_rows: AtomicU64,
+    pruned_rows: AtomicU64,
+}
+
+impl WindowMetrics {
+    pub fn from_context(context: &RuntimeContext) -> Option<Arc<Self>> {
+        let labels = context.metrics_labels()?;
+        Some(Arc::new(Self {
+            vertex_id: context.vertex_id_arc(),
+            labels,
+            late_dropped_rows: AtomicU64::new(0),
+            pruned_rows: AtomicU64::new(0),
+        }))
+    }
+
+    pub fn vertex_id(&self) -> &str {
+        self.vertex_id.as_ref()
+    }
+
+    pub fn labels(&self) -> &MetricsLabels {
+        &self.labels
+    }
+
+    pub fn add_late_dropped(&self, rows: u64) {
+        if rows == 0 {
+            return;
+        }
+        self.late_dropped_rows.fetch_add(rows, Ordering::Relaxed);
+        increment_vertex_counter(
+            METRIC_WO_LATE_DROPPED_ROWS,
+            rows,
+            self.vertex_id.as_ref(),
+            Some(&self.labels),
+        );
+    }
+
+    pub fn add_pruned(&self, rows: u64) {
+        if rows == 0 {
+            return;
+        }
+        self.pruned_rows.fetch_add(rows, Ordering::Relaxed);
+        increment_vertex_counter(
+            METRIC_WO_MAINTAIN_PRUNED_ROWS,
+            rows,
+            self.vertex_id.as_ref(),
+            Some(&self.labels),
+        );
+    }
+
+    pub fn record_wm_process_ms(&self, ms: f64) {
+        record_vertex_histogram(
+            METRIC_WO_WM_PROCESS_MS,
+            ms,
+            self.vertex_id.as_ref(),
+            Some(&self.labels),
+        );
+    }
+
+    pub fn record_maintain_ms(&self, ms: f64) {
+        record_vertex_histogram(
+            METRIC_WO_MAINTAIN_MS,
+            ms,
+            self.vertex_id.as_ref(),
+            Some(&self.labels),
+        );
+    }
+
+    /// Record result freshness as min/mean/max over the batch (3 hist samples).
+    pub fn record_result_freshness(&self, ts: &TimestampMillisecondArray) {
+        let n = ts.len();
+        if n == 0 {
+            return;
+        }
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        let mut min_f = i64::MAX;
+        let mut max_f = 0i64;
+        let mut sum = 0i64;
+        for i in 0..n {
+            let f = now_ms.saturating_sub(ts.value(i)).max(0);
+            min_f = min_f.min(f);
+            max_f = max_f.max(f);
+            sum = sum.saturating_add(f);
+        }
+        let mean = sum / n as i64;
+        let vertex = self.vertex_id.as_ref();
+        let labels = Some(&self.labels);
+        for sample in [min_f, mean, max_f] {
+            record_vertex_histogram(
+                METRIC_WO_RESULT_FRESHNESS_MS,
+                sample as f64,
+                vertex,
+                labels,
+            );
+        }
+    }
+
+    /// Publish store-size gauges from a snapshot (called when the operator samples for API).
+    pub fn publish_state_sizes(&self, state: &WindowOperatorMetrics) {
+        let vertex = self.vertex_id.as_ref().to_string();
+        let worker = self.labels.worker_id.clone();
+        let pipeline = self.labels.pipeline_id.clone();
         gauge!(
             METRIC_WO_STATE_RAW_COUNT,
             LABEL_VERTEX_ID => vertex.clone(),
-            LABEL_WORKER_ID => labels.worker_id.clone(),
-            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => worker.clone(),
+            LABEL_PIPELINE_ID => pipeline.clone(),
         )
-        .set(self.raw_count as f64);
+        .set(state.raw_count as f64);
         gauge!(
             METRIC_WO_STATE_RAW_BYTES,
             LABEL_VERTEX_ID => vertex.clone(),
-            LABEL_WORKER_ID => labels.worker_id.clone(),
-            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => worker.clone(),
+            LABEL_PIPELINE_ID => pipeline.clone(),
         )
-        .set(self.raw_bytes as f64);
+        .set(state.raw_bytes as f64);
         gauge!(
             METRIC_WO_STATE_TILES_COUNT,
             LABEL_VERTEX_ID => vertex.clone(),
-            LABEL_WORKER_ID => labels.worker_id.clone(),
-            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => worker.clone(),
+            LABEL_PIPELINE_ID => pipeline.clone(),
         )
-        .set(self.tiles_count as f64);
+        .set(state.tiles_count as f64);
         gauge!(
             METRIC_WO_STATE_TILES_BYTES,
             LABEL_VERTEX_ID => vertex.clone(),
-            LABEL_WORKER_ID => labels.worker_id.clone(),
-            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => worker.clone(),
+            LABEL_PIPELINE_ID => pipeline.clone(),
         )
-        .set(self.tiles_bytes as f64);
+        .set(state.tiles_bytes as f64);
         gauge!(
             METRIC_WO_STATE_TRIGGERS_COUNT,
             LABEL_VERTEX_ID => vertex.clone(),
-            LABEL_WORKER_ID => labels.worker_id.clone(),
-            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => worker.clone(),
+            LABEL_PIPELINE_ID => pipeline.clone(),
         )
-        .set(self.triggers_count as f64);
+        .set(state.triggers_count as f64);
         gauge!(
             METRIC_WO_STATE_TRIGGERS_BYTES,
             LABEL_VERTEX_ID => vertex.clone(),
-            LABEL_WORKER_ID => labels.worker_id.clone(),
-            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => worker.clone(),
+            LABEL_PIPELINE_ID => pipeline.clone(),
         )
-        .set(self.triggers_bytes as f64);
+        .set(state.triggers_bytes as f64);
         gauge!(
             METRIC_WO_STATE_KEY_STATES_COUNT,
             LABEL_VERTEX_ID => vertex.clone(),
-            LABEL_WORKER_ID => labels.worker_id.clone(),
-            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => worker.clone(),
+            LABEL_PIPELINE_ID => pipeline.clone(),
         )
-        .set(self.key_states_count as f64);
+        .set(state.key_states_count as f64);
         gauge!(
             METRIC_WO_STATE_KEY_STATES_BYTES,
             LABEL_VERTEX_ID => vertex,
-            LABEL_WORKER_ID => labels.worker_id.clone(),
-            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+            LABEL_WORKER_ID => worker,
+            LABEL_PIPELINE_ID => pipeline,
         )
-        .set(self.key_states_bytes as f64);
+        .set(state.key_states_bytes as f64);
+    }
+
+    pub fn counter_totals(&self) -> (u64, u64) {
+        (
+            self.late_dropped_rows.load(Ordering::Relaxed),
+            self.pruned_rows.load(Ordering::Relaxed),
+        )
     }
 }

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -2,9 +2,10 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Instant;
 
 use anyhow::Result;
-use arrow::array::RecordBatch;
+use arrow::array::{RecordBatch, TimestampMillisecondArray};
 use arrow::datatypes::SchemaRef;
 use async_trait::async_trait;
 use futures::{future, TryStreamExt};
@@ -18,6 +19,7 @@ use crate::runtime::operators::operator::{
 use crate::runtime::operators::window::config::{BuiltWindows, WindowConfig};
 use crate::runtime::operators::window::eval::advance_key;
 use crate::runtime::operators::window::frame_utils::{get_window_length_ms, require_range_frame};
+use crate::runtime::operators::window::metrics::WindowMetrics;
 use crate::runtime::operators::window::model::{Cursor, WindowId};
 use crate::runtime::operators::window::spec::WindowSpec;
 use crate::runtime::operators::window::state::{WindowOperatorState, WindowStateSnapshot};
@@ -224,14 +226,18 @@ impl OperatorTrait for WindowOperator {
                     .expect("operator id must be configured for WindowOperator"),
                 context.task_index(),
             );
-            let state = Arc::new(WindowOperatorState::new(
+            let mut state = WindowOperatorState::new(
                 store,
                 ns,
                 self.ts_column_index,
                 self.window_configs.clone(),
                 self.lateness_ms,
                 self.max_window_length_ms,
-            ));
+            );
+            if let Some(metrics) = WindowMetrics::from_context(context) {
+                state = state.with_metrics(metrics);
+            }
+            let state = Arc::new(state);
             registry.insert_task_state(
                 context.vertex_id_arc(),
                 state.clone() as Arc<dyn OperatorTaskState>,
@@ -285,8 +291,8 @@ impl OperatorTrait for WindowOperator {
                 Message::Keyed(keyed_message) => {
                     let key = keyed_message.key();
                     let input_rows = keyed_message.base.record_batch.num_rows();
-                    let dropped = self
-                        .state_ref()
+                    let state = self.state_ref();
+                    let dropped = state
                         .insert_batch(
                             key,
                             keyed_message.base.record_batch.clone(),
@@ -300,6 +306,9 @@ impl OperatorTrait for WindowOperator {
                     );
                     self.task_metadata
                         .increment_u64(TASK_METADATA_ROWS_DROPPED_LATE, dropped as u64);
+                    if let Some(metrics) = state.metrics() {
+                        metrics.add_late_dropped(dropped as u64);
+                    }
                     OperatorPollResult::Continue
                 }
                 Message::Watermark(watermark) => {
@@ -317,7 +326,21 @@ impl OperatorTrait for WindowOperator {
                     let result = if advances_frontier
                         && self.output_mode == WindowOutputMode::Emit
                     {
-                        self.process_due(advance_to).await
+                        let started = Instant::now();
+                        let batch = self.process_due(advance_to).await;
+                        if let Some(metrics) = state.metrics() {
+                            metrics.record_wm_process_ms(
+                                started.elapsed().as_secs_f64() * 1000.0,
+                            );
+                            if let Some(ts) = batch
+                                .column(self.ts_column_index)
+                                .as_any()
+                                .downcast_ref::<TimestampMillisecondArray>()
+                            {
+                                metrics.record_result_freshness(ts);
+                            }
+                        }
+                        batch
                     } else {
                         RecordBatch::new_empty(self.output_schema.clone())
                     };

--- a/src/runtime/operators/window/state.rs
+++ b/src/runtime/operators/window/state.rs
@@ -11,6 +11,7 @@ use crate::common::Key;
 use crate::runtime::operators::window::config::WindowConfig;
 use crate::runtime::operators::window::model::{WindowId, WindowTrigger, WindowTriggerKind};
 use crate::runtime::operators::window::store::data::cursors_from_batch;
+use crate::runtime::operators::window::metrics::WindowMetrics;
 use crate::runtime::operators::window::store::{
     InMemWindowStore, PartitionKey, StateNamespace, WindowBackendSnapshot, WindowOperatorStore,
 };
@@ -35,6 +36,8 @@ pub struct WindowOperatorState {
     max_window_length_ms: i64,
     /// Task watermark frontier; [`WATERMARK_UNSET`] until the first advance.
     pub watermark_frontier: AtomicI64,
+    /// Prom + API metrics handle (None in tests without worker/pipeline labels).
+    metrics: Option<Arc<WindowMetrics>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,7 +64,17 @@ impl WindowOperatorState {
             lateness_ms,
             max_window_length_ms,
             watermark_frontier: AtomicI64::new(WATERMARK_UNSET),
+            metrics: None,
         }
+    }
+
+    pub fn with_metrics(mut self, metrics: Arc<WindowMetrics>) -> Self {
+        self.metrics = Some(metrics);
+        self
+    }
+
+    pub fn metrics(&self) -> Option<&WindowMetrics> {
+        self.metrics.as_deref()
     }
 
     pub fn store(&self) -> &dyn WindowOperatorStore {
@@ -229,9 +242,14 @@ impl OperatorTaskState for WindowOperatorState {
             .as_any()
             .downcast_ref::<InMemWindowStore>()
             .expect("window task_operator_metrics requires InMemWindowStore");
-        Some(TaskOperatorMetrics::Window(
-            store.sample_namespace_metrics(&self.namespace).await,
-        ))
+        let mut snap = store.sample_namespace_metrics(&self.namespace).await;
+        if let Some(metrics) = self.metrics() {
+            let (late, pruned) = metrics.counter_totals();
+            snap.late_dropped_rows = late;
+            snap.pruned_rows = pruned;
+            metrics.publish_state_sizes(&snap);
+        }
+        Some(TaskOperatorMetrics::Window(snap))
     }
 }
 

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -125,19 +125,24 @@ impl InMemWindowStore {
         snap
     }
 
-    fn prune_namespace(state: &mut InMemState, namespace: &[u8], watermark: i64, floor: i64) {
+    /// Returns number of raw rows pruned.
+    fn prune_namespace(state: &mut InMemState, namespace: &[u8], watermark: i64, floor: i64) -> u64 {
         state.triggers.retain(|trigger| {
             trigger.partition.namespace.as_slice() != namespace || trigger.fire_at.ts > watermark
         });
+        let mut pruned_rows = 0u64;
         for (partition, part) in state.partitions.iter_mut() {
             if partition.namespace.as_slice() != namespace {
                 continue;
             }
+            let before = part.raw.len();
             part.raw.retain(|cursor, _| cursor.ts >= floor);
+            pruned_rows += (before - part.raw.len()) as u64;
             part.tiles.retain(|&(granularity, start_ts), _| {
                 start_ts + granularity.to_millis() > floor
             });
         }
+        pruned_rows
     }
 
     fn select_raw(state: &PartitionState, runs: &[RawRun]) -> Vec<RecordBatch> {
@@ -438,8 +443,14 @@ impl OperatorStore for InMemWindowStore {
         let Some((watermark, floor)) = wo.retention_cutoff() else {
             return Ok(());
         };
+        let started = std::time::Instant::now();
         let mut store = self.state.write().await;
-        Self::prune_namespace(&mut store, ns.bytes.as_slice(), watermark, floor);
+        let pruned_rows = Self::prune_namespace(&mut store, ns.bytes.as_slice(), watermark, floor);
+        drop(store);
+        if let Some(metrics) = wo.metrics() {
+            metrics.record_maintain_ms(started.elapsed().as_secs_f64() * 1000.0);
+            metrics.add_pruned(pruned_rows);
+        }
         Ok(())
     }
 }

--- a/src/runtime/runtime_context.rs
+++ b/src/runtime/runtime_context.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use crate::api::spec::state::{OperatorStateBackendConfig, RequestStoreConfig};
 use crate::common::types::PipelineId;
 use crate::runtime::execution_graph::ExecutionGraph;
+use crate::runtime::metrics::MetricsLabels;
 use crate::{common::Message, runtime::functions::source::request_source::PendingRequest};
 use crate::runtime::operators::source::SourceHandles;
 use crate::runtime::observability::TaskMetadata;
@@ -72,6 +73,33 @@ impl RuntimeContext {
     pub fn job_config(&self) -> &HashMap<String, Value> {
         &self.job_config
     }
+
+    /// Worker id from job config (`worker_id` string), when present.
+    pub fn worker_id(&self) -> Option<&str> {
+        self.job_config
+            .get("worker_id")
+            .and_then(|v| v.as_str())
+    }
+
+    /// Pipeline + worker labels for Prom, when both are configured.
+    pub fn metrics_labels(&self) -> Option<MetricsLabels> {
+        let pipeline_id = self
+            .pipeline_id
+            .as_ref()
+            .map(|p| p.0.clone())
+            .or_else(|| {
+                self.job_config
+                    .get("pipeline_id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            })?;
+        let worker_id = self.worker_id()?.to_string();
+        Some(MetricsLabels {
+            pipeline_id,
+            worker_id,
+        })
+    }
+
     pub fn state_registry(&self) -> Option<&Arc<StateRegistry>> {
         self.state_registry.as_ref()
     }

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -162,25 +162,7 @@ impl StreamTask {
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
 
-        let metrics_labels = {
-            let cfg = runtime_context.job_config();
-            let pipeline_id = cfg
-                .get("pipeline_id")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let worker_id = cfg
-                .get("worker_id")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-
-            match (pipeline_id, worker_id) {
-                (Some(pipeline_id), Some(worker_id)) => Some(MetricsLabels {
-                    pipeline_id,
-                    worker_id,
-                }),
-                _ => None,
-            }
-        };
+        let metrics_labels = runtime_context.metrics_labels();
         Self {
             vertex_id: vertex_id.clone(),
             runtime_context,

--- a/src/runtime/worker/tasks.rs
+++ b/src/runtime/worker/tasks.rs
@@ -101,9 +101,6 @@ impl WorkerInner {
             WorkerAggregateMetrics::new(worker_id, pipeline_id, task_metrics_str, &graph);
         worker_metrics.record();
         emit_backpressure_gauges(&worker_metrics);
-        for (vertex_id, op_metrics) in &task_operator_metrics {
-            op_metrics.emit(vertex_id.as_ref(), &labels);
-        }
         emit_worker_memory_gauges(&labels);
 
         {


### PR DESCRIPTION
## Summary
- Follow-up to merged #212: drop worker-side operator `emit`; record WO Prom on the operator lifecycle via `WindowMetrics`
- Size gauges published when sampling for the API; hot-path counters/histograms (late drops, wm_process, freshness min/mean/max, maintain + pruned rows)
- `RuntimeContext::worker_id` / `metrics_labels`; restore shared per-vertex Prom helpers

Part of #211. Absorbs the model formerly planned for #213.

## Test plan
- [x] `./scripts/test unit` (168 passed)
- [ ] CI green
- [x] #214–#216 rebased onto this tip


Made with [Cursor](https://cursor.com)