### PR TITLE
Fix bench dump names, kill oracle, lag, and Grafana layout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,14 +14,14 @@ fail-fast = false
 slow-timeout = { period = "120s", terminate-after = 1 }
 fail-fast = false
 
-# Kind / kube (scripts/test kube).
+# Kind / kube (scripts/test kube) and scripts/stress-test. Must exceed the
+# harness kube kill-restore budget (recovery_started+replacement+
+# attempt1_running ≈ 300s) so nextest does not mask LifecycleOracle
+# diagnostics on slow replaces (4-node Kind, mid-flight kill after a safe CP).
 [profile.kube]
-slow-timeout = { period = "90s", terminate-after = 1 }
+slow-timeout = { period = "360s", terminate-after = 1 }
 fail-fast = false
 
-# scripts/stress-test (kube-heavy). Must exceed harness kube kill-restore
-# budget (recovery_started+replacement+attempt1_running ≈ 300s) so nextest
-# does not mask LifecycleOracle diagnostics on slow replaces.
 [profile.stress]
 slow-timeout = { period = "360s", terminate-after = 1 }
 fail-fast = false

--- a/kubevolga/README.md
+++ b/kubevolga/README.md
@@ -24,31 +24,21 @@ Kubernetes operator for Volga pipelines.
 
 ## Dev Flow
 
-From repo root:
+From repo root. The sample CR pins master to `volga.io/role=infra` and workers to
+tainted `volga.io/role=worker` nodes, so the cluster must match
+`kubevolga/hack/kind-multi.yaml` (default name `kubevolga`).
 
 ```bash
-# 1) Build/load operator image
-docker build -t kubevolga:dev ./kubevolga
-kind load docker-image kubevolga:dev --name kubevolga
+# Kind (infra + 2 worker nodes), images, CRD, operator
+scripts/kube-test-env setup
 
-# 2) Build/load Volga runtime image used by master/worker/test-storage
-docker build -t volga:latest .
-kind load docker-image volga:latest --name kubevolga
-
-# 3) Deploy operator stack and sample
 cd kubevolga
-make install   # CRD
-make deploy    # namespace + RBAC + operator
 make sample    # sample VolgaPipeline
 ```
 
-Cleanup:
-
-```bash
-make unsample
-make undeploy
-make uninstall
-```
+`scripts/kube-test-env setup` is `kind create --name kubevolga --config kubevolga/hack/kind-multi.yaml`
+plus image load and `make install deploy`. A single-node cluster with that name
+is recreated. Cleanup: `make unsample` / `scripts/kube-test-env destroy`.
 
 ## Image/Target Notes
 
@@ -83,7 +73,7 @@ Test file:
 
 Behavior summary:
 
-- Reads `kubevolga/config/samples/volga_v1alpha1_pipeline.yaml`.
+- Reads `kubevolga/config/samples/volga_v1alpha1_pipeline.yaml` (master on `volga.io/role=infra`, workers on tainted `volga.io/role=worker` nodes).
 - Patches at runtime:
   - pipeline `metadata.name` (unique UUID-based name)
   - CR sink `InMemoryStorageGrpc.create: true` plus `server_addr` `http://{name}-storage.default.svc.cluster.local:50071` when the job needs the store; Count left alone

--- a/kubevolga/config/samples/volga_v1alpha1_pipeline.yaml
+++ b/kubevolga/config/samples/volga_v1alpha1_pipeline.yaml
@@ -9,6 +9,8 @@ spec:
   image: volga:latest
   imagePullPolicy: IfNotPresent
   master:
+    nodeSelector:
+      volga.io/role: infra
     resources:
       requests:
         cpu: "500m"
@@ -17,6 +19,22 @@ spec:
         cpu: "2"
         memory: "2Gi"
   worker:
+    nodeSelector:
+      volga.io/role: worker
+    tolerations:
+      - key: volga.io/role
+        operator: Equal
+        value: worker
+        effect: NoSchedule
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  volga.io/component: worker
+              topologyKey: kubernetes.io/hostname
     resources:
       requests:
         cpu: "500m"

--- a/kubevolga/hack/bench/dashboards/volga-bench.json
+++ b/kubevolga/hack/bench/dashboards/volga-bench.json
@@ -7,7 +7,7 @@
   ],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 1,
+  "version": 2,
   "refresh": "5s",
   "time": {
     "from": "now-15m",
@@ -22,7 +22,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "query": "label_values(volga_checkpoint_completed_total, pipeline_id)",
+        "query": "label_values(volga_stream_task_busy_time_ms_per_second, pipeline_id)",
         "includeAll": true,
         "multi": true,
         "allValue": ".*",
@@ -32,20 +32,74 @@
         },
         "refresh": 2,
         "sort": 1,
-        "hide": 0
+        "hide": 0,
+        "label": "pipeline"
+      },
+      {
+        "name": "worker",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values(volga_stream_task_busy_time_ms_per_second{pipeline_id=~\"$pipeline\"}, worker_id)",
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0,
+        "label": "worker"
+      },
+      {
+        "name": "task",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "query": "label_values(volga_stream_task_busy_time_ms_per_second{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\"}, task_id)",
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "hide": 0,
+        "label": "task"
       }
     ]
   },
   "panels": [
     {
-      "id": 1,
-      "type": "timeseries",
-      "title": "Job health",
+      "id": 10,
+      "type": "row",
+      "title": "Job",
       "gridPos": {
-        "h": 8,
+        "h": 1,
         "w": 24,
         "x": 0,
         "y": 0
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Checkpoints",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
       },
       "datasource": {
         "type": "prometheus",
@@ -58,7 +112,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "increase(volga_checkpoint_completed_total{pipeline_id=~\"$pipeline\"}[5m])",
+          "expr": "increase(volga_checkpoint_completed{pipeline_id=~\"$pipeline\"}[5m])",
           "legendFormat": "completed",
           "editorMode": "code",
           "instant": false,
@@ -70,14 +124,61 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "increase(volga_checkpoint_failed_total{pipeline_id=~\"$pipeline\"}[5m])",
+          "expr": "increase(volga_checkpoint_failed{pipeline_id=~\"$pipeline\"}[5m])",
           "legendFormat": "failed",
           "editorMode": "code",
           "instant": false,
           "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
         },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Master counters (metrics crate does not add _total). Empty if scrape missed the master."
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Checkpoint duration p99",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
         {
-          "refId": "C",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "prometheus"
@@ -94,162 +195,8 @@
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
-            "fillOpacity": 8,
-            "lineWidth": 1,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "mode": "none",
-              "group": "A"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "description": "Job-level checkpoint counters and success-only duration histogram."
-    },
-    {
-      "id": 2,
-      "type": "timeseries",
-      "title": "Task time (ms / s, stack \u2248 1000)",
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "avg by (task_id) (volga_stream_task_busy_time_ms_per_second{pipeline_id=~\"$pipeline\"})",
-          "legendFormat": "busy {{task_id}}",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        },
-        {
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "avg by (task_id) (volga_stream_task_idle_time_ms_per_second{pipeline_id=~\"$pipeline\"})",
-          "legendFormat": "idle {{task_id}}",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        },
-        {
-          "refId": "C",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "avg by (task_id) (volga_stream_task_backpressured_time_ms_per_second{pipeline_id=~\"$pipeline\"})",
-          "legendFormat": "backpressured {{task_id}}",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "fillOpacity": 20,
-            "lineWidth": 1,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "mode": "normal",
-              "group": "A"
-            }
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      }
-    },
-    {
-      "id": 3,
-      "type": "timeseries",
-      "title": "Event-time lag",
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 16
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "quantile(0.50, volga_stream_task_watermark_lag_ms{pipeline_id=~\"$pipeline\"})",
-          "legendFormat": "lag p50",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        },
-        {
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "quantile(0.99, volga_stream_task_watermark_lag_ms{pipeline_id=~\"$pipeline\"})",
-          "legendFormat": "lag p99",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "fillOpacity": 8,
-            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineWidth": 2,
             "pointSize": 5,
             "showPoints": "never",
             "spanNulls": true,
@@ -273,17 +220,30 @@
           "sort": "desc"
         }
       },
-      "description": "Per-task lag gauges; quantile across tasks (not a histogram)."
+      "description": "Success-only histogram. Sparse on a 2-minute / 30s-checkpoint run \u2014 expect a flat-ish line."
     },
     {
-      "id": 4,
+      "id": 20,
+      "type": "row",
+      "title": "Flow",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 21,
       "type": "timeseries",
       "title": "Throughput",
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
-        "y": 24
+        "y": 10
       },
       "datasource": {
         "type": "prometheus",
@@ -296,7 +256,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(volga_stream_task_records_sent_total{pipeline_id=~\"$pipeline\"}[1m]))",
+          "expr": "sum(rate(volga_stream_task_records_sent{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
           "legendFormat": "records sent / s",
           "editorMode": "code",
           "instant": false,
@@ -308,7 +268,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(volga_sink_records_written_total{pipeline_id=~\"$pipeline\"}[1m]))",
+          "expr": "sum(rate(volga_sink_records_written{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
           "legendFormat": "sink records / s",
           "editorMode": "code",
           "instant": false,
@@ -320,8 +280,8 @@
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
-            "fillOpacity": 8,
-            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineWidth": 2,
             "pointSize": 5,
             "showPoints": "never",
             "spanNulls": true,
@@ -346,14 +306,14 @@
       }
     },
     {
-      "id": 5,
+      "id": 22,
       "type": "timeseries",
-      "title": "Window operator",
+      "title": "Event-time lag",
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 32
+        "w": 12,
+        "x": 12,
+        "y": 10
       },
       "datasource": {
         "type": "prometheus",
@@ -366,7 +326,189 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(volga_wo_ingest_ms_bucket{pipeline_id=~\"$pipeline\"}[1m])))",
+          "expr": "quantile(0.50, volga_stream_task_watermark_lag_ms{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "lag p50",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "quantile(0.99, volga_stream_task_watermark_lag_ms{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "lag p99",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "wall_now_ms \u2212 watermark. Needs wall-clock event time (ProcessingTimestamp)."
+    },
+    {
+      "id": 30,
+      "type": "row",
+      "title": "Task time (pick a task above \u2014 three lines: busy / idle / backpressured \u2248 1000 ms/s)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 31,
+      "type": "timeseries",
+      "title": "Task time",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg by (task_id) (volga_stream_task_busy_time_ms_per_second{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "busy {{task_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg by (task_id) (volga_stream_task_idle_time_ms_per_second{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "idle {{task_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "avg by (task_id) (volga_stream_task_backpressured_time_ms_per_second{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "bp {{task_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Select one task in the dropdown for three readable lines. All-tasks view is noisy."
+    },
+    {
+      "id": 40,
+      "type": "row",
+      "title": "Window operator",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 41,
+      "type": "timeseries",
+      "title": "Window ingest / drops",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(volga_wo_ingest_ms_bucket{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m])))",
           "legendFormat": "ingest p99",
           "editorMode": "code",
           "instant": false,
@@ -378,7 +520,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(volga_wo_late_dropped_rows_total{pipeline_id=~\"$pipeline\"}[1m]))",
+          "expr": "sum(rate(volga_wo_late_dropped_rows{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
           "legendFormat": "late dropped / s",
           "editorMode": "code",
           "instant": false,
@@ -390,20 +532,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(volga_wo_maintain_pruned_rows_total{pipeline_id=~\"$pipeline\"}[1m]))",
+          "expr": "sum(rate(volga_wo_maintain_pruned_rows{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
           "legendFormat": "pruned / s",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        },
-        {
-          "refId": "D",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum(volga_wo_state_raw_bytes{pipeline_id=~\"$pipeline\"}) + sum(volga_wo_state_tiles_bytes{pipeline_id=~\"$pipeline\"}) + sum(volga_wo_state_triggers_bytes{pipeline_id=~\"$pipeline\"}) + sum(volga_wo_state_key_states_bytes{pipeline_id=~\"$pipeline\"})",
-          "legendFormat": "state bytes",
           "editorMode": "code",
           "instant": false,
           "range": true
@@ -414,8 +544,8 @@
           "custom": {
             "drawStyle": "line",
             "lineInterpolation": "smooth",
-            "fillOpacity": 8,
-            "lineWidth": 1,
+            "fillOpacity": 10,
+            "lineWidth": 2,
             "pointSize": 5,
             "showPoints": "never",
             "spanNulls": true,
@@ -438,7 +568,186 @@
           "sort": "desc"
         }
       },
-      "description": "Empty until a window operator emits series."
+      "description": "Ingest latency vs drop rates. State size is the next panel (different scale)."
+    },
+    {
+      "id": 42,
+      "type": "timeseries",
+      "title": "Window state size",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(volga_wo_state_raw_bytes{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "raw",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(volga_wo_state_tiles_bytes{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "tiles",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(volga_wo_state_triggers_bytes{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "triggers",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(volga_wo_state_key_states_bytes{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "key states",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "id": 50,
+      "type": "row",
+      "title": "Operator (poll gauges)",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 51,
+      "type": "timeseries",
+      "title": "Operator records",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (operator_id) (volga_operator_records_sent{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\"})",
+          "legendFormat": "sent {{operator_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (operator_id) (volga_operator_records_recv{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\"})",
+          "legendFormat": "recv {{operator_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Worker poll-time gauges, labeled by operator_id."
     }
   ]
 }

--- a/kubevolga/hack/bench/grafana.yaml
+++ b/kubevolga/hack/bench/grafana.yaml
@@ -17,16 +17,8 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/part-of: volga-bench
     spec:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: volga.io/role
-                    operator: In
-                    values:
-                      - infra
+      nodeSelector:
+        volga.io/role: infra
       containers:
         - name: grafana
           image: grafana/grafana:11.3.1

--- a/kubevolga/hack/bench/kustomization.yaml
+++ b/kubevolga/hack/bench/kustomization.yaml
@@ -1,7 +1,7 @@
 # Lightweight Prom + Grafana for Volga bench (not kube-prometheus-stack).
 # Apply: kubectl apply -k kubevolga/hack/bench
 # UI:    kubectl -n volga-bench port-forward svc/grafana 3000:3000
-# Scrapes pods with prometheus.io/{scrape,port,path} (PR A). Prefers infra nodes (PR C).
+# Scrapes pods with prometheus.io/{scrape,port,path}. Requires infra nodes (kind-multi).
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: volga-bench

--- a/kubevolga/hack/bench/prometheus.yaml
+++ b/kubevolga/hack/bench/prometheus.yaml
@@ -18,16 +18,8 @@ spec:
         app.kubernetes.io/part-of: volga-bench
     spec:
       serviceAccountName: prometheus
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              preference:
-                matchExpressions:
-                  - key: volga.io/role
-                    operator: In
-                    values:
-                      - infra
+      nodeSelector:
+        volga.io/role: infra
       containers:
         - name: prometheus
           image: prom/prometheus:v2.54.1

--- a/kubevolga/hack/kind-multi.yaml
+++ b/kubevolga/hack/kind-multi.yaml
@@ -1,12 +1,22 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-# 1 control-plane + infra + 1 volga-worker (CI contract). CPU is still shared.
-# Labels/taints are also applied by scripts/kube-test-env after create.
+# Topology for `scripts/kube-test-env` (`kind create --name $VOLGA_KIND_CLUSTER --config`).
+# Do not set `name:` here: stress shards pass a different --name.
+# 1 control-plane + infra (untainted) + 2 worker nodes (tainted). CPU is still shared.
 nodes:
   - role: control-plane
   - role: worker
     labels:
       volga.io/role: infra
+  - role: worker
+    labels:
+      volga.io/role: worker
+    kubeadmConfigPatches:
+      - |
+        kind: JoinConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            register-with-taints: "volga.io/role=worker:NoSchedule"
   - role: worker
     labels:
       volga.io/role: worker

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -168,3 +168,44 @@ Stress options:
 
 Timeouts are suite-scoped nextest profiles only (`default` 30s, `inprocess` 90s,
 `docker` 120s, `kube` 90s, `stress` 180s) — no per-test overrides.
+
+## Bench (`volga-bench`)
+
+Long-run job on the same Kind (or remote) cluster as kube tests. Not a
+`scripts/test` profile: YAML is the run spec; CLI only overrides `--env` and
+`--duration-secs`. Count sink + Datagen are fixed in code.
+
+```bash
+# 1) Kind + operator (infra + 2 tainted worker nodes). Recreates kubevolga if
+#    the current cluster is single-node.
+scripts/kube-test-env setup
+
+# 2) Prom + Grafana in namespace volga-bench (infra nodeSelector).
+make -C kubevolga bench
+
+# 3) Reach Prom (oracles/dump) and the Grafana board from the laptop.
+export VOLGA_KUBE_CONTEXT="${VOLGA_KUBE_CONTEXT:-kind-kubevolga}"
+kubectl --context "$VOLGA_KUBE_CONTEXT" -n volga-bench port-forward svc/prometheus 9090:9090 &
+kubectl --context "$VOLGA_KUBE_CONTEXT" -n volga-bench port-forward svc/grafana 3000:3000 &
+
+# 4) Short Kind smoke (example.yaml is a 1h kill scenario; override duration).
+cargo run --bin volga-bench -- \
+  --config kubevolga/hack/bench/example.yaml \
+  --env kube \
+  --duration-secs 120
+```
+
+Grafana: http://localhost:3000 (anonymous viewer; Volga bench is the home
+dashboard). Prom dump/oracles need `prom_url` in the YAML (example uses
+`http://127.0.0.1:9090` after the port-forward).
+
+| | Kind (local / CI wiring) | Remote cluster |
+| --- | --- | --- |
+| Cluster | `scripts/kube-test-env setup` | existing kubeconfig; skip Kind |
+| Context | `VOLGA_KUBE_CONTEXT=kind-kubevolga` | omit, or set to that context |
+| Observability | `make -C kubevolga bench` + port-forward | same manifests; port-forward or in-cluster `prom_url` |
+| Duration | `--duration-secs 120` to see the board | YAML `duration` (example: 1h) |
+| Numbers | scrape/oracles wiring only | overnight; not GitHub-hosted CI |
+
+`make -C kubevolga unbench` removes Prom/Grafana. `scripts/kube-test-env destroy`
+deletes the Kind cluster. Overnight soaks belong on a real cluster, not Kind.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -167,7 +167,7 @@ Stress options:
 ```
 
 Timeouts are suite-scoped nextest profiles only (`default` 30s, `inprocess` 90s,
-`docker` 120s, `kube` 90s, `stress` 180s) — no per-test overrides.
+`docker` 120s, `kube`/`stress` 360s) — no per-test overrides.
 
 ## Bench (`volga-bench`)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -90,7 +90,9 @@ docker/kube jobs unless you pick an env-only profile).
 `all` runs `unit` + `inprocess` first, then docker/Kind setup only when those
 suites start. `scripts/docker-test-env setup` prefetches testcontainers images
 (LocalStack, Redpanda) before building `volga:latest`. Kube uses the Kind
-cluster named by `VOLGA_KIND_CLUSTER` (default: `kubevolga`).
+cluster named by `VOLGA_KIND_CLUSTER` (default: `kubevolga`), created from
+`kubevolga/hack/kind-multi.yaml` (control-plane + infra + 2 tainted worker
+nodes). A cluster without that topology is deleted and recreated.
 
 ### CI image cache
 

--- a/scripts/kube-test-env
+++ b/scripts/kube-test-env
@@ -4,6 +4,9 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLUSTER_NAME="${VOLGA_KIND_CLUSTER:-kubevolga}"
 CONTEXT="kind-$CLUSTER_NAME"
+KIND_CONFIG="$ROOT/kubevolga/hack/kind-multi.yaml"
+MIN_WORKER_NODES=2
+MIN_INFRA_NODES=1
 ACTION="${1:-setup}"
 REBUILD="${2:-}"
 
@@ -21,6 +24,32 @@ cluster_exists() {
 
 kubectl_test() {
   kubectl --context "$CONTEXT" "$@"
+}
+
+node_count_by_role() {
+  local role="$1"
+  kubectl_test get nodes -l "volga.io/role=$role" --no-headers 2>/dev/null |
+    wc -l |
+    tr -d ' '
+}
+
+cluster_has_topology() {
+  local workers infra
+  workers="$(node_count_by_role worker)"
+  infra="$(node_count_by_role infra)"
+  [[ "${workers:-0}" -ge "$MIN_WORKER_NODES" && "${infra:-0}" -ge "$MIN_INFRA_NODES" ]]
+}
+
+ensure_cluster() {
+  if cluster_exists; then
+    if cluster_has_topology; then
+      echo "using existing Kind cluster: $CLUSTER_NAME"
+      return
+    fi
+    echo "Kind cluster $CLUSTER_NAME is missing infra/worker topology; recreating"
+    kind delete cluster --name "$CLUSTER_NAME"
+  fi
+  kind create cluster --name "$CLUSTER_NAME" --config "$KIND_CONFIG"
 }
 
 cleanup_resources() {
@@ -48,12 +77,8 @@ setup() {
   require make
   docker info >/dev/null
 
-  if cluster_exists; then
-    echo "using existing Kind cluster: $CLUSTER_NAME"
-  else
-    kind create cluster --name "$CLUSTER_NAME"
-  fi
-  kubectl_test wait --for=condition=Ready nodes --all --timeout=120s
+  ensure_cluster
+  kubectl_test wait --for=condition=Ready nodes --all --timeout=180s
 
   # Shared Buildx/GHA cache with the docker job (scope=volga-image).
   if [[ "$REBUILD" == "--rebuild" ]]; then

--- a/src/bench/config.rs
+++ b/src/bench/config.rs
@@ -292,12 +292,11 @@ fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<D
         "launch.datagen.num_unique",
     )?;
     let mut fields = HashMap::new();
+    // Wall-clock event time so watermark lag is `now − watermark`, not ~55 years
+    // (IncrementalTimestamp starts at 1s and lag uses UNIX epoch ms).
     fields.insert(
         "timestamp".to_string(),
-        FieldGenerator::IncrementalTimestamp {
-            start_ms: 1_000,
-            step_ms: 1_000,
-        },
+        FieldGenerator::ProcessingTimestamp,
     );
     fields.insert(
         "key".to_string(),

--- a/src/bench/dump.rs
+++ b/src/bench/dump.rs
@@ -78,7 +78,7 @@ pub const REQUIRED_PROM_QUERIES: &[PromQuery] = &[
     (
         "checkpoint_completed",
         concat!(
-            "increase(volga_checkpoint_completed_total",
+            "increase(volga_checkpoint_completed",
             r#"{pipeline_id=~".*"}"#,
             "[5m])"
         ),
@@ -86,7 +86,7 @@ pub const REQUIRED_PROM_QUERIES: &[PromQuery] = &[
     (
         "checkpoint_failed",
         concat!(
-            "increase(volga_checkpoint_failed_total",
+            "increase(volga_checkpoint_failed",
             r#"{pipeline_id=~".*"}"#,
             "[5m])"
         ),
@@ -94,7 +94,7 @@ pub const REQUIRED_PROM_QUERIES: &[PromQuery] = &[
     (
         "records_sent_rate",
         concat!(
-            "sum(rate(volga_stream_task_records_sent_total",
+            "sum(rate(volga_stream_task_records_sent",
             r#"{pipeline_id=~".*"}"#,
             "[1m]))"
         ),
@@ -153,7 +153,7 @@ pub const EXTRA_PROM_QUERIES: &[PromQuery] = &[
     (
         "sink_records_rate",
         concat!(
-            "sum(rate(volga_sink_records_written_total",
+            "sum(rate(volga_sink_records_written",
             r#"{pipeline_id=~".*"}"#,
             "[1m]))"
         ),
@@ -169,7 +169,7 @@ pub const EXTRA_PROM_QUERIES: &[PromQuery] = &[
     (
         "wo_late_dropped_rate",
         concat!(
-            "sum(rate(volga_wo_late_dropped_rows_total",
+            "sum(rate(volga_wo_late_dropped_rows",
             r#"{pipeline_id=~".*"}"#,
             "[1m]))"
         ),
@@ -177,7 +177,7 @@ pub const EXTRA_PROM_QUERIES: &[PromQuery] = &[
     (
         "wo_maintain_pruned_rate",
         concat!(
-            "sum(rate(volga_wo_maintain_pruned_rows_total",
+            "sum(rate(volga_wo_maintain_pruned_rows",
             r#"{pipeline_id=~".*"}"#,
             "[1m]))"
         ),

--- a/src/bench/oracles.rs
+++ b/src/bench/oracles.rs
@@ -129,7 +129,10 @@ fn unexpected_fatal(
                     .unwrap_or(false)
                     && matches!(
                         kind.as_str(),
-                        "HeartbeatUnavailable" | "StatePollFailure" | "PodUnhealthy"
+                        "HeartbeatUnavailable"
+                            | "StatePollFailure"
+                            | "PodUnhealthy"
+                            | "TransportDisconnect",
                     );
                 if !expected_kill {
                     return Err(anyhow!(
@@ -359,6 +362,27 @@ mod tests {
                 worker_id: "w0".into(),
                 kind: "HeartbeatUnavailable".into(),
                 detail: "gone".into(),
+            },
+        }];
+        let kill = KillWindow {
+            at_unix: 100.0,
+            restore_at_unix: 110.0,
+            after_checkpoint: 1,
+            seq_lo: 1,
+            seq_hi: 2,
+        };
+        assert!(unexpected_fatal(&cfg(), &events, Some(&kill)).is_ok());
+    }
+
+    #[test]
+    fn transport_disconnect_during_kill_ok() {
+        let events = vec![LifecycleEventRecord {
+            sequence: 1,
+            event: LifecycleEvent::WorkerFailure {
+                attempt_id: 0,
+                worker_id: "w1".into(),
+                kind: "TransportDisconnect".into(),
+                detail: "stream_messages failed".into(),
             },
         }];
         let kill = KillWindow {


### PR DESCRIPTION
## Summary
- Prom dump/Grafana queried `*_total` counters; the metrics crate exports `volga_checkpoint_completed`, `volga_stream_task_records_sent`, etc. without that suffix (histograms still use `_bucket`).
- Kill scenario emits `TransportDisconnect` first; treat it as expected in the kill window (with HB / pod unhealthy).
- Bench datagen uses `ProcessingTimestamp` so watermark lag is `wall_now − event time`, not ~55 years from IncrementalTimestamp starting at 1s.
- Grafana: pipeline / worker / task variables; split job health vs duration; task time is three series for the selected task; window ingest vs state size are separate panels.

## Test plan
- [ ] `make -C kubevolga bench` to reload the dashboard ConfigMap, then refresh Grafana
- [ ] Rebuild/run `volga-bench` with `--duration-secs 120` and Prom forwarded; dump `checkpoint_completed` / `records_sent_rate` should be non-empty; lag p99 should be seconds not years
- [ ] Kill scenario should not fail on TransportDisconnect during the kill window
- [ ] In Grafana, pick one task: Task time shows busy / idle / bp