### PR TITLE
obs: checkpoint duration, align wait, payload, outcome (#211)

### DIFF
--- a/src/runtime/master/checkpoint/actor.rs
+++ b/src/runtime/master/checkpoint/actor.rs
@@ -85,7 +85,7 @@ impl Message<StartCheckpoint> for CheckpointCoordinator {
 }
 
 impl Message<AbortInFlightCheckpoint> for CheckpointCoordinator {
-    type Reply = Option<u64>;
+    type Reply = Option<(u64, u64)>;
 
     async fn handle(
         &mut self,

--- a/src/runtime/master/checkpoint/actor.rs
+++ b/src/runtime/master/checkpoint/actor.rs
@@ -85,7 +85,7 @@ impl Message<StartCheckpoint> for CheckpointCoordinator {
 }
 
 impl Message<AbortInFlightCheckpoint> for CheckpointCoordinator {
-    type Reply = Option<(u64, u64)>;
+    type Reply = Option<u64>;
 
     async fn handle(
         &mut self,

--- a/src/runtime/master/checkpoint/mod.rs
+++ b/src/runtime/master/checkpoint/mod.rs
@@ -102,10 +102,10 @@ impl Checkpoints {
             .start(&self.expected_acks, &self.expected_aligns)
     }
 
-    pub fn abort_in_flight(&mut self) -> Option<(u64, u64)> {
-        let (checkpoint_id, duration_ms) = self.protocol.abort_in_flight()?;
+    pub fn abort_in_flight(&mut self) -> Option<u64> {
+        let checkpoint_id = self.protocol.abort_in_flight()?;
         self.pending.remove(&checkpoint_id);
-        Some((checkpoint_id, duration_ms))
+        Some(checkpoint_id)
     }
 
     pub fn in_flight_id(&self) -> Option<u64> {
@@ -290,7 +290,7 @@ mod tests {
             CheckpointAckOutcome::Pending
         );
         assert!(cps.load(id).await.is_err());
-        assert_eq!(cps.abort_in_flight().map(|(cid, _)| cid), Some(id));
+        assert_eq!(cps.abort_in_flight(), Some(id));
         assert!(cps.load(id).await.is_err());
     }
 

--- a/src/runtime/master/checkpoint/mod.rs
+++ b/src/runtime/master/checkpoint/mod.rs
@@ -33,7 +33,10 @@ pub enum CheckpointAckOutcome {
     /// Progress recorded; still waiting for state acks and/or barrier aligns.
     Pending,
     /// Expected state acks and barrier aligns both satisfied; newly completed.
-    Completed,
+    Completed {
+        /// Wall ms from checkpoint start to completion.
+        duration_ms: u64,
+    },
     /// Ignored / rejected without completing.
     Rejected(CheckpointAckReject),
 }
@@ -99,10 +102,10 @@ impl Checkpoints {
             .start(&self.expected_acks, &self.expected_aligns)
     }
 
-    pub fn abort_in_flight(&mut self) -> Option<u64> {
-        let checkpoint_id = self.protocol.abort_in_flight()?;
+    pub fn abort_in_flight(&mut self) -> Option<(u64, u64)> {
+        let (checkpoint_id, duration_ms) = self.protocol.abort_in_flight()?;
         self.pending.remove(&checkpoint_id);
-        Some(checkpoint_id)
+        Some((checkpoint_id, duration_ms))
     }
 
     pub fn in_flight_id(&self) -> Option<u64> {
@@ -175,7 +178,7 @@ impl Checkpoints {
         checkpoint_id: u64,
         outcome: CheckpointAckOutcome,
     ) -> anyhow::Result<CheckpointAckOutcome> {
-        if !matches!(outcome, CheckpointAckOutcome::Completed) {
+        if !matches!(outcome, CheckpointAckOutcome::Completed { .. }) {
             return Ok(outcome);
         }
         let tasks = self.pending.remove(&checkpoint_id).unwrap_or_default();
@@ -246,10 +249,10 @@ mod tests {
                 .unwrap(),
             CheckpointAckOutcome::Pending
         );
-        assert_eq!(
+        assert!(matches!(
             cps.note_barrier_progress(id, task("a", 0)).await.unwrap(),
-            CheckpointAckOutcome::Completed
-        );
+            CheckpointAckOutcome::Completed { .. }
+        ));
         id
     }
 
@@ -287,7 +290,7 @@ mod tests {
             CheckpointAckOutcome::Pending
         );
         assert!(cps.load(id).await.is_err());
-        assert_eq!(cps.abort_in_flight(), Some(id));
+        assert_eq!(cps.abort_in_flight().map(|(cid, _)| cid), Some(id));
         assert!(cps.load(id).await.is_err());
     }
 
@@ -310,11 +313,11 @@ mod tests {
                 .unwrap(),
             CheckpointAckOutcome::Pending
         );
-        assert_eq!(
+        assert!(matches!(
             cps.note_barrier_progress(id, task("sink", 0))
                 .await
                 .unwrap(),
-            CheckpointAckOutcome::Completed
-        );
+            CheckpointAckOutcome::Completed { .. }
+        ));
     }
 }

--- a/src/runtime/master/checkpoint/protocol.rs
+++ b/src/runtime/master/checkpoint/protocol.rs
@@ -63,8 +63,14 @@ impl CheckpointProtocol {
         Ok(checkpoint_id)
     }
 
-    pub(super) fn abort_in_flight(&mut self) -> Option<u64> {
-        self.in_flight.take().map(|c| c.checkpoint_id)
+    /// Returns `(checkpoint_id, duration_ms)` when an in-flight checkpoint is aborted.
+    pub(super) fn abort_in_flight(&mut self) -> Option<(u64, u64)> {
+        self.in_flight.take().map(|c| {
+            (
+                c.checkpoint_id,
+                c.started_at.elapsed().as_millis() as u64,
+            )
+        })
     }
 
     /// Record a state ack. Completes only when acks and aligns both match expected sets.
@@ -129,9 +135,10 @@ impl CheckpointProtocol {
         }
 
         if in_flight.acks == *expected_acks && in_flight.aligns == *expected_aligns {
+            let duration_ms = in_flight.started_at.elapsed().as_millis() as u64;
             self.in_flight = None;
             self.completed.insert(checkpoint_id);
-            CheckpointAckOutcome::Completed
+            CheckpointAckOutcome::Completed { duration_ms }
         } else {
             CheckpointAckOutcome::Pending
         }
@@ -179,10 +186,10 @@ mod tests {
     ) -> u64 {
         let id = protocol.start(acks, aligns).unwrap();
         assert_eq!(protocol.ack(id, t.clone(), acks, aligns), CheckpointAckOutcome::Pending);
-        assert_eq!(
+        assert!(matches!(
             protocol.align(id, t, acks, aligns),
-            CheckpointAckOutcome::Completed
-        );
+            CheckpointAckOutcome::Completed { .. }
+        ));
         id
     }
 
@@ -201,10 +208,10 @@ mod tests {
             protocol.align(id, task("src", 0), &acks, &aligns),
             CheckpointAckOutcome::Pending
         );
-        assert_eq!(
+        assert!(matches!(
             protocol.align(id, task("sink", 0), &acks, &aligns),
-            CheckpointAckOutcome::Completed
-        );
+            CheckpointAckOutcome::Completed { .. }
+        ));
         assert_eq!(protocol.latest_complete(), Some(id));
         assert!(protocol.in_flight_id().is_none());
     }
@@ -223,10 +230,10 @@ mod tests {
             protocol.ack(id, task("a", 0), &acks, &aligns),
             CheckpointAckOutcome::Pending
         );
-        assert_eq!(
+        assert!(matches!(
             protocol.align(id, task("a", 0), &acks, &aligns),
-            CheckpointAckOutcome::Completed
-        );
+            CheckpointAckOutcome::Completed { .. }
+        ));
         assert!(matches!(
             protocol.ack(id, task("a", 0), &acks, &aligns),
             CheckpointAckOutcome::Rejected(CheckpointAckReject::AlreadyComplete)

--- a/src/runtime/master/checkpoint/protocol.rs
+++ b/src/runtime/master/checkpoint/protocol.rs
@@ -63,14 +63,9 @@ impl CheckpointProtocol {
         Ok(checkpoint_id)
     }
 
-    /// Returns `(checkpoint_id, duration_ms)` when an in-flight checkpoint is aborted.
-    pub(super) fn abort_in_flight(&mut self) -> Option<(u64, u64)> {
-        self.in_flight.take().map(|c| {
-            (
-                c.checkpoint_id,
-                c.started_at.elapsed().as_millis() as u64,
-            )
-        })
+    /// Returns the aborted checkpoint id, if any.
+    pub(super) fn abort_in_flight(&mut self) -> Option<u64> {
+        self.in_flight.take().map(|c| c.checkpoint_id)
     }
 
     /// Record a state ack. Completes only when acks and aligns both match expected sets.

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -323,13 +323,9 @@ impl MasterState {
             .ask(AbortInFlightCheckpoint)
             .await
             .map_err(|error| format!("checkpoint coordinator: {error}"))?;
-        if let Some((checkpoint_id, duration_ms)) = aborted {
+        if let Some(checkpoint_id) = aborted {
             let pipeline_id = self.orchestrator.get_pipeline_id().await;
-            record_pipeline_histogram(
-                METRIC_CHECKPOINT_DURATION_MS,
-                duration_ms as f64,
-                &pipeline_id,
-            );
+            // Duration stays success-only so abort/timeouts do not inflate the histogram.
             increment_pipeline_counter(METRIC_CHECKPOINT_FAILED, 1, &pipeline_id);
             self.record_lifecycle_event(LifecycleEvent::CheckpointFailed {
                 checkpoint_id,

--- a/src/runtime/master/state.rs
+++ b/src/runtime/master/state.rs
@@ -17,6 +17,10 @@ use crate::runtime::consts::{
     runtime_consts, MASTER_CHECKPOINT_RETENTION, MASTER_REGISTRY_WAIT_TICK,
 };
 use crate::runtime::execution_graph::ExecutionGraph;
+use crate::runtime::metrics::{
+    increment_pipeline_counter, record_pipeline_histogram, METRIC_CHECKPOINT_COMPLETED,
+    METRIC_CHECKPOINT_DURATION_MS, METRIC_CHECKPOINT_FAILED,
+};
 use crate::runtime::observability::snapshot_types::PipelineSnapshot;
 use crate::runtime::operators::operator::operator_config_requires_checkpoint;
 
@@ -314,20 +318,29 @@ impl MasterState {
         attempt_id: u64,
         detail: String,
     ) -> Result<Option<u64>, String> {
-        let checkpoint_id = self
+        let aborted = self
             .checkpoints
             .ask(AbortInFlightCheckpoint)
             .await
             .map_err(|error| format!("checkpoint coordinator: {error}"))?;
-        if let Some(checkpoint_id) = checkpoint_id {
+        if let Some((checkpoint_id, duration_ms)) = aborted {
+            let pipeline_id = self.orchestrator.get_pipeline_id().await;
+            record_pipeline_histogram(
+                METRIC_CHECKPOINT_DURATION_MS,
+                duration_ms as f64,
+                &pipeline_id,
+            );
+            increment_pipeline_counter(METRIC_CHECKPOINT_FAILED, 1, &pipeline_id);
             self.record_lifecycle_event(LifecycleEvent::CheckpointFailed {
                 checkpoint_id,
                 attempt_id,
                 detail,
             })
             .await;
+            Ok(Some(checkpoint_id))
+        } else {
+            Ok(None)
         }
-        Ok(checkpoint_id)
     }
 
     pub(super) async fn in_flight_checkpoint_timed_out(&self, timeout: Duration) -> Option<u64> {
@@ -381,7 +394,14 @@ impl MasterState {
         })
         .await;
 
-        if matches!(outcome, CheckpointAckOutcome::Completed) {
+        if let CheckpointAckOutcome::Completed { duration_ms } = outcome {
+            let pipeline_id = self.orchestrator.get_pipeline_id().await;
+            record_pipeline_histogram(
+                METRIC_CHECKPOINT_DURATION_MS,
+                duration_ms as f64,
+                &pipeline_id,
+            );
+            increment_pipeline_counter(METRIC_CHECKPOINT_COMPLETED, 1, &pipeline_id);
             self.record_lifecycle_event(LifecycleEvent::CheckpointCompleted { checkpoint_id })
                 .await;
         }
@@ -436,7 +456,14 @@ impl MasterState {
             .map_err(|error| format!("failed to update checkpoint store: {error}"))?;
 
         match outcome {
-            CheckpointAckOutcome::Completed => {
+            CheckpointAckOutcome::Completed { duration_ms } => {
+                let pipeline_id = self.orchestrator.get_pipeline_id().await;
+                record_pipeline_histogram(
+                    METRIC_CHECKPOINT_DURATION_MS,
+                    duration_ms as f64,
+                    &pipeline_id,
+                );
+                increment_pipeline_counter(METRIC_CHECKPOINT_COMPLETED, 1, &pipeline_id);
                 self.record_lifecycle_event(LifecycleEvent::CheckpointCompleted { checkpoint_id })
                     .await;
                 Ok(())

--- a/src/runtime/observability/metrics/helpers.rs
+++ b/src/runtime/observability/metrics/helpers.rs
@@ -4,10 +4,10 @@ use metrics::{counter, gauge, histogram};
 
 use super::names::{MetricsLabels, LABEL_PIPELINE_ID, LABEL_TASK_ID, LABEL_WORKER_ID};
 
-/// Record a per-task histogram sample (ms), with optional pipeline/worker labels.
+/// Record a per-task histogram sample, with optional pipeline/worker labels.
 pub fn record_task_histogram(
     name: &'static str,
-    value_ms: f64,
+    value: f64,
     task_id: &str,
     labels: Option<&MetricsLabels>,
 ) {
@@ -19,9 +19,9 @@ pub fn record_task_histogram(
             LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
             LABEL_WORKER_ID => labels.worker_id.clone(),
         )
-        .record(value_ms);
+        .record(value);
     } else {
-        histogram!(name, LABEL_TASK_ID => task).record(value_ms);
+        histogram!(name, LABEL_TASK_ID => task).record(value);
     }
 }
 

--- a/src/runtime/observability/metrics/names.rs
+++ b/src/runtime/observability/metrics/names.rs
@@ -33,10 +33,11 @@ pub const METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS: &str =
 /// Local snapshot + report RPC wall time.
 pub const METRIC_STREAM_TASK_CHECKPOINT_DURATION_MS: &str =
     "volga_stream_task_checkpoint_duration_ms";
+/// Per-checkpoint snapshot payload size (bytes).
 pub const METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES: &str =
     "volga_stream_task_checkpoint_payload_bytes";
 pub const METRIC_STREAM_TASK_CHECKPOINT_SUCCESS: &str = "volga_stream_task_checkpoint_success";
-pub const METRIC_STREAM_TASK_CHECKPOINT_FAIL: &str = "volga_stream_task_checkpoint_fail";
+pub const METRIC_STREAM_TASK_CHECKPOINT_FAILED: &str = "volga_stream_task_checkpoint_failed";
 /// Flink-style task time budget (≈ ms in the last second; sum ≈ 1000).
 pub const METRIC_STREAM_TASK_BUSY_TIME_MS_PER_SECOND: &str =
     "volga_stream_task_busy_time_ms_per_second";
@@ -85,4 +86,19 @@ pub struct MetricsLabels {
 pub const LATENCY_BUCKET_BOUNDARIES: [f64; 12] = [1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0];
 /// Finite Prom buckets plus the trailing `+Inf` cumulative count.
 pub const LATENCY_HISTOGRAM_LEN: usize = LATENCY_BUCKET_BOUNDARIES.len() + 1;
+/// Prom buckets for checkpoint payload size (bytes). 256 B … 1 GiB.
+pub const PAYLOAD_BUCKET_BOUNDARIES: [f64; 12] = [
+    256.0,
+    1024.0,
+    4096.0,
+    16_384.0,
+    65_536.0,
+    262_144.0,
+    1_048_576.0,
+    4_194_304.0,
+    16_777_216.0,
+    67_108_864.0,
+    268_435_456.0,
+    1_073_741_824.0,
+];
 

--- a/src/runtime/observability/metrics/names.rs
+++ b/src/runtime/observability/metrics/names.rs
@@ -45,7 +45,7 @@ pub const METRIC_STREAM_TASK_IDLE_TIME_MS_PER_SECOND: &str =
 pub const METRIC_STREAM_TASK_BACKPRESSURED_TIME_MS_PER_SECOND: &str =
     "volga_stream_task_backpressured_time_ms_per_second";
 
-/// Job-level checkpoint wall time (master `started_at` → complete/fail).
+/// Job-level checkpoint wall time (master `started_at` → complete only).
 pub const METRIC_CHECKPOINT_DURATION_MS: &str = "volga_checkpoint_duration_ms";
 pub const METRIC_CHECKPOINT_COMPLETED: &str = "volga_checkpoint_completed";
 pub const METRIC_CHECKPOINT_FAILED: &str = "volga_checkpoint_failed";

--- a/src/runtime/observability/metrics/registry.rs
+++ b/src/runtime/observability/metrics/registry.rs
@@ -4,7 +4,7 @@ use metrics::atomics::AtomicU64;
 use metrics::{
     Counter, Gauge, Histogram, HistogramFn, Key, KeyName, Metadata, Recorder, SharedString, Unit,
 };
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
 use metrics_exporter_tcp::TcpBuilder;
 use metrics_util::layers::FanoutBuilder;
 use metrics_util::registry::{Registry, Storage};
@@ -12,8 +12,10 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::{Once, OnceLock};
 
-use super::names::LATENCY_BUCKET_BOUNDARIES;
-use super::names::LATENCY_HISTOGRAM_LEN;
+use super::names::{
+    LATENCY_BUCKET_BOUNDARIES, LATENCY_HISTOGRAM_LEN, METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES,
+    PAYLOAD_BUCKET_BOUNDARIES,
+};
 
 static PROMETHEUS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
 pub(super) static METRICS_REGISTRY: OnceLock<Arc<Registry<Key, MetricsRegistryStorage>>> = OnceLock::new();
@@ -99,7 +101,12 @@ impl Recorder for SnapshotRecorder {
 fn init_metrics_inner() -> Result<(), Box<dyn std::error::Error>> {
     assert!(!LATENCY_BUCKET_BOUNDARIES.contains(&f64::MAX), "LATENCY_BUCKET_BOUNDARIES should not contain f64::MAX");
 
-    let prometheus_builder = PrometheusBuilder::new().set_buckets(&LATENCY_BUCKET_BOUNDARIES)?;
+    let prometheus_builder = PrometheusBuilder::new()
+        .set_buckets(&LATENCY_BUCKET_BOUNDARIES)?
+        .set_buckets_for_metric(
+            Matcher::Full(METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES.to_string()),
+            &PAYLOAD_BUCKET_BOUNDARIES,
+        )?;
     let prometheus_recorder = prometheus_builder.build_recorder();
     let prometheus_handle = prometheus_recorder.handle();
 

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -6,14 +6,17 @@ use crate::{
         execution_graph::ExecutionGraph,
         health::{WorkerFatalReason, WorkerHealth},
         metrics::{
-            init_metrics, record_task_histogram, set_task_gauge, MetricsLabels,
-            LABEL_PIPELINE_ID, LABEL_TASK_ID, LABEL_WORKER_ID,
-            METRIC_STREAM_TASK_BYTES_RECV,
-            METRIC_STREAM_TASK_BYTES_SENT, METRIC_STREAM_TASK_CHECKPOINT_BARRIER_PROPAGATION_MS,
-            METRIC_STREAM_TASK_MESSAGES_RECV,
-            METRIC_STREAM_TASK_MESSAGES_SENT, METRIC_STREAM_TASK_PATH_LATENCY,
-            METRIC_STREAM_TASK_RECORDS_RECV, METRIC_STREAM_TASK_RECORDS_SENT,
-            METRIC_STREAM_TASK_WATERMARK_LAG_MS, METRIC_STREAM_TASK_WM_PROPAGATION_MS,
+            increment_task_counter, init_metrics, record_task_histogram, set_task_gauge,
+            MetricsLabels, LABEL_PIPELINE_ID, LABEL_TASK_ID, LABEL_WORKER_ID,
+            METRIC_STREAM_TASK_BYTES_RECV, METRIC_STREAM_TASK_BYTES_SENT,
+            METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS,
+            METRIC_STREAM_TASK_CHECKPOINT_BARRIER_PROPAGATION_MS,
+            METRIC_STREAM_TASK_CHECKPOINT_DURATION_MS, METRIC_STREAM_TASK_CHECKPOINT_FAIL,
+            METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES, METRIC_STREAM_TASK_CHECKPOINT_SUCCESS,
+            METRIC_STREAM_TASK_MESSAGES_RECV, METRIC_STREAM_TASK_MESSAGES_SENT,
+            METRIC_STREAM_TASK_PATH_LATENCY, METRIC_STREAM_TASK_RECORDS_RECV,
+            METRIC_STREAM_TASK_RECORDS_SENT, METRIC_STREAM_TASK_WATERMARK_LAG_MS,
+            METRIC_STREAM_TASK_WM_PROPAGATION_MS,
         },
         observability::{TaskMetadata, TaskSnapshot, StreamTaskStatus},
         operators::operator::{
@@ -54,6 +57,7 @@ pub(crate) struct CheckpointAligner {
     seen_upstreams: HashSet<String>,
     /// Earliest create stamp among barriers for the current checkpoint (for propagation).
     inject_stamp: Option<u64>,
+    align_started: Option<Instant>,
     reader_control: DataReaderControl,
 }
 
@@ -64,16 +68,17 @@ impl CheckpointAligner {
             current_checkpoint: None,
             seen_upstreams: HashSet::new(),
             inject_stamp: None,
+            align_started: None,
             reader_control,
         }
     }
 
-    /// Returns `Some((checkpoint_id, inject_stamp))` when fully aligned.
+    /// Returns `Some((checkpoint_id, inject_stamp, align_wait_ms))` when fully aligned.
     fn on_barrier(
         &mut self,
         barrier: &crate::common::message::CheckpointBarrierMessage,
         expected_attempt_id: u64,
-    ) -> Result<Option<(u64, Option<u64>)>, String> {
+    ) -> Result<Option<(u64, Option<u64>, f64)>, String> {
         if barrier.execution_attempt_id != expected_attempt_id {
             // Orphan from a previous attempt — drop without failing the new attempt.
             println!(
@@ -94,6 +99,7 @@ impl CheckpointAligner {
         if self.current_checkpoint.is_none() {
             self.current_checkpoint = Some(checkpoint_id);
             self.inject_stamp = barrier.metadata.ingest_timestamp;
+            self.align_started = Some(Instant::now());
         } else if let (Some(existing), Some(stamp)) =
             (self.inject_stamp, barrier.metadata.ingest_timestamp)
         {
@@ -113,9 +119,14 @@ impl CheckpointAligner {
 
         if self.seen_upstreams.len() == self.upstream_count {
             let stamp = self.inject_stamp.take();
+            let align_wait_ms = self
+                .align_started
+                .take()
+                .map(|t| t.elapsed().as_secs_f64() * 1000.0)
+                .unwrap_or(0.0);
             self.current_checkpoint = None;
             self.seen_upstreams.clear();
-            return Ok(Some((checkpoint_id, stamp)));
+            return Ok(Some((checkpoint_id, stamp, align_wait_ms)));
         }
         Ok(None)
     }
@@ -444,7 +455,13 @@ impl StreamTask {
                     }
                     Message::CheckpointBarrier(barrier) => {
                         match aligner.on_barrier(barrier, execution_attempt_id) {
-                            Ok(Some((checkpoint_id, inject_stamp))) => {
+                            Ok(Some((checkpoint_id, inject_stamp, align_wait_ms))) => {
+                                Self::record_histogram(
+                                    METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS,
+                                    align_wait_ms,
+                                    &vertex_id,
+                                    labels.as_ref(),
+                                );
                                 // Once fully aligned, yield a single barrier; preserve inject stamp.
                                 yield Message::CheckpointBarrier(
                                     crate::common::message::CheckpointBarrierMessage::new(
@@ -790,34 +807,73 @@ impl StreamTask {
                                     "[CHECKPOINT] {} checkpointing checkpoint_id={}",
                                     vertex_id, checkpoint_id
                                 );
-                                let checkpoint: SerializedCheckpoint =
-                                    operator.checkpoint(checkpoint_id).await?;
-                                let checkpoint_data = checkpoint.into_bytes();
+                                let started = Instant::now();
+                                let checkpoint_result = async {
+                                    let checkpoint: SerializedCheckpoint =
+                                        operator.checkpoint(checkpoint_id).await?;
+                                    let checkpoint_data = checkpoint.into_bytes();
+                                    let payload_len = checkpoint_data.len() as u64;
 
-                                let report_resp = master_client
-                                    .as_mut()
-                                    .expect("Master client not initialized")
-                                    .report_checkpoint(tonic::Request::new(
-                                        crate::runtime::master::server::master_service::ReportCheckpointRequest {
-                                            checkpoint_id,
-                                            vertex_id: vertex_id.as_ref().to_string(),
-                                            task_index: runtime_context.task_index(),
-                                            checkpoint_data,
-                                            execution_attempt_id,
-                                        },
-                                    ))
-                                    .await?
-                                    .into_inner();
-                                if !report_resp.success {
-                                    return Err(anyhow::anyhow!(
-                                        "report_checkpoint rejected: {}",
-                                        report_resp.error_message
-                                    ));
+                                    let report_resp = master_client
+                                        .as_mut()
+                                        .expect("Master client not initialized")
+                                        .report_checkpoint(tonic::Request::new(
+                                            crate::runtime::master::server::master_service::ReportCheckpointRequest {
+                                                checkpoint_id,
+                                                vertex_id: vertex_id.as_ref().to_string(),
+                                                task_index: runtime_context.task_index(),
+                                                checkpoint_data,
+                                                execution_attempt_id,
+                                            },
+                                        ))
+                                        .await?
+                                        .into_inner();
+                                    if !report_resp.success {
+                                        return Err(anyhow::anyhow!(
+                                            "report_checkpoint rejected: {}",
+                                            report_resp.error_message
+                                        ));
+                                    }
+                                    Ok::<u64, anyhow::Error>(payload_len)
                                 }
-                                println!(
-                                    "[CHECKPOINT] {} reported checkpoint_id={}",
-                                    vertex_id, checkpoint_id
-                                );
+                                .await;
+
+                                let duration_ms = started.elapsed().as_secs_f64() * 1000.0;
+                                match checkpoint_result {
+                                    Ok(payload_len) => {
+                                        Self::record_histogram(
+                                            METRIC_STREAM_TASK_CHECKPOINT_DURATION_MS,
+                                            duration_ms,
+                                            &vertex_id,
+                                            metrics_labels.as_ref(),
+                                        );
+                                        increment_task_counter(
+                                            METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES,
+                                            payload_len,
+                                            vertex_id.as_ref(),
+                                            metrics_labels.as_ref(),
+                                        );
+                                        increment_task_counter(
+                                            METRIC_STREAM_TASK_CHECKPOINT_SUCCESS,
+                                            1,
+                                            vertex_id.as_ref(),
+                                            metrics_labels.as_ref(),
+                                        );
+                                        println!(
+                                            "[CHECKPOINT] {} reported checkpoint_id={}",
+                                            vertex_id, checkpoint_id
+                                        );
+                                    }
+                                    Err(error) => {
+                                        increment_task_counter(
+                                            METRIC_STREAM_TASK_CHECKPOINT_FAIL,
+                                            1,
+                                            vertex_id.as_ref(),
+                                            metrics_labels.as_ref(),
+                                        );
+                                        return Err(error);
+                                    }
+                                }
                             }
 
                             // Resume input after checkpointing

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -11,7 +11,7 @@ use crate::{
             METRIC_STREAM_TASK_BYTES_RECV, METRIC_STREAM_TASK_BYTES_SENT,
             METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS,
             METRIC_STREAM_TASK_CHECKPOINT_BARRIER_PROPAGATION_MS,
-            METRIC_STREAM_TASK_CHECKPOINT_DURATION_MS, METRIC_STREAM_TASK_CHECKPOINT_FAIL,
+            METRIC_STREAM_TASK_CHECKPOINT_DURATION_MS, METRIC_STREAM_TASK_CHECKPOINT_FAILED,
             METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES, METRIC_STREAM_TASK_CHECKPOINT_SUCCESS,
             METRIC_STREAM_TASK_MESSAGES_RECV, METRIC_STREAM_TASK_MESSAGES_SENT,
             METRIC_STREAM_TASK_PATH_LATENCY, METRIC_STREAM_TASK_RECORDS_RECV,
@@ -847,10 +847,10 @@ impl StreamTask {
                                             &vertex_id,
                                             metrics_labels.as_ref(),
                                         );
-                                        increment_task_counter(
+                                        Self::record_histogram(
                                             METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES,
-                                            payload_len,
-                                            vertex_id.as_ref(),
+                                            payload_len as f64,
+                                            &vertex_id,
                                             metrics_labels.as_ref(),
                                         );
                                         increment_task_counter(
@@ -866,7 +866,7 @@ impl StreamTask {
                                     }
                                     Err(error) => {
                                         increment_task_counter(
-                                            METRIC_STREAM_TASK_CHECKPOINT_FAIL,
+                                            METRIC_STREAM_TASK_CHECKPOINT_FAILED,
                                             1,
                                             vertex_id.as_ref(),
                                             metrics_labels.as_ref(),


### PR DESCRIPTION
## Summary
- Task checkpoint align-wait, duration, payload bytes, success/fail
- Job-level checkpoint duration / completed / failed on master

Depends on #225. Followed by time-budget PR.

## Test plan
- [ ] `scripts/test unit`
- [ ] `scripts/test inprocess` (checkpoint paths)

Made with [Cursor](https://cursor.com)