### PR TITLE
Add volga-longrun soak (Steady + KillAfterCheckpoint)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ path = "src/bin/volga-test-storage.rs"
 name = "generate-kube-pipeline-schema"
 path = "src/bin/generate-kube-pipeline-schema.rs"
 
+[[bin]]
+name = "volga-longrun"
+path = "src/bin/volga-longrun.rs"
+
 [build-dependencies]
 tonic-build = "0.12"
 

--- a/src/bin/volga-longrun.rs
+++ b/src/bin/volga-longrun.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    volga::longrun::cli::run(std::env::args().skip(1)).await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod api;
 pub mod orchestrator;
 pub mod storage;
 pub mod test_utils;
+pub mod longrun;
 
 #[cfg(test)]
 pub mod tests;

--- a/src/longrun/cli.rs
+++ b/src/longrun/cli.rs
@@ -1,0 +1,212 @@
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+
+use crate::test_utils::harness::RuntimeEnv;
+
+use super::run::run_soak;
+use super::spec::{SoakScenario, SoakSpec};
+
+const USAGE: &str = "\
+Usage:
+  volga-longrun soak [--env local|kube|docker] [--scenario steady|kill] [--duration-secs N] [--kill-after-checkpoint N]
+  volga-longrun bench
+
+v1 implements soak only. Default duration: local 120s, kube/docker 3600s.
+Checkpoints use prod consts (30s interval). Count sink. Sliding RANGE window job.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LongrunCommand {
+    Soak(SoakArgs),
+    Bench,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoakArgs {
+    pub env: RuntimeEnv,
+    pub scenario: SoakScenario,
+    pub duration_secs: Option<u64>,
+}
+
+pub async fn run<I, S>(args: I) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    match parse_args(args)? {
+        LongrunCommand::Soak(args) => {
+            let duration_secs = args
+                .duration_secs
+                .unwrap_or_else(|| SoakSpec::default_duration_secs(args.env));
+            let spec = SoakSpec::new(args.env, args.scenario, Duration::from_secs(duration_secs));
+            run_soak(spec).await
+        }
+        LongrunCommand::Bench => {
+            bail!("`volga-longrun bench` is not implemented in v1; use `soak`")
+        }
+    }
+}
+
+pub fn parse_args<I, S>(args: I) -> Result<LongrunCommand>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let args: Vec<String> = args.into_iter().map(|s| s.as_ref().to_string()).collect();
+    if args.is_empty() || args.iter().any(|a| a == "--help" || a == "-h") {
+        bail!("{USAGE}");
+    }
+    match args[0].as_str() {
+        "soak" => Ok(LongrunCommand::Soak(parse_soak(&args[1..])?)),
+        "bench" => {
+            if args.len() > 1 {
+                bail!("bench takes no arguments\n{USAGE}");
+            }
+            Ok(LongrunCommand::Bench)
+        }
+        other => bail!("unknown command `{other}`\n{USAGE}"),
+    }
+}
+
+fn parse_soak(args: &[String]) -> Result<SoakArgs> {
+    let mut env = RuntimeEnv::Local;
+    let mut scenario_kill = false;
+    let mut duration_secs = None;
+    let mut kill_after = 1u64;
+    let mut kill_after_set = false;
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        let (flag, inline) = split_flag(arg);
+        match flag {
+            "--env" => {
+                let value = take_value(flag, inline, args, &mut i)?;
+                env = RuntimeEnv::parse(&value)
+                    .ok_or_else(|| anyhow!("invalid --env `{value}` (local|kube|docker)"))?;
+            }
+            "--scenario" => {
+                let value = take_value(flag, inline, args, &mut i)?;
+                scenario_kill = match value.as_str() {
+                    "steady" => false,
+                    "kill" => true,
+                    other => bail!("invalid --scenario `{other}` (steady|kill)"),
+                };
+            }
+            "--duration-secs" => {
+                let value = take_value(flag, inline, args, &mut i)?;
+                let n: u64 = value
+                    .parse()
+                    .map_err(|_| anyhow!("invalid --duration-secs `{value}`"))?;
+                if n == 0 {
+                    bail!("--duration-secs must be >= 1");
+                }
+                duration_secs = Some(n);
+            }
+            "--kill-after-checkpoint" => {
+                let value = take_value(flag, inline, args, &mut i)?;
+                let n: u64 = value
+                    .parse()
+                    .map_err(|_| anyhow!("invalid --kill-after-checkpoint `{value}`"))?;
+                if n == 0 {
+                    bail!("--kill-after-checkpoint must be >= 1");
+                }
+                kill_after = n;
+                kill_after_set = true;
+            }
+            other => bail!("unknown soak flag `{other}`\n{USAGE}"),
+        }
+        i += 1;
+    }
+    if kill_after_set && !scenario_kill {
+        bail!("--kill-after-checkpoint requires --scenario kill");
+    }
+    let scenario = if scenario_kill {
+        SoakScenario::KillAfterCheckpoint {
+            after_checkpoint: kill_after,
+        }
+    } else {
+        SoakScenario::Steady
+    };
+    Ok(SoakArgs {
+        env,
+        scenario,
+        duration_secs,
+    })
+}
+
+fn split_flag(arg: &str) -> (&str, Option<&str>) {
+    match arg.split_once('=') {
+        Some((flag, value)) => (flag, Some(value)),
+        None => (arg, None),
+    }
+}
+
+fn take_value(flag: &str, inline: Option<&str>, args: &[String], i: &mut usize) -> Result<String> {
+    if let Some(value) = inline {
+        return Ok(value.to_string());
+    }
+    *i += 1;
+    args.get(*i)
+        .cloned()
+        .ok_or_else(|| anyhow!("{flag} requires a value"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_soak_defaults() {
+        let LongrunCommand::Soak(args) = parse_args(["soak"]).unwrap() else {
+            panic!("expected soak");
+        };
+        assert_eq!(args.env, RuntimeEnv::Local);
+        assert_eq!(args.scenario, SoakScenario::Steady);
+        assert_eq!(args.duration_secs, None);
+    }
+
+    #[test]
+    fn parse_soak_kill_kube() {
+        let LongrunCommand::Soak(args) = parse_args([
+            "soak",
+            "--env",
+            "kube",
+            "--scenario",
+            "kill",
+            "--duration-secs",
+            "3600",
+            "--kill-after-checkpoint",
+            "2",
+        ])
+        .unwrap() else {
+            panic!("expected soak");
+        };
+        assert_eq!(args.env, RuntimeEnv::Kube);
+        assert_eq!(
+            args.scenario,
+            SoakScenario::KillAfterCheckpoint {
+                after_checkpoint: 2
+            }
+        );
+        assert_eq!(args.duration_secs, Some(3600));
+    }
+
+    #[test]
+    fn parse_equals_and_bench() {
+        let LongrunCommand::Soak(args) =
+            parse_args(["soak", "--env=docker", "--scenario=steady"]).unwrap()
+        else {
+            panic!("expected soak");
+        };
+        assert_eq!(args.env, RuntimeEnv::Docker);
+        assert!(matches!(
+            parse_args(["bench"]).unwrap(),
+            LongrunCommand::Bench
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_kill_flag_on_steady() {
+        assert!(parse_args(["soak", "--kill-after-checkpoint", "1"]).is_err());
+    }
+}

--- a/src/longrun/cli.rs
+++ b/src/longrun/cli.rs
@@ -156,16 +156,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_soak_defaults() {
-        let LongrunCommand::Soak(args) = parse_args(["soak"]).unwrap() else {
-            panic!("expected soak");
-        };
-        assert_eq!(args.env, RuntimeEnv::Local);
-        assert_eq!(args.scenario, SoakScenario::Steady);
-        assert_eq!(args.duration_secs, None);
-    }
-
-    #[test]
     fn parse_soak_kill_kube() {
         let LongrunCommand::Soak(args) = parse_args([
             "soak",
@@ -189,20 +179,6 @@ mod tests {
             }
         );
         assert_eq!(args.duration_secs, Some(3600));
-    }
-
-    #[test]
-    fn parse_equals_and_bench() {
-        let LongrunCommand::Soak(args) =
-            parse_args(["soak", "--env=docker", "--scenario=steady"]).unwrap()
-        else {
-            panic!("expected soak");
-        };
-        assert_eq!(args.env, RuntimeEnv::Docker);
-        assert!(matches!(
-            parse_args(["bench"]).unwrap(),
-            LongrunCommand::Bench
-        ));
     }
 
     #[test]

--- a/src/longrun/flink.rs
+++ b/src/longrun/flink.rs
@@ -1,0 +1,17 @@
+//! Sibling of [`crate::test_utils::harness::VolgaCluster`]. Not implemented in v1.
+//!
+//! Do not wrap Volga in an engine adapter. When Flink lands, it gets its own
+//! submit / kill / teardown, sharing soak scenarios and Prom oracles only.
+
+/// Placeholder for the later Flink engine cluster.
+pub struct FlinkCluster {
+    _private: (),
+}
+
+impl FlinkCluster {
+    pub fn not_implemented() -> anyhow::Result<Self> {
+        anyhow::bail!(
+            "FlinkCluster is not implemented in v1; use `volga-longrun soak` with VolgaCluster"
+        )
+    }
+}

--- a/src/longrun/job.rs
+++ b/src/longrun/job.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use crate::api::spec::connectors::{SinkSpec, SourceSpecKind};
 use crate::api::PipelineSpec;
 use crate::runtime::consts::RuntimeConstsProfile;
@@ -10,21 +8,25 @@ use crate::test_utils::harness::PipelineLaunchSpec;
 
 /// Sliding RANGE window job used by both Steady and KillAfterCheckpoint.
 ///
-/// Same SQL as the checkpoint window suite; Count sink; Datagen `run_for_s` = soak duration;
-/// prod runtime consts (30s checkpoint interval), not `kube_test` 2s.
-pub fn soak_window_launch_spec(duration: Duration) -> PipelineLaunchSpec {
+/// Same SQL as the checkpoint window suite; Count sink; prod runtime consts
+/// (30s checkpoint interval), not `kube_test` 2s.
+///
+/// Datagen `run_for_s` stays unset: the soak loop owns wall-clock duration and
+/// shuts the cluster down. A per-attempt `run_for_s` would restart after kill
+/// restore and overshoot the remaining soak window.
+pub fn soak_window_launch_spec() -> PipelineLaunchSpec {
     let mut launch =
         checkpoint_recovery_launch_spec(MULTI_WORKER_PARALLELISM, CheckpointWorkload::Window);
     launch.pipeline.sink = Some(SinkSpec::Count);
-    set_datagen_run_for_s(&mut launch.pipeline, duration.as_secs_f64());
-    launch.expected_output_rows = 0;
+    clear_datagen_run_for_s(&mut launch.pipeline);
+    launch.expected_output_rows = None;
     launch.with_runtime_consts_profile(RuntimeConstsProfile::Prod)
 }
 
-fn set_datagen_run_for_s(pipeline: &mut PipelineSpec, run_for_s: f64) {
+fn clear_datagen_run_for_s(pipeline: &mut PipelineSpec) {
     for source in &mut pipeline.sources {
         if let SourceSpecKind::Datagen(datagen) = &mut source.source {
-            datagen.run_for_s = Some(run_for_s);
+            datagen.run_for_s = None;
         }
     }
 }
@@ -35,7 +37,7 @@ mod tests {
 
     #[test]
     fn soak_job_is_count_sink_window_prod() {
-        let launch = soak_window_launch_spec(Duration::from_secs(120));
+        let launch = soak_window_launch_spec();
         assert!(matches!(launch.pipeline.sink, Some(SinkSpec::Count)));
         assert!(!launch
             .pipeline
@@ -44,7 +46,7 @@ mod tests {
             .unwrap()
             .needs_in_memory_store());
         assert_eq!(launch.runtime_consts_profile, RuntimeConstsProfile::Prod);
-        assert_eq!(launch.expected_output_rows, 0);
+        assert_eq!(launch.expected_output_rows, None);
         assert_eq!(launch.worker_count, 2);
         let sql = launch.pipeline.sql.as_deref().expect("sql");
         assert!(sql.contains("RANGE BETWEEN INTERVAL '10000' MILLISECOND PRECEDING"));
@@ -56,6 +58,6 @@ mod tests {
                 SourceSpecKind::Datagen(datagen) => datagen.run_for_s,
                 _ => None,
             });
-        assert_eq!(run_for, Some(120.0));
+        assert_eq!(run_for, None);
     }
 }

--- a/src/longrun/job.rs
+++ b/src/longrun/job.rs
@@ -1,0 +1,61 @@
+use std::time::Duration;
+
+use crate::api::spec::connectors::{SinkSpec, SourceSpecKind};
+use crate::api::PipelineSpec;
+use crate::runtime::consts::RuntimeConstsProfile;
+use crate::test_utils::checkpoint::{
+    checkpoint_recovery_launch_spec, CheckpointWorkload, MULTI_WORKER_PARALLELISM,
+};
+use crate::test_utils::harness::PipelineLaunchSpec;
+
+/// Sliding RANGE window job used by both Steady and KillAfterCheckpoint.
+///
+/// Same SQL as the checkpoint window suite; Count sink; Datagen `run_for_s` = soak duration;
+/// prod runtime consts (30s checkpoint interval), not `kube_test` 2s.
+pub fn soak_window_launch_spec(duration: Duration) -> PipelineLaunchSpec {
+    let mut launch =
+        checkpoint_recovery_launch_spec(MULTI_WORKER_PARALLELISM, CheckpointWorkload::Window);
+    launch.pipeline.sink = Some(SinkSpec::Count);
+    set_datagen_run_for_s(&mut launch.pipeline, duration.as_secs_f64());
+    launch.expected_output_rows = 0;
+    launch.with_runtime_consts_profile(RuntimeConstsProfile::Prod)
+}
+
+fn set_datagen_run_for_s(pipeline: &mut PipelineSpec, run_for_s: f64) {
+    for source in &mut pipeline.sources {
+        if let SourceSpecKind::Datagen(datagen) = &mut source.source {
+            datagen.run_for_s = Some(run_for_s);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn soak_job_is_count_sink_window_prod() {
+        let launch = soak_window_launch_spec(Duration::from_secs(120));
+        assert!(matches!(launch.pipeline.sink, Some(SinkSpec::Count)));
+        assert!(!launch
+            .pipeline
+            .sink
+            .as_ref()
+            .unwrap()
+            .needs_in_memory_store());
+        assert_eq!(launch.runtime_consts_profile, RuntimeConstsProfile::Prod);
+        assert_eq!(launch.expected_output_rows, 0);
+        assert_eq!(launch.worker_count, 2);
+        let sql = launch.pipeline.sql.as_deref().expect("sql");
+        assert!(sql.contains("RANGE BETWEEN INTERVAL '10000' MILLISECOND PRECEDING"));
+        let run_for = launch
+            .pipeline
+            .sources
+            .iter()
+            .find_map(|source| match &source.source {
+                SourceSpecKind::Datagen(datagen) => datagen.run_for_s,
+                _ => None,
+            });
+        assert_eq!(run_for, Some(120.0));
+    }
+}

--- a/src/longrun/job.rs
+++ b/src/longrun/job.rs
@@ -30,34 +30,3 @@ fn clear_datagen_run_for_s(pipeline: &mut PipelineSpec) {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn soak_job_is_count_sink_window_prod() {
-        let launch = soak_window_launch_spec();
-        assert!(matches!(launch.pipeline.sink, Some(SinkSpec::Count)));
-        assert!(!launch
-            .pipeline
-            .sink
-            .as_ref()
-            .unwrap()
-            .needs_in_memory_store());
-        assert_eq!(launch.runtime_consts_profile, RuntimeConstsProfile::Prod);
-        assert_eq!(launch.expected_output_rows, None);
-        assert_eq!(launch.worker_count, 2);
-        let sql = launch.pipeline.sql.as_deref().expect("sql");
-        assert!(sql.contains("RANGE BETWEEN INTERVAL '10000' MILLISECOND PRECEDING"));
-        let run_for = launch
-            .pipeline
-            .sources
-            .iter()
-            .find_map(|source| match &source.source {
-                SourceSpecKind::Datagen(datagen) => datagen.run_for_s,
-                _ => None,
-            });
-        assert_eq!(run_for, None);
-    }
-}

--- a/src/longrun/mod.rs
+++ b/src/longrun/mod.rs
@@ -1,0 +1,13 @@
+//! Long-run soak (and later bench) on top of [`crate::test_utils::harness::VolgaCluster`].
+//!
+//! Not a second cluster API: no `EngineAdapter` / `RunSpec`. Flink is a sibling
+//! [`flink::FlinkCluster`] later, not a wrapper around Volga.
+
+pub mod cli;
+pub mod flink;
+pub mod job;
+pub mod run;
+pub mod spec;
+
+pub use run::run_soak;
+pub use spec::{SoakOracleConfig, SoakScenario, SoakSpec};

--- a/src/longrun/run.rs
+++ b/src/longrun/run.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 use anyhow::{anyhow, Result};
 
 use crate::runtime::consts::{init_runtime_consts_profile, RuntimeConstsProfile};
+use crate::runtime::master::LifecycleEvent;
 use crate::test_utils::checkpoint::{
     wait_for_checkpoint_completed, wait_for_kill_restore, wait_until_attempt0_running,
     wait_until_attempt_running, wait_until_checkpoints_idle,
@@ -39,7 +40,13 @@ pub async fn run_soak(spec: SoakSpec) -> Result<()> {
     let duration = spec.duration;
     let scenario = spec.scenario;
     let cluster = VolgaCluster::launch(env, spec.launch).await?;
-    let result = run_scenario(&cluster, env, scenario, duration).await;
+    let result = tokio::select! {
+        result = run_scenario(&cluster, env, scenario, duration) => result,
+        _ = shutdown_signal() => {
+            println!("[volga-longrun] interrupt, shutting down");
+            Ok(())
+        }
+    };
     match cluster.shutdown().await {
         Ok(()) => result,
         Err(shutdown_err) => match result {
@@ -50,6 +57,18 @@ pub async fn run_soak(spec: SoakSpec) -> Result<()> {
 }
 
 async fn run_scenario(
+    cluster: &VolgaCluster,
+    env: RuntimeEnv,
+    scenario: SoakScenario,
+    duration: Duration,
+) -> Result<()> {
+    tokio::select! {
+        result = run_scenario_body(cluster, env, scenario, duration) => result,
+        failed = watch_pipeline_failed(cluster) => failed,
+    }
+}
+
+async fn run_scenario_body(
     cluster: &VolgaCluster,
     env: RuntimeEnv,
     scenario: SoakScenario,
@@ -73,12 +92,7 @@ async fn run_scenario(
     let remaining = duration.saturating_sub(started.elapsed());
     if remaining > Duration::ZERO {
         println!("[volga-longrun] running for remaining {remaining:?}");
-        tokio::select! {
-            _ = tokio::time::sleep(remaining) => {}
-            _ = shutdown_signal() => {
-                println!("[volga-longrun] interrupt, shutting down");
-            }
-        }
+        tokio::time::sleep(remaining).await;
     }
 
     println!(
@@ -86,6 +100,18 @@ async fn run_scenario(
         started.elapsed()
     );
     Ok(())
+}
+
+/// Fail the soak if the pipeline dies. G still owns lag/checkpoint oracles.
+async fn watch_pipeline_failed(cluster: &VolgaCluster) -> Result<()> {
+    loop {
+        for record in cluster.master().lifecycle_events_since(0).await? {
+            if let LifecycleEvent::PipelineFailed { detail } = record.event {
+                return Err(anyhow!("pipeline failed: {detail}"));
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 }
 
 async fn run_kill_after_checkpoint(

--- a/src/longrun/run.rs
+++ b/src/longrun/run.rs
@@ -1,0 +1,158 @@
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Result};
+
+use crate::runtime::consts::{init_runtime_consts_profile, RuntimeConstsProfile};
+use crate::test_utils::checkpoint::{
+    wait_for_checkpoint_completed, wait_for_kill_restore, wait_until_attempt0_running,
+    wait_until_attempt_running, wait_until_checkpoints_idle,
+};
+use crate::test_utils::harness::{RuntimeEnv, VolgaCluster, WorkerKillMode};
+use crate::test_utils::recovery::RecoveryTimeouts;
+
+use super::spec::{SoakScenario, SoakSpec};
+
+/// Prod interval is 30s; wait up to 3× interval plus slack for the first completed CP.
+const CHECKPOINT_WAIT: Duration = Duration::from_secs(120);
+/// Prod checkpoint timeout is 60s; idle wait must cover an in-flight CP before kill.
+const CHECKPOINT_IDLE: Duration = Duration::from_secs(90);
+
+pub async fn run_soak(spec: SoakSpec) -> Result<()> {
+    init_runtime_consts_profile(RuntimeConstsProfile::Prod);
+
+    if let Some(path) = &spec.dump {
+        println!(
+            "[volga-longrun] dump path {} ignored until PR G",
+            path.display()
+        );
+    }
+    println!("[volga-longrun] oracles not evaluated until PR G");
+
+    println!(
+        "[volga-longrun] env={} scenario={} duration={:?}",
+        spec.env,
+        spec.scenario.as_str(),
+        spec.duration
+    );
+
+    let env = spec.env;
+    let duration = spec.duration;
+    let scenario = spec.scenario;
+    let cluster = VolgaCluster::launch(env, spec.launch).await?;
+    let result = run_scenario(&cluster, env, scenario, duration).await;
+    match cluster.shutdown().await {
+        Ok(()) => result,
+        Err(shutdown_err) => match result {
+            Ok(()) => Err(shutdown_err),
+            Err(run_err) => Err(run_err),
+        },
+    }
+}
+
+async fn run_scenario(
+    cluster: &VolgaCluster,
+    env: RuntimeEnv,
+    scenario: SoakScenario,
+    duration: Duration,
+) -> Result<()> {
+    let timeouts = RecoveryTimeouts::for_env(env);
+    let mut cursor = 0u64;
+    cluster.start_execution().await?;
+    let started = Instant::now();
+
+    wait_until_attempt0_running(&cluster.master(), &mut cursor, timeouts.attempt_running).await?;
+    println!("[volga-longrun] attempt 0 running");
+
+    match scenario {
+        SoakScenario::Steady => {}
+        SoakScenario::KillAfterCheckpoint { after_checkpoint } => {
+            run_kill_after_checkpoint(cluster, &timeouts, &mut cursor, after_checkpoint).await?;
+        }
+    }
+
+    let remaining = duration.saturating_sub(started.elapsed());
+    if remaining > Duration::ZERO {
+        println!("[volga-longrun] running for remaining {remaining:?}");
+        tokio::select! {
+            _ = tokio::time::sleep(remaining) => {}
+            _ = shutdown_signal() => {
+                println!("[volga-longrun] interrupt, shutting down");
+            }
+        }
+    }
+
+    println!(
+        "[volga-longrun] soak finished elapsed={:?}",
+        started.elapsed()
+    );
+    Ok(())
+}
+
+async fn run_kill_after_checkpoint(
+    cluster: &VolgaCluster,
+    timeouts: &RecoveryTimeouts,
+    cursor: &mut u64,
+    after_checkpoint: u64,
+) -> Result<()> {
+    if after_checkpoint < 1 {
+        return Err(anyhow!("kill-after-checkpoint must be >= 1"));
+    }
+
+    let mut checkpoint_id = 0u64;
+    for n in 1..=after_checkpoint {
+        checkpoint_id =
+            wait_for_checkpoint_completed(&cluster.master(), cursor, CHECKPOINT_WAIT).await?;
+        println!("[volga-longrun] checkpoint {checkpoint_id} completed ({n}/{after_checkpoint})");
+    }
+
+    wait_until_checkpoints_idle(&cluster.master(), CHECKPOINT_IDLE).await?;
+
+    let worker_ids = cluster.worker_ids();
+    let target = worker_ids
+        .first()
+        .ok_or_else(|| anyhow!("expected at least one worker"))?;
+    println!("[volga-longrun] kill worker={target} after checkpoint>={checkpoint_id}");
+    cluster
+        .worker(target)
+        .ok_or_else(|| anyhow!("missing worker {target}"))?
+        .kill_with(WorkerKillMode::Abrupt)
+        .await?;
+
+    let restore_timeout =
+        timeouts.recovery_started + timeouts.replacement + timeouts.attempt1_running;
+    let attempt_id = wait_for_kill_restore(
+        &cluster.master(),
+        cursor,
+        restore_timeout,
+        target,
+        checkpoint_id,
+        1,
+    )
+    .await?;
+    wait_until_attempt_running(
+        &cluster.master(),
+        cursor,
+        timeouts.attempt1_running,
+        attempt_id,
+        worker_ids.len(),
+    )
+    .await?;
+    println!("[volga-longrun] restore attempt={attempt_id} running");
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sigterm = signal(SignalKind::terminate()).expect("SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}

--- a/src/longrun/spec.rs
+++ b/src/longrun/spec.rs
@@ -68,7 +68,7 @@ impl SoakSpec {
     pub fn new(env: RuntimeEnv, scenario: SoakScenario, duration: Duration) -> Self {
         Self {
             env,
-            launch: soak_window_launch_spec(duration),
+            launch: soak_window_launch_spec(),
             scenario,
             duration,
             oracles: SoakOracleConfig::default(),

--- a/src/longrun/spec.rs
+++ b/src/longrun/spec.rs
@@ -1,0 +1,85 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::test_utils::harness::{PipelineLaunchSpec, RuntimeEnv};
+
+use super::job::soak_window_launch_spec;
+
+/// Kind-calibrated defaults. PR G evaluates these against Prom `query_range`; unused in E.
+#[derive(Clone, Debug)]
+pub struct SoakOracleConfig {
+    /// Fail if watermark lag is unchanged this long while `records_sent` still increases.
+    pub watermark_stale_while_sending: Duration,
+    /// Fail if lag p99 exceeds this for [`Self::lag_p99_sustain`].
+    pub lag_p99: Duration,
+    pub lag_p99_sustain: Duration,
+    /// Fail if no completed checkpoint within this many interval multiples (prod = 30s).
+    pub checkpoint_silence_intervals: u32,
+    /// Fail if checkpoint `failed` increases outside the injected-kill window.
+    pub allow_checkpoint_fail_outside_kill: bool,
+    /// Fail on WorkerPanic / HeartbeatUnavailable / pod restart outside KillAfterCheckpoint.
+    pub allow_unexpected_fatal: bool,
+    /// After restore, lag must be under bound within this window.
+    pub restore_catchup: Duration,
+}
+
+impl Default for SoakOracleConfig {
+    fn default() -> Self {
+        Self {
+            watermark_stale_while_sending: Duration::from_secs(30),
+            lag_p99: Duration::from_secs(15),
+            lag_p99_sustain: Duration::from_secs(60),
+            checkpoint_silence_intervals: 3,
+            allow_checkpoint_fail_outside_kill: false,
+            allow_unexpected_fatal: false,
+            restore_catchup: Duration::from_secs(60),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SoakScenario {
+    Steady,
+    KillAfterCheckpoint { after_checkpoint: u64 },
+}
+
+impl SoakScenario {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Steady => "steady",
+            Self::KillAfterCheckpoint { .. } => "kill",
+        }
+    }
+}
+
+/// What [`PipelineLaunchSpec`] does not have: env, scenario, duration, later dump/oracles.
+#[derive(Clone, Debug)]
+pub struct SoakSpec {
+    pub env: RuntimeEnv,
+    pub launch: PipelineLaunchSpec,
+    pub scenario: SoakScenario,
+    pub duration: Duration,
+    pub oracles: SoakOracleConfig,
+    /// Teardown Prom dump directory. PR G writes `query_range` here.
+    pub dump: Option<PathBuf>,
+}
+
+impl SoakSpec {
+    pub fn new(env: RuntimeEnv, scenario: SoakScenario, duration: Duration) -> Self {
+        Self {
+            env,
+            launch: soak_window_launch_spec(duration),
+            scenario,
+            duration,
+            oracles: SoakOracleConfig::default(),
+            dump: None,
+        }
+    }
+
+    pub fn default_duration_secs(env: RuntimeEnv) -> u64 {
+        match env {
+            RuntimeEnv::Local => 120,
+            RuntimeEnv::Docker | RuntimeEnv::Kube => 3600,
+        }
+    }
+}

--- a/src/test_utils/checkpoint/launch.rs
+++ b/src/test_utils/checkpoint/launch.rs
@@ -152,7 +152,7 @@ pub fn checkpoint_recovery_launch_spec(
         ]))
         .build();
 
-    PipelineLaunchSpec::new(pipeline, worker_count, 0)
+    PipelineLaunchSpec::new(pipeline, worker_count, None)
 }
 
 /// Multi-worker launch for sequential multi-failure stress (same indefinite datagen).

--- a/src/test_utils/checkpoint/mod.rs
+++ b/src/test_utils/checkpoint/mod.rs
@@ -21,5 +21,5 @@ pub use mid_flight::{
 };
 pub use support::{
     wait_for_checkpoint_completed, wait_for_checkpoint_completed_id, wait_for_checkpoint_started,
-    wait_until_checkpoints_idle,
+    wait_until_attempt0_running, wait_until_attempt_running, wait_until_checkpoints_idle,
 };

--- a/src/test_utils/checkpoint/support.rs
+++ b/src/test_utils/checkpoint/support.rs
@@ -17,7 +17,12 @@ pub async fn wait_until_attempt0_running(
         cursor,
         timeout,
         "AttemptRunning attempt=0",
-        |event| matches!(event, LifecycleEvent::AttemptRunning { attempt_id: 0, .. }),
+        |event| {
+            matches!(
+                event,
+                LifecycleEvent::AttemptRunning { attempt_id: 0, .. }
+            )
+        },
     )
     .await?;
     Ok(())
@@ -54,7 +59,10 @@ pub async fn wait_until_attempt_running(
 /// The timeout budget resets whenever the in-flight set changes so a chain of
 /// interval checkpoints (2 → 3 → 4) each get a full settle window rather than
 /// sharing one deadline from the first open CP.
-pub async fn wait_until_checkpoints_idle(master: &MasterHandle, timeout: Duration) -> Result<()> {
+pub async fn wait_until_checkpoints_idle(
+    master: &MasterHandle,
+    timeout: Duration,
+) -> Result<()> {
     let mut started = Instant::now();
     let mut last_open = HashSet::new();
     loop {
@@ -79,9 +87,7 @@ pub async fn wait_until_checkpoints_idle(master: &MasterHandle, timeout: Duratio
             last_open = open.clone();
         }
         if started.elapsed() >= timeout {
-            return Err(anyhow!(
-                "timed out waiting for in-flight checkpoint(s) {open:?} to settle"
-            ));
+            return Err(anyhow!("timed out waiting for in-flight checkpoint(s) {open:?} to settle"));
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
     }

--- a/src/test_utils/checkpoint/support.rs
+++ b/src/test_utils/checkpoint/support.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use crate::runtime::master::LifecycleEvent;
 use crate::test_utils::harness::{LifecycleOracle, MasterHandle, RuntimeEnv, VolgaCluster};
 
-pub(super) async fn wait_until_attempt0_running(
+pub async fn wait_until_attempt0_running(
     master: &MasterHandle,
     cursor: &mut u64,
     timeout: Duration,
@@ -17,18 +17,13 @@ pub(super) async fn wait_until_attempt0_running(
         cursor,
         timeout,
         "AttemptRunning attempt=0",
-        |event| {
-            matches!(
-                event,
-                LifecycleEvent::AttemptRunning { attempt_id: 0, .. }
-            )
-        },
+        |event| matches!(event, LifecycleEvent::AttemptRunning { attempt_id: 0, .. }),
     )
     .await?;
     Ok(())
 }
 
-pub(super) async fn wait_until_attempt_running(
+pub async fn wait_until_attempt_running(
     master: &MasterHandle,
     cursor: &mut u64,
     timeout: Duration,
@@ -59,10 +54,7 @@ pub(super) async fn wait_until_attempt_running(
 /// The timeout budget resets whenever the in-flight set changes so a chain of
 /// interval checkpoints (2 → 3 → 4) each get a full settle window rather than
 /// sharing one deadline from the first open CP.
-pub async fn wait_until_checkpoints_idle(
-    master: &MasterHandle,
-    timeout: Duration,
-) -> Result<()> {
+pub async fn wait_until_checkpoints_idle(master: &MasterHandle, timeout: Duration) -> Result<()> {
     let mut started = Instant::now();
     let mut last_open = HashSet::new();
     loop {
@@ -87,7 +79,9 @@ pub async fn wait_until_checkpoints_idle(
             last_open = open.clone();
         }
         if started.elapsed() >= timeout {
-            return Err(anyhow!("timed out waiting for in-flight checkpoint(s) {open:?} to settle"));
+            return Err(anyhow!(
+                "timed out waiting for in-flight checkpoint(s) {open:?} to settle"
+            ));
         }
         tokio::time::sleep(Duration::from_millis(25)).await;
     }

--- a/src/test_utils/harness/mod.rs
+++ b/src/test_utils/harness/mod.rs
@@ -88,7 +88,8 @@ pub enum FaultAction {
 pub struct PipelineLaunchSpec {
     pub pipeline: PipelineSpec,
     pub worker_count: usize,
-    pub expected_output_rows: usize,
+    /// `None` when the run does not wait on sink row count (`wait_for_completion`).
+    pub expected_output_rows: Option<usize>,
     /// Kube only: sets `volga.io/kube-worker-health-poll` on the pipeline CR.
     /// Master reads it at poll start (env overrides). Default `true`.
     pub kube_worker_health_poll: bool,
@@ -98,7 +99,7 @@ pub struct PipelineLaunchSpec {
 }
 
 impl PipelineLaunchSpec {
-    pub fn new(pipeline: PipelineSpec, worker_count: usize, expected_output_rows: usize) -> Self {
+    pub fn new(pipeline: PipelineSpec, worker_count: usize, expected_output_rows: Option<usize>) -> Self {
         let mut pipeline = pipeline;
         // Cluster e2e (local/docker/kube) always run store maintenance by default.
         pipeline.state.maintenance_enabled = true;

--- a/src/test_utils/harness/mod.rs
+++ b/src/test_utils/harness/mod.rs
@@ -29,6 +29,31 @@ pub enum RuntimeEnv {
     Kube,
 }
 
+impl RuntimeEnv {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Docker => "docker",
+            Self::Kube => "kube",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "local" => Some(Self::Local),
+            "docker" => Some(Self::Docker),
+            "kube" | "kubernetes" => Some(Self::Kube),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for RuntimeEnv {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// How a worker kill is simulated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WorkerKillMode {
@@ -52,7 +77,9 @@ pub enum FaultAction {
         worker_id: String,
         mode: WorkerKillMode,
     },
-    RestartWorker { worker_id: String },
+    RestartWorker {
+        worker_id: String,
+    },
     KillMaster,
     RestartMaster,
 }

--- a/src/test_utils/harness/resources/docker.rs
+++ b/src/test_utils/harness/resources/docker.rs
@@ -15,11 +15,11 @@ use crate::runtime::master::server::master_service::GetLifecycleEventsRequest;
 use crate::runtime::master::LifecycleEvent;
 use crate::runtime::master::LifecycleEventRecord;
 use crate::runtime::observability::{PipelineSnapshot, StreamTaskStatus};
-use crate::test_utils::harness::backend::ClusterBackend;
-use crate::test_utils::harness::PipelineLaunchSpec;
-use crate::test_utils::harness::FaultAction;
-use crate::storage::InMemoryStorageSnapshot;
 use crate::storage::InMemoryStorageClient;
+use crate::storage::InMemoryStorageSnapshot;
+use crate::test_utils::harness::backend::ClusterBackend;
+use crate::test_utils::harness::FaultAction;
+use crate::test_utils::harness::PipelineLaunchSpec;
 use async_trait::async_trait;
 
 struct DockerResources {
@@ -160,10 +160,7 @@ impl ClusterBackend for DockerCluster {
             .await
     }
 
-    async fn lifecycle_events_since(
-        &mut self,
-        sequence: u64,
-    ) -> Result<Vec<LifecycleEventRecord>> {
+    async fn lifecycle_events_since(&mut self, sequence: u64) -> Result<Vec<LifecycleEventRecord>> {
         let resources = self
             .resources
             .as_ref()
@@ -195,7 +192,10 @@ impl ClusterBackend for DockerCluster {
     }
 
     async fn apply_fault(&mut self, fault: FaultAction) -> Result<()> {
-        let resources = self.resources.as_ref().context("docker cluster is not launched")?;
+        let resources = self
+            .resources
+            .as_ref()
+            .context("docker cluster is not launched")?;
         match fault {
             FaultAction::KillWorker { worker_id, mode: _ } => resources.kill(&worker_id),
             FaultAction::RestartWorker { worker_id } => resources.restart(&worker_id),
@@ -240,10 +240,7 @@ impl DockerClusterResources {
             if response.has_snapshot {
                 let snapshot: PipelineSnapshot = bincode::deserialize(&response.snapshot_bytes)?;
                 let all_done = snapshot.worker_states.values().all(|worker| {
-                    worker.all_tasks_in(&[
-                        StreamTaskStatus::Finished,
-                        StreamTaskStatus::Closed,
-                    ])
+                    worker.all_tasks_in(&[StreamTaskStatus::Finished, StreamTaskStatus::Closed])
                 });
                 if all_done && snapshot.worker_states.len() == self.expected_workers {
                     break;
@@ -292,10 +289,7 @@ async fn connect_master(port: u16) -> Result<MasterServiceClient<tonic::transpor
         .map_err(|error| anyhow!("failed to connect to master: {error}"))
 }
 
-async fn fetch_lifecycle_events(
-    port: u16,
-    sequence: u64,
-) -> Result<Vec<LifecycleEventRecord>> {
+async fn fetch_lifecycle_events(port: u16, sequence: u64) -> Result<Vec<LifecycleEventRecord>> {
     let mut client = connect_master(port).await?;
     client
         .get_lifecycle_events(tonic::Request::new(GetLifecycleEventsRequest {
@@ -306,8 +300,8 @@ async fn fetch_lifecycle_events(
         .events
         .into_iter()
         .map(|record| {
-            let event: LifecycleEvent = bincode::deserialize(&record.event_bytes)
-                .with_context(|| {
+            let event: LifecycleEvent =
+                bincode::deserialize(&record.event_bytes).with_context(|| {
                     format!(
                         "failed to decode lifecycle event sequence={} bytes={}",
                         record.sequence,

--- a/src/test_utils/harness/resources/kube.rs
+++ b/src/test_utils/harness/resources/kube.rs
@@ -8,17 +8,17 @@ use serde_json::Value;
 use uuid::Uuid;
 
 use crate::api::PipelineSpec;
-use crate::common::ports::gen_unique_grpc_port;
-use crate::test_utils::harness::PipelineLaunchSpec;
-use crate::test_utils::harness::backend::ClusterBackend;
-use crate::test_utils::harness::FaultAction;
-use crate::storage::InMemoryStorageSnapshot;
-use crate::runtime::master::LifecycleEvent;
-use crate::runtime::master::LifecycleEventRecord;
 use crate::common::grpc::master::master_client;
 use crate::common::grpc::GrpcConfig;
+use crate::common::ports::gen_unique_grpc_port;
 use crate::runtime::master::server::master_service::GetLifecycleEventsRequest;
+use crate::runtime::master::LifecycleEvent;
+use crate::runtime::master::LifecycleEventRecord;
 use crate::storage::InMemoryStorageClient;
+use crate::storage::InMemoryStorageSnapshot;
+use crate::test_utils::harness::backend::ClusterBackend;
+use crate::test_utils::harness::FaultAction;
+use crate::test_utils::harness::PipelineLaunchSpec;
 use async_trait::async_trait;
 
 struct KubeResources {
@@ -104,10 +104,7 @@ impl ClusterBackend for KubeCluster {
             .await
     }
 
-    async fn lifecycle_events_since(
-        &mut self,
-        sequence: u64,
-    ) -> Result<Vec<LifecycleEventRecord>> {
+    async fn lifecycle_events_since(&mut self, sequence: u64) -> Result<Vec<LifecycleEventRecord>> {
         let master_port = self
             .resources
             .as_ref()
@@ -140,7 +137,10 @@ impl ClusterBackend for KubeCluster {
     }
 
     async fn apply_fault(&mut self, fault: FaultAction) -> Result<()> {
-        let resources = self.resources.as_ref().context("kube cluster is not launched")?;
+        let resources = self
+            .resources
+            .as_ref()
+            .context("kube cluster is not launched")?;
         match fault {
             FaultAction::KillWorker { worker_id, mode: _ }
             | FaultAction::RestartWorker { worker_id } => resources.delete_worker_pod(&worker_id),
@@ -373,14 +373,8 @@ fn wait_for_pipeline(pipeline_name: &str) -> Result<()> {
 fn wait_for_pipeline_deleted(pipeline_name: &str) -> Result<()> {
     let start = std::time::Instant::now();
     loop {
-        let pipeline_deleted = kubectl(&[
-            "-n",
-            "default",
-            "get",
-            "volgapipeline",
-            pipeline_name,
-        ])
-        .is_err();
+        let pipeline_deleted =
+            kubectl(&["-n", "default", "get", "volgapipeline", pipeline_name]).is_err();
         let pods_deleted = kubectl(&[
             "-n",
             "default",
@@ -422,7 +416,9 @@ fn wait_for_no_pods(label: &str) -> Result<()> {
             return Ok(());
         }
         if start.elapsed() > Duration::from_secs(120) {
-            return Err(anyhow!("timeout waiting for pods matching {label} to terminate"));
+            return Err(anyhow!(
+                "timeout waiting for pods matching {label} to terminate"
+            ));
         }
         std::thread::sleep(Duration::from_secs(1));
     }
@@ -477,8 +473,7 @@ async fn fetch_lifecycle_events(
     master_port: u16,
     sequence: u64,
 ) -> Result<Vec<LifecycleEventRecord>> {
-    let mut client =
-        master_client(&format!("127.0.0.1:{master_port}"), &GrpcConfig::new()).await?;
+    let mut client = master_client(&format!("127.0.0.1:{master_port}"), &GrpcConfig::new()).await?;
     client
         .get_lifecycle_events(tonic::Request::new(GetLifecycleEventsRequest {
             after_sequence: sequence,
@@ -488,8 +483,8 @@ async fn fetch_lifecycle_events(
         .events
         .into_iter()
         .map(|record| {
-            let event: LifecycleEvent = bincode::deserialize(&record.event_bytes)
-                .with_context(|| {
+            let event: LifecycleEvent =
+                bincode::deserialize(&record.event_bytes).with_context(|| {
                     format!(
                         "failed to decode lifecycle event sequence={} bytes={}",
                         record.sequence,
@@ -507,8 +502,7 @@ async fn fetch_lifecycle_events(
 async fn master_latest_pipeline_snapshot(
     master_port: u16,
 ) -> Result<Option<crate::runtime::observability::PipelineSnapshot>> {
-    let mut client =
-        master_client(&format!("127.0.0.1:{master_port}"), &GrpcConfig::new()).await?;
+    let mut client = master_client(&format!("127.0.0.1:{master_port}"), &GrpcConfig::new()).await?;
     let response = client
         .get_latest_pipeline_snapshot(tonic::Request::new(
             crate::runtime::master::server::master_service::GetLatestPipelineSnapshotRequest {},
@@ -522,8 +516,7 @@ async fn master_latest_pipeline_snapshot(
 }
 
 async fn master_stop_sources(master_port: u16) -> Result<()> {
-    let mut client =
-        master_client(&format!("127.0.0.1:{master_port}"), &GrpcConfig::new()).await?;
+    let mut client = master_client(&format!("127.0.0.1:{master_port}"), &GrpcConfig::new()).await?;
     let response = client
         .stop_sources(tonic::Request::new(
             crate::runtime::master::server::master_service::StopSourcesRequest {},

--- a/src/test_utils/harness/resources/kube.rs
+++ b/src/test_utils/harness/resources/kube.rs
@@ -53,7 +53,7 @@ impl KubeResources {
 pub struct KubeClusterResources {
     resources: Option<KubeResources>,
     storage_endpoint: Option<String>,
-    expected_output_rows: usize,
+    expected_output_rows: Option<usize>,
     worker_ids: Vec<String>,
 }
 
@@ -198,9 +198,12 @@ impl KubeClusterResources {
     }
 
     pub async fn wait_for_completion(&mut self) -> Result<()> {
+        let expected = self
+            .expected_output_rows
+            .context("wait_for_completion requires expected_output_rows")?;
         let start = tokio::time::Instant::now();
         loop {
-            if self.storage_snapshot().await?.row_count() >= self.expected_output_rows {
+            if self.storage_snapshot().await?.row_count() >= expected {
                 return Ok(());
             }
             if start.elapsed() > Duration::from_secs(120) {

--- a/src/test_utils/launch_specs.rs
+++ b/src/test_utils/launch_specs.rs
@@ -56,7 +56,7 @@ pub fn smoke_launch_spec(
         ))
         .sql("SELECT value FROM test_table")
         .build();
-    PipelineLaunchSpec::new(pipeline, worker_count, rows)
+    PipelineLaunchSpec::new(pipeline, worker_count, Some(rows))
 }
 
 pub fn deployment_smoke_launch_spec(generator: FieldGenerator) -> PipelineLaunchSpec {
@@ -90,7 +90,7 @@ pub fn deployment_smoke_launch_spec(generator: FieldGenerator) -> PipelineLaunch
         ))
         .sql("SELECT value FROM test_table")
         .build();
-    PipelineLaunchSpec::new(pipeline, WORKER_COUNT, EXPECTED_ROWS)
+    PipelineLaunchSpec::new(pipeline, WORKER_COUNT, Some(EXPECTED_ROWS))
 }
 
 pub fn worker_count_for(

--- a/src/test_utils/recovery.rs
+++ b/src/test_utils/recovery.rs
@@ -485,7 +485,7 @@ pub fn multi_worker_recovery_launch_spec() -> PipelineLaunchSpec {
 }
 
 fn apply_streaming_recovery_source(launch: &mut PipelineLaunchSpec) {
-    launch.expected_output_rows = 0;
+    launch.expected_output_rows = None;
     if let SourceSpecKind::Datagen(datagen) = &mut launch.pipeline.sources[0].source {
         datagen.rate = Some(50.0);
         datagen.limit = None;


### PR DESCRIPTION
## Summary
- Adds `volga-longrun soak` on top of `VolgaCluster`: same sliding RANGE window job, `SinkSpec::Count`, Datagen `run_for_s` unset (soak loop owns duration), **prod 30s** checkpoints (not `kube_test` 2s).
- Scenarios: **Steady** (run for duration, watch `PipelineFailed`) and **KillAfterCheckpoint** (wait N completed CPs, abrupt kill, `wait_for_kill_restore`, continue). SIGINT wraps the whole scenario then shutdown.
- Count sink is **#234** (merged), not a second copy. It still appears in this PR’s file list because the GitHub base is **#236** (`feat/test-utils`), which does not contain Count. Do not merge D with B.
- Harness starts the in-memory store only when the sink needs it (`pipeline_needs_in_memory_store` on the D path).

`volga-longrun bench` and Prom dump/oracles are **#239**. Empty `FlinkCluster` stub only.

Stacked on **#236**. Includes **#234** via merge. Do not merge with **#233** / **#239**.

## Test plan
- [x] `./scripts/test unit --filter 'test(/longrun::/)'` (kill parse + reject)
- [ ] `cargo run --bin volga-longrun -- soak --env local --duration-secs 120`
- [ ] `cargo run --bin volga-longrun -- soak --env local --scenario kill --duration-secs 180`
- [ ] `soak --env kube` on Kind (Count must not spawn `volga-test-storage`)