### PR TITLE
fix: harden SameAddrRestart fence and kill-restore waits

### DIFF
--- a/src/runtime/master/worker_client.rs
+++ b/src/runtime/master/worker_client.rs
@@ -45,10 +45,14 @@ impl std::error::Error for WorkerCallError {}
 fn is_retryable_status(status: &tonic::Status) -> bool {
     matches!(
         status.code(),
+        // Transient transport / overload. Include Cancelled: an in-flight RPC is often
+        // cancelled when the peer restarts (SameAddrRestart gap); retry so fencing can
+        // land on the rebound listener instead of recovering on a bare Cancelled poll.
         Code::Unavailable
             | Code::DeadlineExceeded
             | Code::ResourceExhausted
             | Code::Aborted
+            | Code::Cancelled
             | Code::Unknown
     )
 }

--- a/src/tests/support/checkpoint/kill_recovery.rs
+++ b/src/tests/support/checkpoint/kill_recovery.rs
@@ -81,6 +81,12 @@ async fn wait_for_kill_restore(
                 }
                 _ => {}
             }
+            // Stop once both signals are seen so we don't advance the cursor past
+            // a later AttemptRunning in the same poll batch (final wait needs it).
+            // Checkpoint metrics make lifecycle batches denser, which amplifies this.
+            if restore_attempt.is_some() && target_replaced {
+                break;
+            }
         }
         if let (Some(attempt_id), true) = (restore_attempt, target_replaced) {
             return Ok(attempt_id);


### PR DESCRIPTION
## Summary
- Treat gRPC `Cancelled` as retryable in worker state polls so SameAddrRestart can still land a fence rejection after a crash cancels an in-flight `get_worker_state`.
- Stop advancing the kill-restore lifecycle cursor once restore+replace are observed, so `AttemptRunning` is not skipped when events arrive in one poll batch.

Extracted from the metrics stack so these CI flake fixes land independently of #223–#227.

## Test plan
- [x] `./scripts/test stress --env local --test test_local_single_worker_same_addr_restart_fenced_recovers --test test_local_single_worker_checkpoint_complete_then_worker_kill_restores --runs-per-shard 30 --shards 2` → 60/60 pass
- [ ] CI inprocess / stress green on this PR


Made with [Cursor](https://cursor.com)