### PR TITLE
obs: watermark lag + WM/checkpoint barrier propagation (#211)

### DIFF
--- a/src/runtime/observability/metrics/names.rs
+++ b/src/runtime/observability/metrics/names.rs
@@ -20,12 +20,13 @@ pub const METRIC_STREAM_TASK_TX_QUEUE_REM: &str = "volga_stream_task_tx_queue_re
 pub const METRIC_STREAM_TASK_BACKPRESSURE_RATIO: &str = "volga_stream_task_backpressure_ratio";
 pub const METRIC_STREAM_TASK_BACKPRESSURE_MAX: &str = "volga_stream_task_backpressure_max";
 /// Event-time lag: `wall_now_ms − current_watermark` (omit for 0 / MAX).
+/// Refreshed on watermark advance and on the task metrics tick so idle lag grows.
 pub const METRIC_STREAM_TASK_WATERMARK_LAG_MS: &str = "volga_stream_task_watermark_lag_ms";
-/// Hop delay for watermarks: `recv − create_stamp`.
+/// Control-path delay for watermarks: `recv − source/inject stamp`.
 pub const METRIC_STREAM_TASK_WM_PROPAGATION_MS: &str = "volga_stream_task_wm_propagation_ms";
-/// Hop delay for checkpoint barriers: `recv − create_stamp`.
-pub const METRIC_STREAM_TASK_BARRIER_PROPAGATION_MS: &str =
-    "volga_stream_task_barrier_propagation_ms";
+/// Control-path delay for checkpoint barriers: `recv − source/inject stamp`.
+pub const METRIC_STREAM_TASK_CHECKPOINT_BARRIER_PROPAGATION_MS: &str =
+    "volga_stream_task_checkpoint_barrier_propagation_ms";
 /// Wait from first barrier seen to full upstream alignment (non-sources).
 pub const METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS: &str =
     "volga_stream_task_checkpoint_align_wait_ms";

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -8,8 +8,9 @@ use crate::{
         metrics::{
             init_metrics, record_task_histogram, set_task_gauge, MetricsLabels,
             LABEL_PIPELINE_ID, LABEL_TASK_ID, LABEL_WORKER_ID,
-            METRIC_STREAM_TASK_BARRIER_PROPAGATION_MS, METRIC_STREAM_TASK_BYTES_RECV,
-            METRIC_STREAM_TASK_BYTES_SENT, METRIC_STREAM_TASK_MESSAGES_RECV,
+            METRIC_STREAM_TASK_BYTES_RECV,
+            METRIC_STREAM_TASK_BYTES_SENT, METRIC_STREAM_TASK_CHECKPOINT_BARRIER_PROPAGATION_MS,
+            METRIC_STREAM_TASK_MESSAGES_RECV,
             METRIC_STREAM_TASK_MESSAGES_SENT, METRIC_STREAM_TASK_PATH_LATENCY,
             METRIC_STREAM_TASK_RECORDS_RECV, METRIC_STREAM_TASK_RECORDS_SENT,
             METRIC_STREAM_TASK_WATERMARK_LAG_MS, METRIC_STREAM_TASK_WM_PROPAGATION_MS,
@@ -32,7 +33,7 @@ use crate::transport::transport_client::DataReaderControl;
 use std::collections::HashSet;
 use crate::transport::transport_client::TransportClient;
 use crate::common::message::{Message, WatermarkMessage};
-use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, Arc}, time::{Duration, SystemTime, UNIX_EPOCH}};
+use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, Arc}, time::{Duration, Instant, SystemTime, UNIX_EPOCH}};
 // serde imports removed; this module does not define serializable DTOs directly.
 use crate::common::grpc::master::master_client as connect_master_client;
 use crate::common::grpc::GrpcConfig;
@@ -267,7 +268,7 @@ impl StreamTask {
             }
             Message::CheckpointBarrier(_) => {
                 Self::record_histogram(
-                    METRIC_STREAM_TASK_BARRIER_PROPAGATION_MS,
+                    METRIC_STREAM_TASK_CHECKPOINT_BARRIER_PROPAGATION_MS,
                     delay_ms,
                     vertex_id,
                     labels,
@@ -292,6 +293,23 @@ impl StreamTask {
             vertex_id.as_ref(),
             labels,
         );
+    }
+
+    fn maybe_publish_watermark_lag(
+        window_start: &mut Instant,
+        vertex_id: &VertexId,
+        labels: Option<&MetricsLabels>,
+        current_watermark: &AtomicU64,
+    ) {
+        if window_start.elapsed() < Duration::from_secs(1) {
+            return;
+        }
+        Self::set_watermark_lag_gauge(
+            vertex_id,
+            current_watermark.load(Ordering::Relaxed),
+            labels,
+        );
+        *window_start = Instant::now();
     }
 
     fn record_metrics(
@@ -708,6 +726,7 @@ impl StreamTask {
                 operator.set_input(Some(preprocessed_stream))
             };
 
+            let mut lag_window_start = Instant::now();
             while status.load(Ordering::SeqCst) == StreamTaskStatus::Running as u8 {
                 // For sources: if checkpoint is triggered, synthesize a CheckpointBarrier message and treat it exactly
                 // like a poll_next() output (same code path, no duplication).
@@ -908,6 +927,12 @@ impl StreamTask {
                     }
                     OperatorPollResult::Continue => { /* no output */ }
                 }
+                Self::maybe_publish_watermark_lag(
+                    &mut lag_window_start,
+                    &vertex_id,
+                    metrics_labels.as_ref(),
+                    &current_watermark,
+                );
             }
             
             // Flush and close collectors

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -6,11 +6,13 @@ use crate::{
         execution_graph::ExecutionGraph,
         health::{WorkerFatalReason, WorkerHealth},
         metrics::{
-            init_metrics, MetricsLabels, LABEL_PIPELINE_ID, LABEL_TASK_ID, LABEL_WORKER_ID,
-            METRIC_STREAM_TASK_BYTES_RECV, METRIC_STREAM_TASK_BYTES_SENT,
-            METRIC_STREAM_TASK_MESSAGES_RECV, METRIC_STREAM_TASK_MESSAGES_SENT,
-            METRIC_STREAM_TASK_PATH_LATENCY, METRIC_STREAM_TASK_RECORDS_RECV,
-            METRIC_STREAM_TASK_RECORDS_SENT,
+            init_metrics, record_task_histogram, set_task_gauge, MetricsLabels,
+            LABEL_PIPELINE_ID, LABEL_TASK_ID, LABEL_WORKER_ID,
+            METRIC_STREAM_TASK_BARRIER_PROPAGATION_MS, METRIC_STREAM_TASK_BYTES_RECV,
+            METRIC_STREAM_TASK_BYTES_SENT, METRIC_STREAM_TASK_MESSAGES_RECV,
+            METRIC_STREAM_TASK_MESSAGES_SENT, METRIC_STREAM_TASK_PATH_LATENCY,
+            METRIC_STREAM_TASK_RECORDS_RECV, METRIC_STREAM_TASK_RECORDS_SENT,
+            METRIC_STREAM_TASK_WATERMARK_LAG_MS, METRIC_STREAM_TASK_WM_PROPAGATION_MS,
         },
         observability::{TaskMetadata, TaskSnapshot, StreamTaskStatus},
         operators::operator::{
@@ -24,7 +26,7 @@ use crate::{
 use anyhow::Result;
 use futures::{FutureExt, StreamExt};
 use async_stream::stream;
-use metrics::{counter, histogram};
+use metrics::counter;
 use tokio::{task::JoinHandle, sync::Mutex, sync::watch, sync::mpsc};
 use crate::transport::transport_client::DataReaderControl;
 use std::collections::HashSet;
@@ -49,6 +51,8 @@ pub(crate) struct CheckpointAligner {
     upstream_count: usize,
     current_checkpoint: Option<u64>,
     seen_upstreams: HashSet<String>,
+    /// Earliest create stamp among barriers for the current checkpoint (for propagation).
+    inject_stamp: Option<u64>,
     reader_control: DataReaderControl,
 }
 
@@ -58,15 +62,17 @@ impl CheckpointAligner {
             upstream_count: upstream_vertices.len(),
             current_checkpoint: None,
             seen_upstreams: HashSet::new(),
+            inject_stamp: None,
             reader_control,
         }
     }
 
+    /// Returns `Some((checkpoint_id, inject_stamp))` when fully aligned.
     fn on_barrier(
         &mut self,
         barrier: &crate::common::message::CheckpointBarrierMessage,
         expected_attempt_id: u64,
-    ) -> Result<Option<u64>, String> {
+    ) -> Result<Option<(u64, Option<u64>)>, String> {
         if barrier.execution_attempt_id != expected_attempt_id {
             // Orphan from a previous attempt — drop without failing the new attempt.
             println!(
@@ -86,6 +92,13 @@ impl CheckpointAligner {
         let checkpoint_id = barrier.checkpoint_id;
         if self.current_checkpoint.is_none() {
             self.current_checkpoint = Some(checkpoint_id);
+            self.inject_stamp = barrier.metadata.ingest_timestamp;
+        } else if let (Some(existing), Some(stamp)) =
+            (self.inject_stamp, barrier.metadata.ingest_timestamp)
+        {
+            self.inject_stamp = Some(existing.min(stamp));
+        } else if self.inject_stamp.is_none() {
+            self.inject_stamp = barrier.metadata.ingest_timestamp;
         }
         if self.current_checkpoint != Some(checkpoint_id) {
             return Err(format!(
@@ -98,9 +111,10 @@ impl CheckpointAligner {
         self.seen_upstreams.insert(upstream_vertex_id);
 
         if self.seen_upstreams.len() == self.upstream_count {
+            let stamp = self.inject_stamp.take();
             self.current_checkpoint = None;
             self.seen_upstreams.clear();
-            return Ok(Some(checkpoint_id));
+            return Ok(Some((checkpoint_id, stamp)));
         }
         Ok(None)
     }
@@ -162,25 +176,7 @@ impl StreamTask {
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
 
-        let metrics_labels = {
-            let cfg = runtime_context.job_config();
-            let pipeline_id = cfg
-                .get("pipeline_id")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let worker_id = cfg
-                .get("worker_id")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-
-            match (pipeline_id, worker_id) {
-                (Some(pipeline_id), Some(worker_id)) => Some(MetricsLabels {
-                    pipeline_id,
-                    worker_id,
-                }),
-                _ => None,
-            }
-        };
+        let metrics_labels = runtime_context.metrics_labels();
         Self {
             vertex_id: vertex_id.clone(),
             runtime_context,
@@ -248,17 +244,54 @@ impl StreamTask {
         vertex_id: &VertexId,
         labels: Option<&MetricsLabels>,
     ) {
-        if let Some(labels) = labels {
-            histogram!(
-                name,
-                LABEL_TASK_ID => vertex_id.clone(),
-                LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                LABEL_WORKER_ID => labels.worker_id.clone()
-            )
-            .record(value_ms);
-        } else {
-            histogram!(name, LABEL_TASK_ID => vertex_id.clone()).record(value_ms);
+        record_task_histogram(name, value_ms, vertex_id.as_ref(), labels);
+    }
+
+    fn record_control_propagation(
+        vertex_id: &VertexId,
+        message: &Message,
+        labels: Option<&MetricsLabels>,
+    ) {
+        let Some(stamp) = message.ingest_timestamp() else {
+            return;
+        };
+        let delay_ms = Self::now_ms().saturating_sub(stamp) as f64;
+        match message {
+            Message::Watermark(_) => {
+                Self::record_histogram(
+                    METRIC_STREAM_TASK_WM_PROPAGATION_MS,
+                    delay_ms,
+                    vertex_id,
+                    labels,
+                );
+            }
+            Message::CheckpointBarrier(_) => {
+                Self::record_histogram(
+                    METRIC_STREAM_TASK_BARRIER_PROPAGATION_MS,
+                    delay_ms,
+                    vertex_id,
+                    labels,
+                );
+            }
+            _ => {}
         }
+    }
+
+    fn set_watermark_lag_gauge(
+        vertex_id: &VertexId,
+        watermark_value: u64,
+        labels: Option<&MetricsLabels>,
+    ) {
+        if watermark_value == 0 || watermark_value == MAX_WATERMARK_VALUE {
+            return;
+        }
+        let lag_ms = Self::now_ms().saturating_sub(watermark_value) as f64;
+        set_task_gauge(
+            METRIC_STREAM_TASK_WATERMARK_LAG_MS,
+            lag_ms,
+            vertex_id.as_ref(),
+            labels,
+        );
     }
 
     fn record_metrics(
@@ -374,6 +407,7 @@ impl StreamTask {
             );
             while let Some(message) = input_stream.next().await {
                 Self::record_metrics(vertex_id.clone(), &message, true, labels.as_ref());
+                Self::record_control_propagation(&vertex_id, &message, labels.as_ref());
 
                 match &message {
                     Message::Watermark(watermark) => {
@@ -382,22 +416,24 @@ impl StreamTask {
                         }
                         // Advance watermark and only forward to operator if advanced.
                         if let Some(new_watermark) = watermark_manager.merge_watermark(watermark.clone()).await {
+                            Self::set_watermark_lag_gauge(&vertex_id, new_watermark, labels.as_ref());
                             let mut wm = watermark.clone();
                             wm.watermark_value = new_watermark;
                             wm.metadata.upstream_vertex_id = Some(vertex_id.as_ref().to_string());
+                            // Keep create stamp for downstream propagation.
                             yield Message::Watermark(wm);
                         }
                     }
                     Message::CheckpointBarrier(barrier) => {
                         match aligner.on_barrier(barrier, execution_attempt_id) {
-                            Ok(Some(checkpoint_id)) => {
-                                // Once fully aligned, yield a single barrier downstream through the operator.
+                            Ok(Some((checkpoint_id, inject_stamp))) => {
+                                // Once fully aligned, yield a single barrier; preserve inject stamp.
                                 yield Message::CheckpointBarrier(
                                     crate::common::message::CheckpointBarrierMessage::new(
                                         vertex_id.as_ref().to_string(),
                                         checkpoint_id,
                                         execution_attempt_id,
-                                        None,
+                                        inject_stamp,
                                     ),
                                 );
                             }
@@ -423,10 +459,15 @@ impl StreamTask {
                             // Treat injected watermark exactly like an upstream watermark: merge and
                             // emit a task-local watermark only if it advances.
                             if let Some(new_watermark) = watermark_manager.merge_watermark(wm.clone()).await {
+                                Self::set_watermark_lag_gauge(
+                                    &vertex_id,
+                                    new_watermark,
+                                    labels.as_ref(),
+                                );
                                 yield Message::Watermark(WatermarkMessage::new(
                                     vertex_id.as_ref().to_string(),
                                     new_watermark,
-                                    None,
+                                    Some(Self::now_ms()),
                                 ));
                             }
                         }
@@ -682,7 +723,7 @@ impl StreamTask {
                                     vertex_id.as_ref().to_string(),
                                     checkpoint_id,
                                     execution_attempt_id,
-                                    None,
+                                    Some(Self::now_ms()),
                                 ),
                             ))
                         }
@@ -771,10 +812,11 @@ impl StreamTask {
                         //     println!("StreamTask {:?} produced message {:?}", vertex_id, message);
                         // }
                         if is_source {
-                            message.set_ingest_timestamp(SystemTime::now()
-                                .duration_since(UNIX_EPOCH)
-                                .unwrap_or_default()
-                                .as_millis() as u64);
+                            // Stamp data (path latency) and control (propagation) at source egress
+                            // unless already stamped (e.g. barrier inject time).
+                            if message.ingest_timestamp().is_none() {
+                                message.set_ingest_timestamp(Self::now_ms());
+                            }
                         }
                         if let Message::Watermark(ref mut watermark) = message {
                             if is_source {
@@ -783,6 +825,11 @@ impl StreamTask {
                                         watermark.watermark_value = new_watermark;
                                     }
                                 }
+                                Self::set_watermark_lag_gauge(
+                                    &vertex_id,
+                                    watermark.watermark_value,
+                                    metrics_labels.as_ref(),
+                                );
                             }
                             // If operator outputs max watermark, finish task
                             if watermark.watermark_value == MAX_WATERMARK_VALUE {
@@ -810,6 +857,14 @@ impl StreamTask {
                         if let Some(wm) = injected_wm {
                             let mut injected = Message::Watermark(wm);
                             injected.set_upstream_vertex_id(vertex_id.as_ref().to_string());
+                            injected.set_ingest_timestamp(Self::now_ms());
+                            if let Message::Watermark(ref w) = injected {
+                                Self::set_watermark_lag_gauge(
+                                    &vertex_id,
+                                    w.watermark_value,
+                                    metrics_labels.as_ref(),
+                                );
+                            }
                             Self::record_metrics(
                                 vertex_id.clone(),
                                 &injected,
@@ -830,7 +885,7 @@ impl StreamTask {
                             let wm = Message::Watermark(WatermarkMessage::new(
                                 vertex_id.as_ref().to_string(),
                                 MAX_WATERMARK_VALUE,
-                                None,
+                                Some(Self::now_ms()),
                             ));
                             Self::record_metrics(vertex_id.clone(), &wm, false, metrics_labels.as_ref());
                             Self::send_to_collectors_if_needed(


### PR DESCRIPTION
## Summary
- Watermark lag gauge (`wall_now − watermark`)
- WM and checkpoint-barrier hop-delay histograms (`recv − create_stamp`)

Depends on #224. Followed by checkpoint + time-budget PRs.

## Test plan
- [ ] `scripts/test unit`
- [ ] Spot-check WM lag / propagation metrics under load