### PR TITLE
obs: busy/idle/backpressured ms-per-second (#211)

### DIFF
--- a/src/runtime/collector.rs
+++ b/src/runtime/collector.rs
@@ -65,22 +65,22 @@ impl Collector {
         partitions.iter().map(|partition_idx| self.output_channels[*partition_idx].clone()).collect()
     }
 
-    async fn write_message_to_channels(&mut self, message: &Message, channels_to_send: Vec<Channel>) -> HashMap<Channel, (bool, u32)> {
-        // parallel write
+    async fn write_message_to_channels(
+        &mut self,
+        message: &Message,
+        channels_to_send: Vec<Channel>,
+    ) -> HashMap<Channel, bool> {
+        // parallel write (BP time is recorded inside DataWriter / BatchSender)
         let mut write_futures = Vec::new();
         for channel in channels_to_send.clone() {
-            
             let mut writer = self.data_writer.clone();
-            // let channel_id_clone = channel_id.clone();
-            write_futures.push(async move {
-                return writer.write_message(&channel, message).await;
-            });
+            write_futures.push(async move { writer.write_message(&channel, message).await });
         }
         let results = join_all(write_futures).await;
-        
+
         let mut channel_results = HashMap::new();
-        for (i, (success, backpressure_time_ms)) in results.into_iter().enumerate() {
-            channel_results.insert(channels_to_send[i].clone(), (success, backpressure_time_ms));
+        for (i, success) in results.into_iter().enumerate() {
+            channel_results.insert(channels_to_send[i].clone(), success);
         }
         channel_results
     }
@@ -88,8 +88,8 @@ impl Collector {
     pub async fn write_message_to_operators(
         collectors: &mut HashMap<String, Collector>,
         message: &Message,
-        channels_per_operator: HashMap<String, Vec<Channel>>
-    ) -> HashMap<String, HashMap<Channel, (bool, u32)>> {
+        channels_per_operator: HashMap<String, Vec<Channel>>,
+    ) -> HashMap<String, HashMap<Channel, bool>> {
         let mut futures = Vec::new();
         for (operator_id, collector) in collectors.iter_mut() {
             let operator_id = operator_id.clone();

--- a/src/runtime/observability/metrics/names.rs
+++ b/src/runtime/observability/metrics/names.rs
@@ -38,7 +38,8 @@ pub const METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES: &str =
     "volga_stream_task_checkpoint_payload_bytes";
 pub const METRIC_STREAM_TASK_CHECKPOINT_SUCCESS: &str = "volga_stream_task_checkpoint_success";
 pub const METRIC_STREAM_TASK_CHECKPOINT_FAILED: &str = "volga_stream_task_checkpoint_failed";
-/// Flink-style task time budget (≈ ms in the last second; sum ≈ 1000).
+/// Flink-style task time budget (ms in the last second; busy+idle+bp ≈ 1000).
+/// Busy is residual wall time; idle is input wait; bp is tx-queue block wait.
 pub const METRIC_STREAM_TASK_BUSY_TIME_MS_PER_SECOND: &str =
     "volga_stream_task_busy_time_ms_per_second";
 pub const METRIC_STREAM_TASK_IDLE_TIME_MS_PER_SECOND: &str =

--- a/src/runtime/observability/metrics/names.rs
+++ b/src/runtime/observability/metrics/names.rs
@@ -38,7 +38,7 @@ pub const METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES: &str =
     "volga_stream_task_checkpoint_payload_bytes";
 pub const METRIC_STREAM_TASK_CHECKPOINT_SUCCESS: &str = "volga_stream_task_checkpoint_success";
 pub const METRIC_STREAM_TASK_CHECKPOINT_FAILED: &str = "volga_stream_task_checkpoint_failed";
-/// Flink-style task time budget (ms in the last second; busy+idle+bp ≈ 1000).
+/// Flink-style task time metrics (ms in the last second; busy+idle+bp ≈ 1000).
 /// Busy is residual wall time; idle is input wait; bp is tx-queue block wait.
 pub const METRIC_STREAM_TASK_BUSY_TIME_MS_PER_SECOND: &str =
     "volga_stream_task_busy_time_ms_per_second";

--- a/src/runtime/observability/metrics/names.rs
+++ b/src/runtime/observability/metrics/names.rs
@@ -39,7 +39,7 @@ pub const METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES: &str =
 pub const METRIC_STREAM_TASK_CHECKPOINT_SUCCESS: &str = "volga_stream_task_checkpoint_success";
 pub const METRIC_STREAM_TASK_CHECKPOINT_FAILED: &str = "volga_stream_task_checkpoint_failed";
 /// Flink-style task time metrics (ms in the last second; busy+idle+bp ≈ 1000).
-/// Busy is residual wall time; idle is input wait; bp is tx-queue block wait.
+/// Busy is residual wall time; idle is poll_next wait; bp is tx-queue block wait.
 pub const METRIC_STREAM_TASK_BUSY_TIME_MS_PER_SECOND: &str =
     "volga_stream_task_busy_time_ms_per_second";
 pub const METRIC_STREAM_TASK_IDLE_TIME_MS_PER_SECOND: &str =

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -42,30 +42,30 @@ use crate::transport::transport_client::TransportClient;
 use crate::common::message::{Message, WatermarkMessage};
 use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, Arc}, time::{Duration, Instant, SystemTime, UNIX_EPOCH}};
 
-/// Accumulates Flink-style task time-budget nanos within a flush window.
+/// Accumulates Flink-style task time metrics within a report window.
 ///
 /// Idle = input wait; backpressured = exclusive tx-queue wait via
-/// [`OutputBackpressure`] (same write path as BP ratio gauges); busy = residual
+/// [`BackpressureTracker`] (same write path as BP ratio gauges); busy = residual
 /// wall time so the three ms/s gauges sum to ~1000.
 #[derive(Debug, Default)]
-pub(crate) struct TaskTimeBudget {
+pub(crate) struct TaskTimeMetrics {
     idle_ns: AtomicU64,
-    output_bp: Arc<crate::transport::batch_channel::OutputBackpressure>,
+    backpressure_tracker: Arc<crate::transport::batch_channel::BackpressureTracker>,
 }
 
-impl TaskTimeBudget {
+impl TaskTimeMetrics {
     fn add_idle_ns(&self, ns: u64) {
         self.idle_ns.fetch_add(ns, Ordering::Relaxed);
     }
 
-    fn output_backpressure(&self) -> Arc<crate::transport::batch_channel::OutputBackpressure> {
-        self.output_bp.clone()
+    fn backpressure_tracker(&self) -> Arc<crate::transport::batch_channel::BackpressureTracker> {
+        self.backpressure_tracker.clone()
     }
 
     /// Scale to ms-per-second and reset. Returns `(busy, idle, backpressured)`.
     fn take_ms_per_second(&self, window: Duration) -> (f64, f64, f64) {
         let idle = self.idle_ns.swap(0, Ordering::Relaxed);
-        let bp = self.output_bp.take_ns();
+        let bp = self.backpressure_tracker.take_ns();
         let window_ms = window.as_secs_f64() * 1000.0;
         if window_ms <= 0.0 {
             return (0.0, 0.0, 0.0);
@@ -349,23 +349,6 @@ impl StreamTask {
         );
     }
 
-    fn maybe_publish_watermark_lag(
-        window_start: &mut Instant,
-        vertex_id: &VertexId,
-        labels: Option<&MetricsLabels>,
-        current_watermark: &AtomicU64,
-    ) {
-        if window_start.elapsed() < Duration::from_secs(1) {
-            return;
-        }
-        Self::set_watermark_lag_gauge(
-            vertex_id,
-            current_watermark.load(Ordering::Relaxed),
-            labels,
-        );
-        *window_start = Instant::now();
-    }
-
     fn record_metrics(
         vertex_id: VertexId,
         message: &Message,
@@ -468,7 +451,7 @@ impl StreamTask {
         mut aligner: CheckpointAligner,
         labels: Option<MetricsLabels>,
         execution_attempt_id: u64,
-        time_budget: Arc<TaskTimeBudget>,
+        task_time_metrics: Arc<TaskTimeMetrics>,
     ) -> MessageStream {
         Box::pin(stream! {
             let mut input_stream = input_stream;
@@ -483,7 +466,7 @@ impl StreamTask {
                 let Some(message) = input_stream.next().await else {
                     break;
                 };
-                time_budget.add_idle_ns(idle_start.elapsed().as_nanos() as u64);
+                task_time_metrics.add_idle_ns(idle_start.elapsed().as_nanos() as u64);
                 Self::record_metrics(vertex_id.clone(), &message, true, labels.as_ref());
                 Self::record_control_propagation(&vertex_id, &message, labels.as_ref());
 
@@ -619,17 +602,18 @@ impl StreamTask {
         }
     }
 
-    fn maybe_flush_time_budget(
-        budget: &TaskTimeBudget,
+    fn report_task_time_metrics(
+        metrics: &TaskTimeMetrics,
         window_start: &mut Instant,
         vertex_id: &VertexId,
         labels: Option<&MetricsLabels>,
+        current_watermark: &AtomicU64,
     ) {
         let elapsed = window_start.elapsed();
         if elapsed < Duration::from_secs(1) {
             return;
         }
-        let (busy, idle, bp) = budget.take_ms_per_second(elapsed);
+        let (busy, idle, bp) = metrics.take_ms_per_second(elapsed);
         set_task_gauge(
             METRIC_STREAM_TASK_BUSY_TIME_MS_PER_SECOND,
             busy,
@@ -646,6 +630,11 @@ impl StreamTask {
             METRIC_STREAM_TASK_BACKPRESSURED_TIME_MS_PER_SECOND,
             bp,
             vertex_id.as_ref(),
+            labels,
+        );
+        Self::set_watermark_lag_gauge(
+            vertex_id,
+            current_watermark.load(Ordering::Relaxed),
             labels,
         );
         *window_start = Instant::now();
@@ -696,10 +685,10 @@ impl StreamTask {
             let mut transport_client =
                 TransportClient::new(vertex_id.clone(), transport_client_config, run_loop_health);
 
-            // Install before collectors clone the writer so ratio + time-budget BP share one clock.
-            let time_budget = Arc::new(TaskTimeBudget::default());
+            // Install before collectors clone the writer so ratio + BP time share one tracker.
+            let task_time_metrics = Arc::new(TaskTimeMetrics::default());
             if let Some(writer) = transport_client.writer.as_mut() {
-                writer.set_output_backpressure(time_budget.output_backpressure());
+                writer.set_backpressure_tracker(task_time_metrics.backpressure_tracker());
             }
             
             let mut collectors_per_target_operator: HashMap<String, Collector> = HashMap::new();
@@ -805,7 +794,7 @@ impl StreamTask {
                 None
             };
             
-            let mut budget_window_start = Instant::now();
+            let mut metrics_window_start = Instant::now();
 
             if !is_source {
                 // Pre-process input stream for non-source operators
@@ -827,13 +816,12 @@ impl StreamTask {
                     checkpoint_aligner,
                     metrics_labels.clone(),
                     execution_attempt_id,
-                    time_budget.clone(),
+                    task_time_metrics.clone(),
                 );
 
                 operator.set_input(Some(preprocessed_stream))
             };
 
-            let mut lag_window_start = Instant::now();
             while status.load(Ordering::SeqCst) == StreamTaskStatus::Running as u8 {
                 // For sources: if checkpoint is triggered, synthesize a CheckpointBarrier message and treat it exactly
                 // like a poll_next() output (same code path, no duplication).
@@ -1011,7 +999,7 @@ impl StreamTask {
                         message.set_upstream_vertex_id(vertex_id.as_ref().to_string());
                         Self::record_metrics(vertex_id.clone(), &message, false, metrics_labels.as_ref());
 
-                        // Send to collectors (queue waits record on time_budget.output_bp)
+                        // Send to collectors (queue waits record on BackpressureTracker)
                         Self::send_to_collectors_if_needed(
                             &mut collectors_per_target_operator,
                             message,
@@ -1071,19 +1059,14 @@ impl StreamTask {
                         status.store(StreamTaskStatus::Finished as u8, Ordering::SeqCst);
                         break;
                     }
-                    OperatorPollResult::Continue => { /* no output; busy = residual on flush */ }
+                    OperatorPollResult::Continue => { /* no output; busy = residual on report */ }
                 }
-                Self::maybe_publish_watermark_lag(
-                    &mut lag_window_start,
+                Self::report_task_time_metrics(
+                    &task_time_metrics,
+                    &mut metrics_window_start,
                     &vertex_id,
                     metrics_labels.as_ref(),
                     &current_watermark,
-                );
-                Self::maybe_flush_time_budget(
-                    &time_budget,
-                    &mut budget_window_start,
-                    &vertex_id,
-                    metrics_labels.as_ref(),
                 );
             }
             

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -43,11 +43,14 @@ use crate::common::message::{Message, WatermarkMessage};
 use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, Arc}, time::{Duration, Instant, SystemTime, UNIX_EPOCH}};
 
 /// Accumulates Flink-style task time-budget nanos within a flush window.
+///
+/// Idle = input wait; backpressured = exclusive tx-queue wait via
+/// [`OutputBackpressure`] (same write path as BP ratio gauges); busy = residual
+/// wall time so the three ms/s gauges sum to ~1000.
 #[derive(Debug, Default)]
 pub(crate) struct TaskTimeBudget {
     idle_ns: AtomicU64,
-    busy_ns: AtomicU64,
-    backpressured_ns: AtomicU64,
+    output_bp: Arc<crate::transport::batch_channel::OutputBackpressure>,
 }
 
 impl TaskTimeBudget {
@@ -55,33 +58,26 @@ impl TaskTimeBudget {
         self.idle_ns.fetch_add(ns, Ordering::Relaxed);
     }
 
-    fn add_busy_ns(&self, ns: u64) {
-        self.busy_ns.fetch_add(ns, Ordering::Relaxed);
+    fn output_backpressure(&self) -> Arc<crate::transport::batch_channel::OutputBackpressure> {
+        self.output_bp.clone()
     }
 
-    fn add_backpressured_ns(&self, ns: u64) {
-        self.backpressured_ns.fetch_add(ns, Ordering::Relaxed);
-    }
-
-    fn idle_ns(&self) -> u64 {
-        self.idle_ns.load(Ordering::Relaxed)
-    }
-
-    /// Scale accumulated times to ms-per-second and reset.
+    /// Scale to ms-per-second and reset. Returns `(busy, idle, backpressured)`.
     fn take_ms_per_second(&self, window: Duration) -> (f64, f64, f64) {
         let idle = self.idle_ns.swap(0, Ordering::Relaxed);
-        let busy = self.busy_ns.swap(0, Ordering::Relaxed);
-        let bp = self.backpressured_ns.swap(0, Ordering::Relaxed);
+        let bp = self.output_bp.take_ns();
         let window_ms = window.as_secs_f64() * 1000.0;
         if window_ms <= 0.0 {
             return (0.0, 0.0, 0.0);
         }
+        let idle_ms = (idle as f64 / 1_000_000.0).min(window_ms);
+        let mut bp_ms = bp as f64 / 1_000_000.0;
+        if idle_ms + bp_ms > window_ms {
+            bp_ms = (window_ms - idle_ms).max(0.0);
+        }
+        let busy_ms = (window_ms - idle_ms - bp_ms).max(0.0);
         let scale = 1000.0 / window_ms;
-        (
-            (busy as f64 / 1_000_000.0) * scale,
-            (idle as f64 / 1_000_000.0) * scale,
-            (bp as f64 / 1_000_000.0) * scale,
-        )
+        (busy_ms * scale, idle_ms * scale, bp_ms * scale)
     }
 }
 // serde imports removed; this module does not define serializable DTOs directly.
@@ -566,19 +562,17 @@ impl StreamTask {
     }
 
     // Helper function to send message to collectors (similar to original stream_task.rs).
-    /// Returns wall-clock nanoseconds spent in the send / retry loop (output wait).
     async fn send_to_collectors_if_needed(
         mut collectors_per_target_operator: &mut HashMap<String, Collector>,
         message: Message,
         vertex_id: VertexId,
         status: Arc<AtomicU8>
-    ) -> u64 {
+    ) {
         if collectors_per_target_operator.is_empty() {
             // Edge operator - no downstream collectors
-            return 0;
+            return;
         }
 
-        let send_started = Instant::now();
         let mut channels_to_send_per_operator = HashMap::new();
         for (target_operator_id, collector) in collectors_per_target_operator.iter_mut() {
             let partitioned_channels = collector.gen_partitioned_channels(&message);
@@ -588,7 +582,7 @@ impl StreamTask {
 
         // TODO should retires be inside transport?
         let mut retries_before_close = 3; // per - messages
-    
+
         // send message to all destinations until no backpressure
         while status.load(Ordering::SeqCst) == StreamTaskStatus::Running as u8 ||
             status.load(Ordering::SeqCst) == StreamTaskStatus::Finished as u8 {
@@ -610,7 +604,7 @@ impl StreamTask {
             for (target_operator_id, write_res) in write_results {
                 let mut resend_channels = vec![];
                 for channel in write_res.keys() {
-                    let (success, _backpressure_time_ms) = write_res.get(channel).unwrap();
+                    let success = write_res.get(channel).unwrap();
                     if !success {
                         resend_channels.push(channel.clone());
                     }
@@ -623,7 +617,6 @@ impl StreamTask {
                 break;
             }
         }
-        send_started.elapsed().as_nanos() as u64
     }
 
     fn maybe_flush_time_budget(
@@ -702,6 +695,12 @@ impl StreamTask {
             
             let mut transport_client =
                 TransportClient::new(vertex_id.clone(), transport_client_config, run_loop_health);
+
+            // Install before collectors clone the writer so ratio + time-budget BP share one clock.
+            let time_budget = Arc::new(TaskTimeBudget::default());
+            if let Some(writer) = transport_client.writer.as_mut() {
+                writer.set_output_backpressure(time_budget.output_backpressure());
+            }
             
             let mut collectors_per_target_operator: HashMap<String, Collector> = HashMap::new();
 
@@ -806,7 +805,6 @@ impl StreamTask {
                 None
             };
             
-            let time_budget = Arc::new(TaskTimeBudget::default());
             let mut budget_window_start = Instant::now();
 
             if !is_source {
@@ -862,16 +860,11 @@ impl StreamTask {
                     None
                 };
 
-                let poll_started = Instant::now();
-                let idle_before = time_budget.idle_ns();
                 let poll_res = if let Some(msg) = produced {
                     OperatorPollResult::Ready(msg)
                 } else {
                     operator.poll_next().await
                 };
-                let poll_elapsed_ns = poll_started.elapsed().as_nanos() as u64;
-                let idle_during_poll = time_budget.idle_ns().saturating_sub(idle_before);
-                time_budget.add_busy_ns(poll_elapsed_ns.saturating_sub(idle_during_poll));
 
                 match poll_res {
                     OperatorPollResult::Ready(mut message) => {
@@ -1018,14 +1011,13 @@ impl StreamTask {
                         message.set_upstream_vertex_id(vertex_id.as_ref().to_string());
                         Self::record_metrics(vertex_id.clone(), &message, false, metrics_labels.as_ref());
 
-                        // Send to collectors
-                        let bp_ns = Self::send_to_collectors_if_needed(
+                        // Send to collectors (queue waits record on time_budget.output_bp)
+                        Self::send_to_collectors_if_needed(
                             &mut collectors_per_target_operator,
                             message,
                             vertex_id.clone(),
                             status.clone()
                         ).await;
-                        time_budget.add_backpressured_ns(bp_ns);
 
                         if let Some(wm) = injected_wm {
                             let mut injected = Message::Watermark(wm);
@@ -1044,14 +1036,13 @@ impl StreamTask {
                                 false,
                                 metrics_labels.as_ref(),
                             );
-                            let bp_ns = Self::send_to_collectors_if_needed(
+                            Self::send_to_collectors_if_needed(
                                 &mut collectors_per_target_operator,
                                 injected,
                                 vertex_id.clone(),
                                 status.clone(),
                             )
                             .await;
-                            time_budget.add_backpressured_ns(bp_ns);
                         }
                     }
                     OperatorPollResult::None => {
@@ -1062,14 +1053,13 @@ impl StreamTask {
                                 Some(Self::now_ms()),
                             ));
                             Self::record_metrics(vertex_id.clone(), &wm, false, metrics_labels.as_ref());
-                            let bp_ns = Self::send_to_collectors_if_needed(
+                            Self::send_to_collectors_if_needed(
                                 &mut collectors_per_target_operator,
                                 wm,
                                 vertex_id.clone(),
                                 status.clone(),
                             )
                             .await;
-                            time_budget.add_backpressured_ns(bp_ns);
                         } else {
                             // Peer/transport teardown can drop the input without a max watermark.
                             println!(
@@ -1081,7 +1071,7 @@ impl StreamTask {
                         status.store(StreamTaskStatus::Finished as u8, Ordering::SeqCst);
                         break;
                     }
-                    OperatorPollResult::Continue => { /* no output; busy already counted */ }
+                    OperatorPollResult::Continue => { /* no output; busy = residual on flush */ }
                 }
                 Self::maybe_publish_watermark_lag(
                     &mut lag_window_start,

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -8,11 +8,15 @@ use crate::{
         metrics::{
             increment_task_counter, init_metrics, record_task_histogram, set_task_gauge,
             MetricsLabels, LABEL_PIPELINE_ID, LABEL_TASK_ID, LABEL_WORKER_ID,
-            METRIC_STREAM_TASK_BYTES_RECV, METRIC_STREAM_TASK_BYTES_SENT,
-            METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS,
+            increment_task_counter, init_metrics, record_task_histogram, set_task_gauge,
+            MetricsLabels, LABEL_PIPELINE_ID, LABEL_TASK_ID, LABEL_WORKER_ID,
+            METRIC_STREAM_TASK_BACKPRESSURED_TIME_MS_PER_SECOND,
+            METRIC_STREAM_TASK_BUSY_TIME_MS_PER_SECOND, METRIC_STREAM_TASK_BYTES_RECV,
+            METRIC_STREAM_TASK_BYTES_SENT, METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS,
             METRIC_STREAM_TASK_CHECKPOINT_BARRIER_PROPAGATION_MS,
             METRIC_STREAM_TASK_CHECKPOINT_DURATION_MS, METRIC_STREAM_TASK_CHECKPOINT_FAILED,
             METRIC_STREAM_TASK_CHECKPOINT_PAYLOAD_BYTES, METRIC_STREAM_TASK_CHECKPOINT_SUCCESS,
+            METRIC_STREAM_TASK_IDLE_TIME_MS_PER_SECOND,
             METRIC_STREAM_TASK_MESSAGES_RECV, METRIC_STREAM_TASK_MESSAGES_SENT,
             METRIC_STREAM_TASK_PATH_LATENCY, METRIC_STREAM_TASK_RECORDS_RECV,
             METRIC_STREAM_TASK_RECORDS_SENT, METRIC_STREAM_TASK_WATERMARK_LAG_MS,
@@ -37,6 +41,49 @@ use std::collections::HashSet;
 use crate::transport::transport_client::TransportClient;
 use crate::common::message::{Message, WatermarkMessage};
 use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, Arc}, time::{Duration, Instant, SystemTime, UNIX_EPOCH}};
+
+/// Accumulates Flink-style task time-budget nanos within a flush window.
+#[derive(Debug, Default)]
+pub(crate) struct TaskTimeBudget {
+    idle_ns: AtomicU64,
+    busy_ns: AtomicU64,
+    backpressured_ns: AtomicU64,
+}
+
+impl TaskTimeBudget {
+    fn add_idle_ns(&self, ns: u64) {
+        self.idle_ns.fetch_add(ns, Ordering::Relaxed);
+    }
+
+    fn add_busy_ns(&self, ns: u64) {
+        self.busy_ns.fetch_add(ns, Ordering::Relaxed);
+    }
+
+    fn add_backpressured_ns(&self, ns: u64) {
+        self.backpressured_ns.fetch_add(ns, Ordering::Relaxed);
+    }
+
+    fn idle_ns(&self) -> u64 {
+        self.idle_ns.load(Ordering::Relaxed)
+    }
+
+    /// Scale accumulated times to ms-per-second and reset.
+    fn take_ms_per_second(&self, window: Duration) -> (f64, f64, f64) {
+        let idle = self.idle_ns.swap(0, Ordering::Relaxed);
+        let busy = self.busy_ns.swap(0, Ordering::Relaxed);
+        let bp = self.backpressured_ns.swap(0, Ordering::Relaxed);
+        let window_ms = window.as_secs_f64() * 1000.0;
+        if window_ms <= 0.0 {
+            return (0.0, 0.0, 0.0);
+        }
+        let scale = 1000.0 / window_ms;
+        (
+            (busy as f64 / 1_000_000.0) * scale,
+            (idle as f64 / 1_000_000.0) * scale,
+            (bp as f64 / 1_000_000.0) * scale,
+        )
+    }
+}
 // serde imports removed; this module does not define serializable DTOs directly.
 use crate::common::grpc::master::master_client as connect_master_client;
 use crate::common::grpc::GrpcConfig;
@@ -425,6 +472,7 @@ impl StreamTask {
         mut aligner: CheckpointAligner,
         labels: Option<MetricsLabels>,
         execution_attempt_id: u64,
+        time_budget: Arc<TaskTimeBudget>,
     ) -> MessageStream {
         Box::pin(stream! {
             let mut input_stream = input_stream;
@@ -434,7 +482,12 @@ impl StreamTask {
                 upstream_watermarks.clone(),
                 current_watermark.clone(),
             );
-            while let Some(message) = input_stream.next().await {
+            loop {
+                let idle_start = Instant::now();
+                let Some(message) = input_stream.next().await else {
+                    break;
+                };
+                time_budget.add_idle_ns(idle_start.elapsed().as_nanos() as u64);
                 Self::record_metrics(vertex_id.clone(), &message, true, labels.as_ref());
                 Self::record_control_propagation(&vertex_id, &message, labels.as_ref());
 
@@ -512,18 +565,20 @@ impl StreamTask {
         })
     }
 
-    // Helper function to send message to collectors (similar to original stream_task.rs)
+    // Helper function to send message to collectors (similar to original stream_task.rs).
+    /// Returns wall-clock nanoseconds spent in the send / retry loop (output wait).
     async fn send_to_collectors_if_needed(
         mut collectors_per_target_operator: &mut HashMap<String, Collector>,
         message: Message,
         vertex_id: VertexId,
         status: Arc<AtomicU8>
-    ) {
+    ) -> u64 {
         if collectors_per_target_operator.is_empty() {
             // Edge operator - no downstream collectors
-            return;
+            return 0;
         }
 
+        let send_started = Instant::now();
         let mut channels_to_send_per_operator = HashMap::new();
         for (target_operator_id, collector) in collectors_per_target_operator.iter_mut() {
             let partitioned_channels = collector.gen_partitioned_channels(&message);
@@ -568,6 +623,39 @@ impl StreamTask {
                 break;
             }
         }
+        send_started.elapsed().as_nanos() as u64
+    }
+
+    fn maybe_flush_time_budget(
+        budget: &TaskTimeBudget,
+        window_start: &mut Instant,
+        vertex_id: &VertexId,
+        labels: Option<&MetricsLabels>,
+    ) {
+        let elapsed = window_start.elapsed();
+        if elapsed < Duration::from_secs(1) {
+            return;
+        }
+        let (busy, idle, bp) = budget.take_ms_per_second(elapsed);
+        set_task_gauge(
+            METRIC_STREAM_TASK_BUSY_TIME_MS_PER_SECOND,
+            busy,
+            vertex_id.as_ref(),
+            labels,
+        );
+        set_task_gauge(
+            METRIC_STREAM_TASK_IDLE_TIME_MS_PER_SECOND,
+            idle,
+            vertex_id.as_ref(),
+            labels,
+        );
+        set_task_gauge(
+            METRIC_STREAM_TASK_BACKPRESSURED_TIME_MS_PER_SECOND,
+            bp,
+            vertex_id.as_ref(),
+            labels,
+        );
+        *window_start = Instant::now();
     }
 
     pub async fn start(&mut self) {
@@ -718,6 +806,9 @@ impl StreamTask {
                 None
             };
             
+            let time_budget = Arc::new(TaskTimeBudget::default());
+            let mut budget_window_start = Instant::now();
+
             if !is_source {
                 // Pre-process input stream for non-source operators
                 let reader = transport_client.reader.take()
@@ -738,6 +829,7 @@ impl StreamTask {
                     checkpoint_aligner,
                     metrics_labels.clone(),
                     execution_attempt_id,
+                    time_budget.clone(),
                 );
 
                 operator.set_input(Some(preprocessed_stream))
@@ -770,11 +862,16 @@ impl StreamTask {
                     None
                 };
 
+                let poll_started = Instant::now();
+                let idle_before = time_budget.idle_ns();
                 let poll_res = if let Some(msg) = produced {
                     OperatorPollResult::Ready(msg)
                 } else {
                     operator.poll_next().await
                 };
+                let poll_elapsed_ns = poll_started.elapsed().as_nanos() as u64;
+                let idle_during_poll = time_budget.idle_ns().saturating_sub(idle_before);
+                time_budget.add_busy_ns(poll_elapsed_ns.saturating_sub(idle_during_poll));
 
                 match poll_res {
                     OperatorPollResult::Ready(mut message) => {
@@ -922,12 +1019,13 @@ impl StreamTask {
                         Self::record_metrics(vertex_id.clone(), &message, false, metrics_labels.as_ref());
 
                         // Send to collectors
-                        Self::send_to_collectors_if_needed(
+                        let bp_ns = Self::send_to_collectors_if_needed(
                             &mut collectors_per_target_operator,
                             message,
                             vertex_id.clone(),
                             status.clone()
                         ).await;
+                        time_budget.add_backpressured_ns(bp_ns);
 
                         if let Some(wm) = injected_wm {
                             let mut injected = Message::Watermark(wm);
@@ -946,13 +1044,14 @@ impl StreamTask {
                                 false,
                                 metrics_labels.as_ref(),
                             );
-                            Self::send_to_collectors_if_needed(
+                            let bp_ns = Self::send_to_collectors_if_needed(
                                 &mut collectors_per_target_operator,
                                 injected,
                                 vertex_id.clone(),
                                 status.clone(),
                             )
                             .await;
+                            time_budget.add_backpressured_ns(bp_ns);
                         }
                     }
                     OperatorPollResult::None => {
@@ -963,13 +1062,14 @@ impl StreamTask {
                                 Some(Self::now_ms()),
                             ));
                             Self::record_metrics(vertex_id.clone(), &wm, false, metrics_labels.as_ref());
-                            Self::send_to_collectors_if_needed(
+                            let bp_ns = Self::send_to_collectors_if_needed(
                                 &mut collectors_per_target_operator,
                                 wm,
                                 vertex_id.clone(),
                                 status.clone(),
                             )
                             .await;
+                            time_budget.add_backpressured_ns(bp_ns);
                         } else {
                             // Peer/transport teardown can drop the input without a max watermark.
                             println!(
@@ -981,13 +1081,19 @@ impl StreamTask {
                         status.store(StreamTaskStatus::Finished as u8, Ordering::SeqCst);
                         break;
                     }
-                    OperatorPollResult::Continue => { /* no output */ }
+                    OperatorPollResult::Continue => { /* no output; busy already counted */ }
                 }
                 Self::maybe_publish_watermark_lag(
                     &mut lag_window_start,
                     &vertex_id,
                     metrics_labels.as_ref(),
                     &current_watermark,
+                );
+                Self::maybe_flush_time_budget(
+                    &time_budget,
+                    &mut budget_window_start,
+                    &vertex_id,
+                    metrics_labels.as_ref(),
                 );
             }
             
@@ -1022,7 +1128,7 @@ impl StreamTask {
 
     pub async fn get_state(&self) -> TaskSnapshot {
         // Detach from the live bag so later operator writes do not mutate the snapshot.
-        // Throughput/latency for WorkerSnapshot are scraped once by the worker poll.
+        // Throughput/latency for WorkerSnapshot are collected once by the worker poll.
         let metadata = TaskMetadata::default();
         metadata.extend(&self.runtime_context.task_metadata());
         TaskSnapshot {

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -8,8 +8,6 @@ use crate::{
         metrics::{
             increment_task_counter, init_metrics, record_task_histogram, set_task_gauge,
             MetricsLabels, LABEL_PIPELINE_ID, LABEL_TASK_ID, LABEL_WORKER_ID,
-            increment_task_counter, init_metrics, record_task_histogram, set_task_gauge,
-            MetricsLabels, LABEL_PIPELINE_ID, LABEL_TASK_ID, LABEL_WORKER_ID,
             METRIC_STREAM_TASK_BACKPRESSURED_TIME_MS_PER_SECOND,
             METRIC_STREAM_TASK_BUSY_TIME_MS_PER_SECOND, METRIC_STREAM_TASK_BYTES_RECV,
             METRIC_STREAM_TASK_BYTES_SENT, METRIC_STREAM_TASK_CHECKPOINT_ALIGN_WAIT_MS,
@@ -44,9 +42,9 @@ use std::{collections::HashMap, sync::{atomic::{AtomicU8, AtomicU64, Ordering}, 
 
 /// Accumulates Flink-style task time metrics within a report window.
 ///
-/// Idle = input wait; backpressured = exclusive tx-queue wait via
-/// [`BackpressureTracker`] (same write path as BP ratio gauges); busy = residual
-/// wall time so the three ms/s gauges sum to ~1000.
+/// Idle = `poll_next` wait (source produce or input); backpressured = exclusive
+/// tx-queue wait via [`BackpressureTracker`] (same write path as BP ratio
+/// gauges); busy = residual wall time so the three ms/s gauges sum to ~1000.
 #[derive(Debug, Default)]
 pub(crate) struct TaskTimeMetrics {
     idle_ns: AtomicU64,
@@ -451,7 +449,6 @@ impl StreamTask {
         mut aligner: CheckpointAligner,
         labels: Option<MetricsLabels>,
         execution_attempt_id: u64,
-        task_time_metrics: Arc<TaskTimeMetrics>,
     ) -> MessageStream {
         Box::pin(stream! {
             let mut input_stream = input_stream;
@@ -461,12 +458,7 @@ impl StreamTask {
                 upstream_watermarks.clone(),
                 current_watermark.clone(),
             );
-            loop {
-                let idle_start = Instant::now();
-                let Some(message) = input_stream.next().await else {
-                    break;
-                };
-                task_time_metrics.add_idle_ns(idle_start.elapsed().as_nanos() as u64);
+            while let Some(message) = input_stream.next().await {
                 Self::record_metrics(vertex_id.clone(), &message, true, labels.as_ref());
                 Self::record_control_propagation(&vertex_id, &message, labels.as_ref());
 
@@ -816,7 +808,6 @@ impl StreamTask {
                     checkpoint_aligner,
                     metrics_labels.clone(),
                     execution_attempt_id,
-                    task_time_metrics.clone(),
                 );
 
                 operator.set_input(Some(preprocessed_stream))
@@ -851,7 +842,10 @@ impl StreamTask {
                 let poll_res = if let Some(msg) = produced {
                     OperatorPollResult::Ready(msg)
                 } else {
-                    operator.poll_next().await
+                    let idle_start = Instant::now();
+                    let res = operator.poll_next().await;
+                    task_time_metrics.add_idle_ns(idle_start.elapsed().as_nanos() as u64);
+                    res
                 };
 
                 match poll_res {

--- a/src/runtime/watermark/manager.rs
+++ b/src/runtime/watermark/manager.rs
@@ -273,7 +273,7 @@ mod tests {
     use futures::StreamExt;
 
         use crate::runtime::observability::snapshot_types::StreamTaskStatus;
-        use crate::runtime::stream_task::{CheckpointAligner, StreamTask, TaskTimeBudget};
+        use crate::runtime::stream_task::{CheckpointAligner, StreamTask, TaskTimeMetrics};
     use crate::transport::transport_client::DataReaderControl;
     use std::sync::atomic::AtomicU8;
     use std::time::Duration;
@@ -359,7 +359,7 @@ mod tests {
             CheckpointAligner::new(&["u0".to_string()], DataReaderControl::empty_for_test()),
             None,
             0,
-            Arc::new(TaskTimeBudget::default()),
+            Arc::new(TaskTimeMetrics::default()),
         );
 
         let mut seen = Vec::new();
@@ -434,7 +434,7 @@ mod tests {
             ),
             None,
             0,
-            Arc::new(TaskTimeBudget::default()),
+            Arc::new(TaskTimeMetrics::default()),
         );
 
         let mut seen = Vec::new();
@@ -496,7 +496,7 @@ mod tests {
             ),
             None,
             0,
-            Arc::new(TaskTimeBudget::default()),
+            Arc::new(TaskTimeMetrics::default()),
         );
 
         let mut seen = Vec::new();
@@ -551,7 +551,7 @@ mod tests {
             ),
             None,
             0,
-            Arc::new(TaskTimeBudget::default()),
+            Arc::new(TaskTimeMetrics::default()),
         );
 
         let mut seen = Vec::new();

--- a/src/runtime/watermark/manager.rs
+++ b/src/runtime/watermark/manager.rs
@@ -273,7 +273,7 @@ mod tests {
     use futures::StreamExt;
 
         use crate::runtime::observability::snapshot_types::StreamTaskStatus;
-        use crate::runtime::stream_task::{CheckpointAligner, StreamTask, TaskTimeMetrics};
+        use crate::runtime::stream_task::{CheckpointAligner, StreamTask};
     use crate::transport::transport_client::DataReaderControl;
     use std::sync::atomic::AtomicU8;
     use std::time::Duration;
@@ -359,7 +359,6 @@ mod tests {
             CheckpointAligner::new(&["u0".to_string()], DataReaderControl::empty_for_test()),
             None,
             0,
-            Arc::new(TaskTimeMetrics::default()),
         );
 
         let mut seen = Vec::new();
@@ -434,7 +433,6 @@ mod tests {
             ),
             None,
             0,
-            Arc::new(TaskTimeMetrics::default()),
         );
 
         let mut seen = Vec::new();
@@ -496,7 +494,6 @@ mod tests {
             ),
             None,
             0,
-            Arc::new(TaskTimeMetrics::default()),
         );
 
         let mut seen = Vec::new();
@@ -551,7 +548,6 @@ mod tests {
             ),
             None,
             0,
-            Arc::new(TaskTimeMetrics::default()),
         );
 
         let mut seen = Vec::new();

--- a/src/runtime/watermark/manager.rs
+++ b/src/runtime/watermark/manager.rs
@@ -273,7 +273,7 @@ mod tests {
     use futures::StreamExt;
 
         use crate::runtime::observability::snapshot_types::StreamTaskStatus;
-        use crate::runtime::stream_task::{CheckpointAligner, StreamTask};
+        use crate::runtime::stream_task::{CheckpointAligner, StreamTask, TaskTimeBudget};
     use crate::transport::transport_client::DataReaderControl;
     use std::sync::atomic::AtomicU8;
     use std::time::Duration;
@@ -359,6 +359,7 @@ mod tests {
             CheckpointAligner::new(&["u0".to_string()], DataReaderControl::empty_for_test()),
             None,
             0,
+            Arc::new(TaskTimeBudget::default()),
         );
 
         let mut seen = Vec::new();
@@ -433,6 +434,7 @@ mod tests {
             ),
             None,
             0,
+            Arc::new(TaskTimeBudget::default()),
         );
 
         let mut seen = Vec::new();
@@ -494,6 +496,7 @@ mod tests {
             ),
             None,
             0,
+            Arc::new(TaskTimeBudget::default()),
         );
 
         let mut seen = Vec::new();
@@ -548,6 +551,7 @@ mod tests {
             ),
             None,
             0,
+            Arc::new(TaskTimeBudget::default()),
         );
 
         let mut seen = Vec::new();

--- a/src/transport/batch_channel.rs
+++ b/src/transport/batch_channel.rs
@@ -17,7 +17,7 @@ use crate::common::Message;
 /// matching Flink-style backpressured time and the queue-fill ratio published by
 /// [`crate::transport::transport_client::DataWriter`] on the same write path.
 #[derive(Debug, Default)]
-pub struct OutputBackpressure {
+pub struct BackpressureTracker {
     accumulated_ns: AtomicU64,
     state: Mutex<WaitState>,
 }
@@ -28,7 +28,7 @@ struct WaitState {
     started: Option<Instant>,
 }
 
-impl OutputBackpressure {
+impl BackpressureTracker {
     pub fn new() -> Self {
         Self::default()
     }
@@ -58,7 +58,7 @@ impl OutputBackpressure {
     }
 }
 
-struct WaitGuard<'a>(&'a OutputBackpressure);
+struct WaitGuard<'a>(&'a BackpressureTracker);
 
 impl Drop for WaitGuard<'_> {
     fn drop(&mut self) {
@@ -107,7 +107,7 @@ impl BatchSender {
     pub async fn send(
         &self,
         message: Message,
-        bp: Option<&OutputBackpressure>,
+        bp: Option<&BackpressureTracker>,
     ) -> Result<(), SendError<Message>> {
         // Ensure that every message is sendable, even if it's bigger than our max size
         let count = message_count(&message, self.size);
@@ -246,7 +246,7 @@ mod tests {
     #[tokio::test]
     async fn fast_send_records_no_blocked_time() {
         let (tx, mut rx) = batch_bounded_channel(4);
-        let bp = OutputBackpressure::new();
+        let bp = BackpressureTracker::new();
         tx.send(wm(1), Some(&bp)).await.unwrap();
         assert_eq!(bp.take_ns(), 0);
         assert!(rx.recv().await.is_some());
@@ -255,7 +255,7 @@ mod tests {
     #[tokio::test]
     async fn blocked_send_records_wait_near_hold_time() {
         let (tx, mut rx) = batch_bounded_channel(1);
-        let bp = Arc::new(OutputBackpressure::new());
+        let bp = Arc::new(BackpressureTracker::new());
         tx.send(wm(1), None).await.unwrap();
         // size=1 full → 1 - 1/(1+1) = 0.5
         assert!((tx.backpressure_ratio() - 0.5).abs() < 1e-9);
@@ -276,7 +276,7 @@ mod tests {
     #[tokio::test]
     async fn parallel_waits_count_exclusively() {
         let (tx, mut rx) = batch_bounded_channel(1);
-        let bp = Arc::new(OutputBackpressure::new());
+        let bp = Arc::new(BackpressureTracker::new());
         tx.send(wm(0), None).await.unwrap();
 
         let hold = Duration::from_millis(80);
@@ -306,7 +306,7 @@ mod tests {
     #[tokio::test]
     async fn timeout_cancel_still_accounts_blocked_time() {
         let (tx, _rx) = batch_bounded_channel(1);
-        let bp = OutputBackpressure::new();
+        let bp = BackpressureTracker::new();
         tx.send(wm(1), None).await.unwrap();
 
         let wait = Duration::from_millis(50);

--- a/src/transport/batch_channel.rs
+++ b/src/transport/batch_channel.rs
@@ -1,9 +1,78 @@
-use std::sync::{atomic::{AtomicU32, AtomicU64, Ordering}, Arc};
+use std::sync::{
+    atomic::{AtomicU32, AtomicU64, Ordering},
+    Arc, Mutex,
+};
+use std::time::Instant;
 
-use tokio::sync::{mpsc::{error::SendError, unbounded_channel, UnboundedReceiver, UnboundedSender}, Notify};
+use tokio::sync::{
+    mpsc::{error::SendError, unbounded_channel, UnboundedReceiver, UnboundedSender},
+    Notify,
+};
 
 use crate::common::Message;
 
+/// Exclusive wall-clock time spent blocked on tx queue space.
+///
+/// Parallel `send`s share one instance: overlapping waits count once (task-level BP),
+/// matching Flink-style backpressured time and the queue-fill ratio published by
+/// [`crate::transport::transport_client::DataWriter`] on the same write path.
+#[derive(Debug, Default)]
+pub struct OutputBackpressure {
+    accumulated_ns: AtomicU64,
+    state: Mutex<WaitState>,
+}
+
+#[derive(Debug, Default)]
+struct WaitState {
+    waiters: u32,
+    started: Option<Instant>,
+}
+
+impl OutputBackpressure {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn begin_wait(&self) -> WaitGuard<'_> {
+        {
+            let mut g = self.state.lock().expect("output backpressure");
+            if g.waiters == 0 {
+                g.started = Some(Instant::now());
+            }
+            g.waiters = g.waiters.saturating_add(1);
+        }
+        WaitGuard(self)
+    }
+
+    /// Take accumulated blocked nanos for the current metrics window (includes an
+    /// in-flight wait slice, which continues into the next window).
+    pub fn take_ns(&self) -> u64 {
+        let mut g = self.state.lock().expect("output backpressure");
+        let mut total = self.accumulated_ns.swap(0, Ordering::Relaxed);
+        if g.waiters > 0 {
+            if let Some(started) = g.started.replace(Instant::now()) {
+                total = total.saturating_add(started.elapsed().as_nanos() as u64);
+            }
+        }
+        total
+    }
+}
+
+struct WaitGuard<'a>(&'a OutputBackpressure);
+
+impl Drop for WaitGuard<'_> {
+    fn drop(&mut self) {
+        let mut g = self.0.state.lock().expect("output backpressure");
+        g.waiters = g.waiters.saturating_sub(1);
+        if g.waiters == 0 {
+            if let Some(started) = g.started.take() {
+                self.0
+                    .accumulated_ns
+                    .fetch_add(started.elapsed().as_nanos() as u64, Ordering::Relaxed);
+            }
+        }
+    }
+}
 
 // Arroyo-style bounded batch channel
 // uses batch-size as a bound
@@ -27,7 +96,19 @@ fn message_bytes(message: &Message) -> u64 {
 }
 
 impl BatchSender {
-    pub async fn send(&self, message: Message) -> Result<(), SendError<Message>> {
+    /// Queue fill ratio in `[0, 1)` used for `volga_stream_task_backpressure_ratio`.
+    pub fn backpressure_ratio(&self) -> f64 {
+        let size = self.size as f64;
+        let remaining = self.capacity() as f64;
+        1.0 - (remaining + 1.0) / (size + 1.0)
+    }
+
+    /// Send `message`. When `bp` is set, queue-full waits are recorded there.
+    pub async fn send(
+        &self,
+        message: Message,
+        bp: Option<&OutputBackpressure>,
+    ) -> Result<(), SendError<Message>> {
         // Ensure that every message is sendable, even if it's bigger than our max size
         let count = message_count(&message, self.size);
         loop {
@@ -56,6 +137,7 @@ impl BatchSender {
             } else {
                 // not enough room in the queue, wait to be notified that the receiver has
                 // consumed
+                let _wait = bp.map(|b| b.begin_wait());
                 self.notify.notified().await;
             }
         }

--- a/src/transport/batch_channel.rs
+++ b/src/transport/batch_channel.rs
@@ -202,3 +202,120 @@ pub fn batch_bounded_channel(size: u32) -> (BatchSender, BatchReceiver) {
         },
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::message::WatermarkMessage;
+    use std::time::Duration;
+    use tokio::time::{sleep, timeout};
+
+    fn wm(i: u64) -> Message {
+        Message::Watermark(WatermarkMessage::new("t".to_string(), i, Some(0)))
+    }
+
+    fn assert_ns_near(actual: u64, expected: Duration, lo_frac: f64, hi_frac: f64) {
+        let expected_ns = expected.as_nanos() as f64;
+        let lo = (expected_ns * lo_frac) as u64;
+        let hi = (expected_ns * hi_frac) as u64;
+        assert!(
+            actual >= lo && actual <= hi,
+            "blocked_ns={actual} not in [{lo}, {hi}] for expected {expected:?}"
+        );
+    }
+
+    #[test]
+    fn backpressure_ratio_empty_and_full() {
+        let (tx, _rx) = batch_bounded_channel(2);
+        assert!((tx.backpressure_ratio() - 0.0).abs() < 1e-9);
+
+        // Fill: each watermark counts as 1 toward the bound.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            tx.send(wm(1), None).await.unwrap();
+            tx.send(wm(2), None).await.unwrap();
+        });
+        assert_eq!(tx.capacity(), 0);
+        // 1 - 1/(2+1) = 2/3
+        assert!((tx.backpressure_ratio() - (2.0 / 3.0)).abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn fast_send_records_no_blocked_time() {
+        let (tx, mut rx) = batch_bounded_channel(4);
+        let bp = OutputBackpressure::new();
+        tx.send(wm(1), Some(&bp)).await.unwrap();
+        assert_eq!(bp.take_ns(), 0);
+        assert!(rx.recv().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn blocked_send_records_wait_near_hold_time() {
+        let (tx, mut rx) = batch_bounded_channel(1);
+        let bp = Arc::new(OutputBackpressure::new());
+        tx.send(wm(1), None).await.unwrap();
+        // size=1 full → 1 - 1/(1+1) = 0.5
+        assert!((tx.backpressure_ratio() - 0.5).abs() < 1e-9);
+
+        let hold = Duration::from_millis(80);
+        let sender = tx.clone();
+        let bp_send = bp.clone();
+        let blocked = tokio::spawn(async move { sender.send(wm(2), Some(&bp_send)).await });
+
+        sleep(hold).await;
+        assert!(rx.recv().await.is_some());
+        blocked.await.unwrap().unwrap();
+
+        let ns = bp.take_ns();
+        assert_ns_near(ns, hold, 0.5, 2.5);
+    }
+
+    #[tokio::test]
+    async fn parallel_waits_count_exclusively() {
+        let (tx, mut rx) = batch_bounded_channel(1);
+        let bp = Arc::new(OutputBackpressure::new());
+        tx.send(wm(0), None).await.unwrap();
+
+        let hold = Duration::from_millis(80);
+        let mut joins = Vec::new();
+        for i in 1..=2 {
+            let sender = tx.clone();
+            let bp_send = bp.clone();
+            joins.push(tokio::spawn(async move {
+                sender.send(wm(i), Some(&bp_send)).await
+            }));
+        }
+
+        sleep(hold).await;
+        // Still both waiting: in-flight exclusive slice ≈ hold, not 2×hold.
+        let mid = bp.take_ns();
+        assert_ns_near(mid, hold, 0.5, 1.75);
+
+        assert!(rx.recv().await.is_some());
+        assert!(rx.recv().await.is_some());
+        for j in joins {
+            j.await.unwrap().unwrap();
+        }
+        // Residual after mid take should be small (drain latency), not another full hold.
+        assert!(bp.take_ns() < Duration::from_millis(40).as_nanos() as u64);
+    }
+
+    #[tokio::test]
+    async fn timeout_cancel_still_accounts_blocked_time() {
+        let (tx, _rx) = batch_bounded_channel(1);
+        let bp = OutputBackpressure::new();
+        tx.send(wm(1), None).await.unwrap();
+
+        let wait = Duration::from_millis(50);
+        let err = timeout(wait, tx.send(wm(2), Some(&bp))).await;
+        assert!(err.is_err(), "send should time out while queue is full");
+
+        let ns = bp.take_ns();
+        assert_ns_near(ns, wait, 0.5, 2.5);
+        // No double-count after drop.
+        assert_eq!(bp.take_ns(), 0);
+    }
+}

--- a/src/transport/test_utils.rs
+++ b/src/transport/test_utils.rs
@@ -77,7 +77,7 @@ impl kameo::message::Message<TestDataWriterMessage> for TestDataWriterActor {
     async fn handle(&mut self, msg: TestDataWriterMessage, _ctx: &mut Context<TestDataWriterActor, Result<()>>) -> Self::Reply {
         match msg {
             TestDataWriterMessage::WriteMessage { channel, message } => {
-                let (success, _) = self.writer.write_message(&channel, &message).await;
+                let success = self.writer.write_message(&channel, &message).await;
                 if success {
                     Ok(())
                 } else {

--- a/src/transport/transport_backend.rs
+++ b/src/transport/transport_backend.rs
@@ -215,8 +215,11 @@ impl TransportBackend {
                         // THIS WILL CAUSE BACKPRESSURE FOR ALL CHANNELS IF ONE CHANNEL IS BLOCKED
                         let sender = remote_reader_senders.get(&channel_id).unwrap();
                         while running.load(std::sync::atomic::Ordering::Relaxed) {
-                            match time::timeout(Duration::from_millis(100), sender.send(message.clone()))
-                                .await
+                            match time::timeout(
+                                Duration::from_millis(100),
+                                sender.send(message.clone(), None),
+                            )
+                            .await
                             {
                                 Ok(Ok(())) => break,
                                 Ok(Err(e)) => {

--- a/src/transport/transport_client.rs
+++ b/src/transport/transport_client.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use metrics::gauge;
 use std::collections::HashMap;
-use crate::{common::message::Message, runtime::{health::{WorkerFatalReason, WorkerHealth}, metrics::{MetricsLabels, LABEL_PIPELINE_ID, LABEL_TARGET_TASK_ID, LABEL_TASK_ID, LABEL_WORKER_ID, METRIC_STREAM_TASK_BACKPRESSURE_RATIO, METRIC_STREAM_TASK_TX_QUEUE_REM, METRIC_STREAM_TASK_TX_QUEUE_SIZE}, operators::operator::MessageStream}, transport::{batch_channel::{BatchReceiver, BatchSender, OutputBackpressure}, channel::Channel}};
+use crate::{common::message::Message, runtime::{health::{WorkerFatalReason, WorkerHealth}, metrics::{MetricsLabels, LABEL_PIPELINE_ID, LABEL_TARGET_TASK_ID, LABEL_TASK_ID, LABEL_WORKER_ID, METRIC_STREAM_TASK_BACKPRESSURE_RATIO, METRIC_STREAM_TASK_TX_QUEUE_REM, METRIC_STREAM_TASK_TX_QUEUE_SIZE}, operators::operator::MessageStream}, transport::{batch_channel::{BatchReceiver, BatchSender, BackpressureTracker}, channel::Channel}};
 use std::time::Duration;
 use tokio::{sync::mpsc::error::SendError, time};
 use tokio::sync::Notify;
@@ -181,8 +181,8 @@ pub struct DataWriter {
     pub senders: HashMap<String, BatchSender>,
     metrics_labels: Option<MetricsLabels>,
     worker_health: Arc<WorkerHealth>,
-    /// Task-scoped queue-wait clock (ratio gauges + time-budget BP share this write path).
-    output_backpressure: Option<Arc<OutputBackpressure>>,
+    /// Task-scoped queue-wait clock (ratio gauges + task time BP share this write path).
+    backpressure_tracker: Option<Arc<BackpressureTracker>>,
     // batcher: Batcher,
     default_timeout: Duration,
     default_retries: usize,
@@ -204,7 +204,7 @@ impl DataWriter {
             senders,
             metrics_labels,
             worker_health,
-            output_backpressure: None,
+            backpressure_tracker: None,
             // batcher,
             default_timeout: Duration::from_millis(5000),
             default_retries: 10,
@@ -212,8 +212,8 @@ impl DataWriter {
         }
     }
 
-    pub fn set_output_backpressure(&mut self, bp: Arc<OutputBackpressure>) {
-        self.output_backpressure = Some(bp);
+    pub fn set_backpressure_tracker(&mut self, bp: Arc<BackpressureTracker>) {
+        self.backpressure_tracker = Some(bp);
     }
 
     pub async fn start(&mut self) {
@@ -290,7 +290,7 @@ impl DataWriter {
         retries: usize,
     ) -> bool {
         let mut attempts = 0;
-        let bp = self.output_backpressure.as_deref();
+        let bp = self.backpressure_tracker.as_deref();
 
         while attempts <= retries {
             if self.senders.is_empty() {
@@ -299,7 +299,7 @@ impl DataWriter {
             let channel_id = channel.get_channel_id();
             if let Some(sender) = self.senders.get(&channel_id) {
                 let target_vertex_id = channel.get_target_vertex_id();
-                // Same path as time-budget BP: sample queue, then send (waits record on `bp`).
+                // Same path as task time BP: sample queue, then send (waits record on `bp`).
                 self.publish_queue_metrics(sender, &target_vertex_id);
                 match time::timeout(timeout_duration, sender.send(message.clone(), bp)).await {
                     Ok(Ok(())) => return true,

--- a/src/transport/transport_client.rs
+++ b/src/transport/transport_client.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use metrics::gauge;
 use std::collections::HashMap;
-use crate::{common::message::Message, runtime::{health::{WorkerFatalReason, WorkerHealth}, metrics::{MetricsLabels, LABEL_PIPELINE_ID, LABEL_TARGET_TASK_ID, LABEL_TASK_ID, LABEL_WORKER_ID, METRIC_STREAM_TASK_BACKPRESSURE_RATIO, METRIC_STREAM_TASK_TX_QUEUE_REM, METRIC_STREAM_TASK_TX_QUEUE_SIZE}, operators::operator::MessageStream}, transport::{batch_channel::{BatchReceiver, BatchSender}, channel::Channel}};
+use crate::{common::message::Message, runtime::{health::{WorkerFatalReason, WorkerHealth}, metrics::{MetricsLabels, LABEL_PIPELINE_ID, LABEL_TARGET_TASK_ID, LABEL_TASK_ID, LABEL_WORKER_ID, METRIC_STREAM_TASK_BACKPRESSURE_RATIO, METRIC_STREAM_TASK_TX_QUEUE_REM, METRIC_STREAM_TASK_TX_QUEUE_SIZE}, operators::operator::MessageStream}, transport::{batch_channel::{BatchReceiver, BatchSender, OutputBackpressure}, channel::Channel}};
 use std::time::Duration;
 use tokio::{sync::mpsc::error::SendError, time};
 use tokio::sync::Notify;
@@ -181,6 +181,8 @@ pub struct DataWriter {
     pub senders: HashMap<String, BatchSender>,
     metrics_labels: Option<MetricsLabels>,
     worker_health: Arc<WorkerHealth>,
+    /// Task-scoped queue-wait clock (ratio gauges + time-budget BP share this write path).
+    output_backpressure: Option<Arc<OutputBackpressure>>,
     // batcher: Batcher,
     default_timeout: Duration,
     default_retries: usize,
@@ -202,11 +204,16 @@ impl DataWriter {
             senders,
             metrics_labels,
             worker_health,
+            output_backpressure: None,
             // batcher,
             default_timeout: Duration::from_millis(5000),
             default_retries: 10,
             _batching_config: batching_config,
         }
+    }
+
+    pub fn set_output_backpressure(&mut self, bp: Arc<OutputBackpressure>) {
+        self.output_backpressure = Some(bp);
     }
 
     pub async fn start(&mut self) {
@@ -218,12 +225,61 @@ impl DataWriter {
         Ok(())
     }
 
-    pub async fn write_message(&mut self, channel: &Channel, message: &Message) -> (bool, u32) {
-        // match self.batcher.write_message(channel_id, message.clone()).await {
-        //     Ok(()) => (true, 0), // Success, no latency for batching
-        //     Err(_) => (false, 0)
-        // }
-        self.write_message_with_params(channel, message, self.default_timeout, self.default_retries).await
+    /// Publish queue size / remaining / fill-ratio for one outbound channel.
+    fn publish_queue_metrics(&self, sender: &BatchSender, target_vertex_id: &str) {
+        let queue_size = sender.size();
+        let queue_remaining = sender.capacity();
+        let backpressure = sender.backpressure_ratio();
+        if let Some(labels) = &self.metrics_labels {
+            gauge!(
+                METRIC_STREAM_TASK_TX_QUEUE_SIZE,
+                LABEL_TASK_ID => self.vertex_id.clone(),
+                LABEL_TARGET_TASK_ID => target_vertex_id.to_string(),
+                LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                LABEL_WORKER_ID => labels.worker_id.clone()
+            )
+            .set(queue_size);
+            gauge!(
+                METRIC_STREAM_TASK_TX_QUEUE_REM,
+                LABEL_TASK_ID => self.vertex_id.clone(),
+                LABEL_TARGET_TASK_ID => target_vertex_id.to_string(),
+                LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                LABEL_WORKER_ID => labels.worker_id.clone()
+            )
+            .set(queue_remaining);
+            gauge!(
+                METRIC_STREAM_TASK_BACKPRESSURE_RATIO,
+                LABEL_TASK_ID => self.vertex_id.clone(),
+                LABEL_TARGET_TASK_ID => target_vertex_id.to_string(),
+                LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                LABEL_WORKER_ID => labels.worker_id.clone()
+            )
+            .set(backpressure);
+        } else {
+            gauge!(
+                METRIC_STREAM_TASK_TX_QUEUE_SIZE,
+                LABEL_TASK_ID => self.vertex_id.clone(),
+                LABEL_TARGET_TASK_ID => target_vertex_id.to_string()
+            )
+            .set(queue_size);
+            gauge!(
+                METRIC_STREAM_TASK_TX_QUEUE_REM,
+                LABEL_TASK_ID => self.vertex_id.clone(),
+                LABEL_TARGET_TASK_ID => target_vertex_id.to_string()
+            )
+            .set(queue_remaining);
+            gauge!(
+                METRIC_STREAM_TASK_BACKPRESSURE_RATIO,
+                LABEL_TASK_ID => self.vertex_id.clone(),
+                LABEL_TARGET_TASK_ID => target_vertex_id.to_string()
+            )
+            .set(backpressure);
+        }
+    }
+
+    pub async fn write_message(&mut self, channel: &Channel, message: &Message) -> bool {
+        self.write_message_with_params(channel, message, self.default_timeout, self.default_retries)
+            .await
     }
 
     async fn write_message_with_params(
@@ -231,10 +287,10 @@ impl DataWriter {
         channel: &Channel,
         message: &Message,
         timeout_duration: Duration,
-        retries: usize
-    ) -> (bool, u32) {
+        retries: usize,
+    ) -> bool {
         let mut attempts = 0;
-        let start_time = std::time::Instant::now();
+        let bp = self.output_backpressure.as_deref();
 
         while attempts <= retries {
             if self.senders.is_empty() {
@@ -242,43 +298,11 @@ impl DataWriter {
             }
             let channel_id = channel.get_channel_id();
             if let Some(sender) = self.senders.get(&channel_id) {
-                let queue_size = sender.size();
-                let queue_remaining = sender.capacity();
                 let target_vertex_id = channel.get_target_vertex_id();
-
-                if let Some(labels) = &self.metrics_labels {
-                    gauge!(
-                        METRIC_STREAM_TASK_TX_QUEUE_SIZE,
-                        LABEL_TASK_ID => self.vertex_id.clone(),
-                        LABEL_TARGET_TASK_ID => target_vertex_id.clone(),
-                        LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                        LABEL_WORKER_ID => labels.worker_id.clone()
-                    ).set(queue_size);
-                    gauge!(
-                        METRIC_STREAM_TASK_TX_QUEUE_REM,
-                        LABEL_TASK_ID => self.vertex_id.clone(),
-                        LABEL_TARGET_TASK_ID => target_vertex_id.clone(),
-                        LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                        LABEL_WORKER_ID => labels.worker_id.clone()
-                    ).set(queue_remaining);
-                    let backpressure = 1.0 - (queue_remaining as f64 + 1.0) / (queue_size as f64 + 1.0);
-                    gauge!(
-                        METRIC_STREAM_TASK_BACKPRESSURE_RATIO,
-                        LABEL_TASK_ID => self.vertex_id.clone(),
-                        LABEL_TARGET_TASK_ID => target_vertex_id.clone(),
-                        LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                        LABEL_WORKER_ID => labels.worker_id.clone()
-                    ).set(backpressure);
-                } else {
-                    gauge!(METRIC_STREAM_TASK_TX_QUEUE_SIZE, LABEL_TASK_ID => self.vertex_id.clone(), LABEL_TARGET_TASK_ID => target_vertex_id.clone()).set(queue_size);
-                    gauge!(METRIC_STREAM_TASK_TX_QUEUE_REM, LABEL_TASK_ID => self.vertex_id.clone(), LABEL_TARGET_TASK_ID => target_vertex_id.clone()).set(queue_remaining);
-                    let backpressure = 1.0 - (queue_remaining as f64 + 1.0) / (queue_size as f64 + 1.0);
-                    gauge!(METRIC_STREAM_TASK_BACKPRESSURE_RATIO, LABEL_TASK_ID => self.vertex_id.clone(), LABEL_TARGET_TASK_ID => target_vertex_id.clone()).set(backpressure);
-                }
-                match time::timeout(timeout_duration, sender.send(message.clone())).await {
-                    Ok(Ok(())) => {
-                        return (true, start_time.elapsed().as_millis() as u32)
-                    }
+                // Same path as time-budget BP: sample queue, then send (waits record on `bp`).
+                self.publish_queue_metrics(sender, &target_vertex_id);
+                match time::timeout(timeout_duration, sender.send(message.clone(), bp)).await {
+                    Ok(Ok(())) => return true,
                     Ok(Err(_)) => {
                         self.worker_health.report_fatal(
                             WorkerFatalReason::TransportDisconnect,
@@ -287,9 +311,10 @@ impl DataWriter {
                                 self.vertex_id, channel_id
                             ),
                         );
-                        return (false, start_time.elapsed().as_millis() as u32);
+                        return false;
                     }
                     Err(_) => {
+                        // Timed out mid-wait: WaitGuard drop still accounts blocked time on `bp`.
                         println!("DataWriter {:?} timeout", self.vertex_id);
                         attempts += 1;
                         continue;
@@ -299,8 +324,8 @@ impl DataWriter {
                 panic!("DataWriter {:?} channel {} not found", self.vertex_id, channel_id);
             }
         }
-    
-        (false, start_time.elapsed().as_millis() as u32)
+
+        false
     }
 
     pub fn get_queue_size_and_capacity(&self, channel_id: &str) -> Option<(u32, u32)> {


### PR DESCRIPTION
## Summary
- Flink-style per-task `busy` / `idle` / `backpressured` ms-per-second gauges via `TaskTimeMetrics` + `report_task_time_metrics`
- **Idle** = input wait; **backpressured** = exclusive tx-queue wait via `BackpressureTracker` (same `DataWriter` / `BatchSender` path as BP ratio + queue gauges; `set_backpressure_tracker`); **busy** = residual wall time so the three sum ≈ 1000 ms/s
- Unit tests for ratio, blocked-time bounds, parallel exclusive accounting, and timeout cancel

Depends on #226 (checkpoint metrics).

## Test plan
- [x] `scripts/test unit --filter 'test(batch_channel)'` (5 passed)
- [ ] `scripts/test unit`
- [ ] Smoke a pipeline under load and confirm busy+idle+bp ≈ 1000 and BP ratio rises when queues fill