### PR TITLE
Add Prom + Grafana soak dashboard

### DIFF
--- a/kubevolga/Makefile
+++ b/kubevolga/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 KUBECTL ?= kubectl
 KUSTOMIZE ?= $(KUBECTL) kustomize
 
-.PHONY: install uninstall deploy undeploy sample unsample render
+.PHONY: install uninstall deploy undeploy sample unsample render bench unbench
 
 install:
 	$(KUSTOMIZE) config/crd | $(KUBECTL) apply -f -
@@ -25,3 +25,10 @@ unsample:
 
 render:
 	$(KUSTOMIZE) config/default
+
+# Prom + Grafana on infra (kubevolga/hack/bench). Opt-in; not part of kube tests.
+bench:
+	$(KUSTOMIZE) hack/bench | $(KUBECTL) apply -f -
+
+unbench:
+	$(KUSTOMIZE) hack/bench | $(KUBECTL) delete --ignore-not-found=true -f -

--- a/kubevolga/hack/bench/dashboards/volga-soak.json
+++ b/kubevolga/hack/bench/dashboards/volga-soak.json
@@ -1,0 +1,444 @@
+{
+  "uid": "volga-soak",
+  "title": "Volga soak",
+  "tags": [
+    "volga",
+    "soak"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "5s",
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "pipeline",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values(volga_checkpoint_completed_total, pipeline_id)",
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Job health",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "increase(volga_checkpoint_completed_total{pipeline_id=~\"$pipeline\"}[5m])",
+          "legendFormat": "completed",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "increase(volga_checkpoint_failed_total{pipeline_id=~\"$pipeline\"}[5m])",
+          "legendFormat": "failed",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(volga_checkpoint_duration_ms_bucket{pipeline_id=~\"$pipeline\"}[1m])))",
+          "legendFormat": "duration p99",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Job-level checkpoint counters and success-only duration histogram."
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Task time (ms / s, stack \u2248 1000)",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg by (task_id) (volga_stream_task_busy_time_ms_per_second{pipeline_id=~\"$pipeline\"})",
+          "legendFormat": "busy {{task_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg by (task_id) (volga_stream_task_idle_time_ms_per_second{pipeline_id=~\"$pipeline\"})",
+          "legendFormat": "idle {{task_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg by (task_id) (volga_stream_task_backpressured_time_ms_per_second{pipeline_id=~\"$pipeline\"})",
+          "legendFormat": "backpressured {{task_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Event-time lag",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "quantile(0.50, volga_stream_task_watermark_lag_ms{pipeline_id=~\"$pipeline\"})",
+          "legendFormat": "lag p50",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "quantile(0.99, volga_stream_task_watermark_lag_ms{pipeline_id=~\"$pipeline\"})",
+          "legendFormat": "lag p99",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Per-task lag gauges; quantile across tasks (not a histogram)."
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Throughput",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(volga_stream_task_records_sent_total{pipeline_id=~\"$pipeline\"}[1m]))",
+          "legendFormat": "records sent / s",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(volga_sink_records_written_total{pipeline_id=~\"$pipeline\"}[1m]))",
+          "legendFormat": "sink records / s",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Window operator",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(volga_wo_ingest_ms_bucket{pipeline_id=~\"$pipeline\"}[1m])))",
+          "legendFormat": "ingest p99",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(volga_wo_late_dropped_rows_total{pipeline_id=~\"$pipeline\"}[1m]))",
+          "legendFormat": "late dropped / s",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(volga_wo_maintain_pruned_rows_total{pipeline_id=~\"$pipeline\"}[1m]))",
+          "legendFormat": "pruned / s",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(volga_wo_state_raw_bytes{pipeline_id=~\"$pipeline\"}) + sum(volga_wo_state_tiles_bytes{pipeline_id=~\"$pipeline\"}) + sum(volga_wo_state_triggers_bytes{pipeline_id=~\"$pipeline\"}) + sum(volga_wo_state_key_states_bytes{pipeline_id=~\"$pipeline\"})",
+          "legendFormat": "state bytes",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Empty until a window operator emits series."
+    }
+  ]
+}

--- a/kubevolga/hack/bench/grafana-dashboards.yaml
+++ b/kubevolga/hack/bench/grafana-dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+providers:
+  - name: volga
+    orgId: 1
+    folder: Volga
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/kubevolga/hack/bench/grafana-datasources.yaml
+++ b/kubevolga/hack/bench/grafana-datasources.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/kubevolga/hack/bench/grafana.yaml
+++ b/kubevolga/hack/bench/grafana.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: volga-bench
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: volga-bench
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+        app.kubernetes.io/part-of: volga-bench
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: volga.io/role
+                    operator: In
+                    values:
+                      - infra
+      containers:
+        - name: grafana
+          image: grafana/grafana:11.3.1
+          env:
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: Viewer
+            - name: GF_AUTH_DISABLE_LOGIN_FORM
+              value: "false"
+            - name: GF_USERS_DEFAULT_THEME
+              value: dark
+            - name: GF_PATHS_DATA
+              value: /var/lib/grafana-data
+            - name: GF_PATHS_PROVISIONING
+              value: /etc/grafana/provisioning
+            - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
+              value: /var/lib/grafana/dashboards/volga-soak.json
+          ports:
+            - name: http
+              containerPort: 3000
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+              readOnly: true
+            - name: dashboard-provider
+              mountPath: /etc/grafana/provisioning/dashboards
+              readOnly: true
+            - name: dashboards
+              mountPath: /var/lib/grafana/dashboards
+              readOnly: true
+            - name: data
+              mountPath: /var/lib/grafana-data
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: dashboard-provider
+          configMap:
+            name: grafana-dashboard-provider
+        - name: dashboards
+          configMap:
+            name: grafana-dashboards
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: volga-bench
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: volga-bench
+spec:
+  selector:
+    app.kubernetes.io/name: grafana
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http

--- a/kubevolga/hack/bench/kustomization.yaml
+++ b/kubevolga/hack/bench/kustomization.yaml
@@ -1,0 +1,27 @@
+# Lightweight Prom + Grafana for Volga soak (not kube-prometheus-stack).
+# Apply: kubectl apply -k kubevolga/hack/bench
+# UI:    kubectl -n volga-bench port-forward svc/grafana 3000:3000
+# Scrapes pods with prometheus.io/{scrape,port,path} (PR A). Prefers infra nodes (PR C).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: volga-bench
+resources:
+  - namespace.yaml
+  - rbac.yaml
+  - prometheus.yaml
+  - grafana.yaml
+configMapGenerator:
+  - name: prometheus-config
+    files:
+      - prometheus.yml
+  - name: grafana-datasources
+    files:
+      - datasources.yaml=grafana-datasources.yaml
+  - name: grafana-dashboard-provider
+    files:
+      - dashboards.yaml=grafana-dashboards.yaml
+  - name: grafana-dashboards
+    files:
+      - volga-soak.json=dashboards/volga-soak.json
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubevolga/hack/bench/namespace.yaml
+++ b/kubevolga/hack/bench/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volga-bench

--- a/kubevolga/hack/bench/prometheus.yaml
+++ b/kubevolga/hack/bench/prometheus.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: volga-bench
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: volga-bench
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/part-of: volga-bench
+    spec:
+      serviceAccountName: prometheus
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: volga.io/role
+                    operator: In
+                    values:
+                      - infra
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v2.54.1
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=24h
+            - --web.enable-lifecycle
+          ports:
+            - name: http
+              containerPort: 9090
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/prometheus
+              readOnly: true
+            - name: data
+              mountPath: /prometheus
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 20
+      volumes:
+        - name: config
+          configMap:
+            name: prometheus-config
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: volga-bench
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: volga-bench
+spec:
+  selector:
+    app.kubernetes.io/name: prometheus
+  ports:
+    - name: http
+      port: 9090
+      targetPort: http

--- a/kubevolga/hack/bench/prometheus.yml
+++ b/kubevolga/hack/bench/prometheus.yml
@@ -1,0 +1,28 @@
+global:
+  scrape_interval: 5s
+  scrape_timeout: 4s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: volga
+    kubernetes_sd_configs:
+      - role: pod
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: "true"
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        target_label: kubernetes_pod

--- a/kubevolga/hack/bench/rbac.yaml
+++ b/kubevolga/hack/bench/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: volga-bench
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: volga-bench-prometheus
+rules:
+  - apiGroups: [""]
+    resources: [nodes, nodes/metrics, nodes/proxy, services, endpoints, pods]
+    verbs: [get, list, watch]
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: volga-bench-prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: volga-bench-prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: volga-bench


### PR DESCRIPTION
## Summary
- Adds `kubevolga/hack/bench`: Prometheus (`5s` scrape of `prometheus.io/{scrape,port,path}` pods) + Grafana with the soak board provisioned as home.
- Prefers `volga.io/role=infra` (soft affinity). Not kube-prometheus-stack; not part of `scripts/kube-test-env`.
- Dashboard rows: job checkpoints, stacked busy/idle/backpressured ms/s, watermark lag p50/p99, throughput, window operator (empty until those series exist).

Rebased onto current **#235** (1-node Kind, no role taints). Still needs **#233** for the `/metrics` listener and scrape annotations — not folded in, so this PR stays bench YAML only. Until A lands, Prom will see zero Volga targets.

```bash
make -C kubevolga bench
kubectl -n volga-bench port-forward svc/grafana 3000:3000
```

## Test plan
- [x] `kubectl kustomize kubevolga/hack/bench` renders Namespace, Prom, Grafana, dashboard ConfigMap
- [ ] `scripts/test kube` on this branch (should no longer die in Kind setup)
- [ ] After #233+#235 on Kind: `make -C kubevolga bench`, confirm Grafana loads *Volga soak* and Prom has `volga_*` series while a pipeline runs
- [ ] Confirm Prom/Grafana land on the infra node when `volga.io/role=infra` exists