### PR TITLE
Kind infra + two tainted worker nodes for kube tests

### DIFF
--- a/kubevolga/README.md
+++ b/kubevolga/README.md
@@ -24,31 +24,21 @@ Kubernetes operator for Volga pipelines.
 
 ## Dev Flow
 
-From repo root:
+From repo root. The sample CR pins master to `volga.io/role=infra` and workers to
+tainted `volga.io/role=worker` nodes, so the cluster must match
+`kubevolga/hack/kind-multi.yaml` (default name `kubevolga`).
 
 ```bash
-# 1) Build/load operator image
-docker build -t kubevolga:dev ./kubevolga
-kind load docker-image kubevolga:dev --name kubevolga
+# Kind (infra + 2 worker nodes), images, CRD, operator
+scripts/kube-test-env setup
 
-# 2) Build/load Volga runtime image used by master/worker/test-storage
-docker build -t volga:latest .
-kind load docker-image volga:latest --name kubevolga
-
-# 3) Deploy operator stack and sample
 cd kubevolga
-make install   # CRD
-make deploy    # namespace + RBAC + operator
 make sample    # sample VolgaPipeline
 ```
 
-Cleanup:
-
-```bash
-make unsample
-make undeploy
-make uninstall
-```
+`scripts/kube-test-env setup` is `kind create --name kubevolga --config kubevolga/hack/kind-multi.yaml`
+plus image load and `make install deploy`. A single-node cluster with that name
+is recreated. Cleanup: `make unsample` / `scripts/kube-test-env destroy`.
 
 ## Image/Target Notes
 
@@ -83,7 +73,7 @@ Test file:
 
 Behavior summary:
 
-- Reads `kubevolga/config/samples/volga_v1alpha1_pipeline.yaml`.
+- Reads `kubevolga/config/samples/volga_v1alpha1_pipeline.yaml` (master on `volga.io/role=infra`, workers on tainted `volga.io/role=worker` nodes).
 - Patches at runtime:
   - pipeline `metadata.name` (unique UUID-based name)
   - CR sink `InMemoryStorageGrpc.create: true` plus `server_addr` `http://{name}-storage.default.svc.cluster.local:50071` when the job needs the store; Count left alone

--- a/kubevolga/config/samples/volga_v1alpha1_pipeline.yaml
+++ b/kubevolga/config/samples/volga_v1alpha1_pipeline.yaml
@@ -9,6 +9,8 @@ spec:
   image: volga:latest
   imagePullPolicy: IfNotPresent
   master:
+    nodeSelector:
+      volga.io/role: infra
     resources:
       requests:
         cpu: "500m"
@@ -17,6 +19,22 @@ spec:
         cpu: "2"
         memory: "2Gi"
   worker:
+    nodeSelector:
+      volga.io/role: worker
+    tolerations:
+      - key: volga.io/role
+        operator: Equal
+        value: worker
+        effect: NoSchedule
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  volga.io/component: worker
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: "500m"

--- a/kubevolga/hack/bench/grafana.yaml
+++ b/kubevolga/hack/bench/grafana.yaml
@@ -17,16 +17,8 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/part-of: volga-bench
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: volga.io/role
-                    operator: In
-                    values:
-                      - infra
+      nodeSelector:
+        volga.io/role: infra
       containers:
         - name: grafana
           image: grafana/grafana:11.3.1

--- a/kubevolga/hack/bench/kustomization.yaml
+++ b/kubevolga/hack/bench/kustomization.yaml
@@ -1,7 +1,7 @@
 # Lightweight Prom + Grafana for Volga bench (not kube-prometheus-stack).
 # Apply: kubectl apply -k kubevolga/hack/bench
 # UI:    kubectl -n volga-bench port-forward svc/grafana 3000:3000
-# Scrapes pods with prometheus.io/{scrape,port,path} (PR A). Prefers infra nodes (PR C).
+# Scrapes pods with prometheus.io/{scrape,port,path}. Requires infra nodes (kind-multi).
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: volga-bench

--- a/kubevolga/hack/bench/prometheus.yaml
+++ b/kubevolga/hack/bench/prometheus.yaml
@@ -18,16 +18,8 @@ spec:
         app.kubernetes.io/part-of: volga-bench
     spec:
       serviceAccountName: prometheus
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: volga.io/role
-                    operator: In
-                    values:
-                      - infra
+      nodeSelector:
+        volga.io/role: infra
       containers:
         - name: prometheus
           image: prom/prometheus:v2.54.1

--- a/kubevolga/hack/kind-multi.yaml
+++ b/kubevolga/hack/kind-multi.yaml
@@ -1,12 +1,22 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-# 1 control-plane + infra + 1 volga-worker (CI contract). CPU is still shared.
-# Labels/taints are also applied by scripts/kube-test-env after create.
+# Topology for `scripts/kube-test-env` (`kind create --name $VOLGA_KIND_CLUSTER --config`).
+# Do not set `name:` here: stress shards pass a different --name.
+# 1 control-plane + infra (untainted) + 2 worker nodes (tainted). CPU is still shared.
 nodes:
   - role: control-plane
   - role: worker
     labels:
       volga.io/role: infra
+  - role: worker
+    labels:
+      volga.io/role: worker
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            register-with-taints: "volga.io/role=worker:NoSchedule"
   - role: worker
     labels:
       volga.io/role: worker

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -168,3 +168,44 @@ Stress options:
 
 Timeouts are suite-scoped nextest profiles only (`default` 30s, `inprocess` 90s,
 `docker` 120s, `kube` 90s, `stress` 180s) — no per-test overrides.
+
+## Bench (`volga-bench`)
+
+Long-run job on the same Kind (or remote) cluster as kube tests. Not a
+`scripts/test` profile: YAML is the run spec; CLI only overrides `--env` and
+`--duration-secs`. Count sink + Datagen are fixed in code.
+
+```bash
+# 1) Kind + operator (infra + 2 tainted worker nodes). Recreates kubevolga if
+#    the current cluster is single-node.
+scripts/kube-test-env setup
+
+# 2) Prom + Grafana in namespace volga-bench (infra nodeSelector).
+make -C kubevolga bench
+
+# 3) Reach Prom (oracles/dump) and the Grafana board from the laptop.
+export VOLGA_KUBE_CONTEXT="${VOLGA_KUBE_CONTEXT:-kind-kubevolga}"
+kubectl --context "$VOLGA_KUBE_CONTEXT" -n volga-bench port-forward svc/prometheus 9090:9090 &
+kubectl --context "$VOLGA_KUBE_CONTEXT" -n volga-bench port-forward svc/grafana 3000:3000 &
+
+# 4) Short Kind smoke (example.yaml is a 1h kill scenario; override duration).
+cargo run --bin volga-bench -- \
+  --config kubevolga/hack/bench/example.yaml \
+  --env kube \
+  --duration-secs 120
+```
+
+Grafana: http://localhost:3000 (anonymous viewer; Volga bench is the home
+dashboard). Prom dump/oracles need `prom_url` in the YAML (example uses
+`http://127.0.0.1:9090` after the port-forward).
+
+| | Kind (local / CI wiring) | Remote cluster |
+| --- | --- | --- |
+| Cluster | `scripts/kube-test-env setup` | existing kubeconfig; skip Kind |
+| Context | `VOLGA_KUBE_CONTEXT=kind-kubevolga` | omit, or set to that context |
+| Observability | `make -C kubevolga bench` + port-forward | same manifests; port-forward or in-cluster `prom_url` |
+| Duration | `--duration-secs 120` to see the board | YAML `duration` (example: 1h) |
+| Numbers | scrape/oracles wiring only | overnight; not GitHub-hosted CI |
+
+`make -C kubevolga unbench` removes Prom/Grafana. `scripts/kube-test-env destroy`
+deletes the Kind cluster. Overnight soaks belong on a real cluster, not Kind.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -90,7 +90,9 @@ docker/kube jobs unless you pick an env-only profile).
 `all` runs `unit` + `inprocess` first, then docker/Kind setup only when those
 suites start. `scripts/docker-test-env setup` prefetches testcontainers images
 (LocalStack, Redpanda) before building `volga:latest`. Kube uses the Kind
-cluster named by `VOLGA_KIND_CLUSTER` (default: `kubevolga`).
+cluster named by `VOLGA_KIND_CLUSTER` (default: `kubevolga`), created from
+`kubevolga/hack/kind-multi.yaml` (control-plane + infra + 2 tainted worker
+nodes). A cluster without that topology is deleted and recreated.
 
 ### CI image cache
 

--- a/scripts/kube-test-env
+++ b/scripts/kube-test-env
@@ -4,6 +4,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLUSTER_NAME="${VOLGA_KIND_CLUSTER:-kubevolga}"
 CONTEXT="kind-$CLUSTER_NAME"
+KIND_CONFIG="$ROOT/kubevolga/hack/kind-multi.yaml"
+MIN_WORKER_NODES=2
+MIN_INFRA_NODES=1
 ACTION="${1:-setup}"
 REBUILD="${2:-}"
 
@@ -21,6 +24,32 @@ cluster_exists() {
 
 kubectl_test() {
   kubectl --context "$CONTEXT" "$@"
+}
+
+node_count_by_role() {
+  local role="$1"
+  kubectl_test get nodes -l "volga.io/role=$role" --no-headers 2>/dev/null |
+    wc -l |
+    tr -d ' '
+}
+
+cluster_has_topology() {
+  local workers infra
+  workers="$(node_count_by_role worker)"
+  infra="$(node_count_by_role infra)"
+  [[ "${workers:-0}" -ge "$MIN_WORKER_NODES" && "${infra:-0}" -ge "$MIN_INFRA_NODES" ]]
+}
+
+ensure_cluster() {
+  if cluster_exists; then
+    if cluster_has_topology; then
+      echo "using existing Kind cluster: $CLUSTER_NAME"
+      return
+    fi
+    echo "Kind cluster $CLUSTER_NAME is missing infra/worker topology; recreating"
+    kind delete cluster --name "$CLUSTER_NAME"
+  fi
+  kind create cluster --name "$CLUSTER_NAME" --config "$KIND_CONFIG"
 }
 
 cleanup_resources() {
@@ -48,12 +77,8 @@ setup() {
   require make
   docker info >/dev/null
 
-  if cluster_exists; then
-    echo "using existing Kind cluster: $CLUSTER_NAME"
-  else
-    kind create cluster --name "$CLUSTER_NAME"
-  fi
-  kubectl_test wait --for=condition=Ready nodes --all --timeout=120s
+  ensure_cluster
+  kubectl_test wait --for=condition=Ready nodes --all --timeout=180s
 
   # Shared Buildx/GHA cache with the docker job (scope=volga-image).
   if [[ "$REBUILD" == "--rebuild" ]]; then


### PR DESCRIPTION
## Summary
- `scripts/kube-test-env` creates the Kind cluster from `kubevolga/hack/kind-multi.yaml` (control-plane + infra + 2 worker nodes with `volga.io/role=worker:NoSchedule`). A cluster that lacks that topology is recreated.
- Sample CR pins master to infra and workers to the worker taint (selector + toleration + preferred anti-affinity). Prom/Grafana require the infra label.
- Cluster name stays `kubevolga` (`--name`); the Kind config has no `name:` so stress shards still work.

## Test plan
- [ ] `kind delete cluster --name test-cluster` if that leftover still exists
- [ ] `scripts/kube-test-env setup` recreates single-node `kubevolga` as 4 nodes; `kubectl get nodes --show-labels` shows 1 infra + 2 worker
- [ ] `./scripts/test kube` (or CI kube-tests job)
- [ ] `make -C kubevolga bench` — Prom/Grafana pods land on infra


Made with [Cursor](https://cursor.com)