### PR TITLE
Unlimited bench rate and per-edge queue gauges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ go.work.sum
 # Local working notes (not for review)
 docs/metrics-redesign-plan.md
 docs/longrun-soak-plan.md
+docs/transport-improvements-plan.md

--- a/kubevolga/Makefile
+++ b/kubevolga/Makefile
@@ -27,8 +27,10 @@ render:
 	$(KUSTOMIZE) config/default
 
 # Prom + Grafana on infra (kubevolga/hack/bench). Opt-in; not part of kube tests.
+# Restart Prometheus so scrape-config ConfigMap changes are picked up.
 bench:
 	$(KUSTOMIZE) hack/bench | $(KUBECTL) apply -f -
+	$(KUBECTL) -n volga-bench rollout restart deploy/prometheus
 
 unbench:
 	$(KUSTOMIZE) hack/bench | $(KUBECTL) delete --ignore-not-found=true -f -

--- a/kubevolga/hack/bench/dashboards/volga-bench.json
+++ b/kubevolga/hack/bench/dashboards/volga-bench.json
@@ -7,7 +7,7 @@
   ],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 2,
+  "version": 5,
   "refresh": "5s",
   "time": {
     "from": "now-15m",
@@ -375,7 +375,7 @@
           "sort": "desc"
         }
       },
-      "description": "wall_now_ms \u2212 watermark. Needs wall-clock event time (ProcessingTimestamp)."
+      "description": "wall_now_ms \u2212 watermark. Event time is IncrementalTimestamp starting at submit wall-clock (replayable)."
     },
     {
       "id": 30,
@@ -490,7 +490,7 @@
     {
       "id": 41,
       "type": "timeseries",
-      "title": "Window ingest / drops",
+      "title": "Window ingest / watermark process",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -508,8 +508,104 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(volga_wo_ingest_ms_bucket{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m])))",
+          "legendFormat": "ingest p50",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "histogram_quantile(0.99, sum by (le) (rate(volga_wo_ingest_ms_bucket{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m])))",
           "legendFormat": "ingest p99",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(volga_wo_wm_process_ms_bucket{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m])))",
+          "legendFormat": "wm process p50",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(volga_wo_wm_process_ms_bucket{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m])))",
+          "legendFormat": "wm process p99",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "insert_batch (ingest) vs process_due on watermark advance. First histogram bucket is 1ms."
+    },
+    {
+      "id": 43,
+      "type": "timeseries",
+      "title": "Window rows",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(volga_wo_ingest_ms_count{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
+          "legendFormat": "ingest batches / s",
           "editorMode": "code",
           "instant": false,
           "range": true
@@ -568,17 +664,17 @@
           "sort": "desc"
         }
       },
-      "description": "Ingest latency vs drop rates. State size is the next panel (different scale)."
+      "description": "Ingest batch rate vs late drops vs maintain prune. Prune should track sink rate on a tumbling RANGE window."
     },
     {
       "id": 42,
       "type": "timeseries",
-      "title": "Window state size",
+      "title": "Window state bytes",
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 30
+        "x": 0,
+        "y": 38
       },
       "datasource": {
         "type": "prometheus",
@@ -666,6 +762,246 @@
       }
     },
     {
+      "id": 44,
+      "type": "timeseries",
+      "title": "Window state counts",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(volga_wo_state_raw_count{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "raw",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(volga_wo_state_tiles_count{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "tiles",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(volga_wo_state_triggers_count{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "triggers",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(volga_wo_state_key_states_count{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "key states",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "In-mem backend entries (not bytes). key_states \u2248 distinct keys in the window store."
+    },
+    {
+      "id": 60,
+      "type": "row",
+      "title": "Process / container",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 61,
+      "type": "timeseries",
+      "title": "CPU (cAdvisor)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 47
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{container=~\"master|worker\"}[1m]))",
+          "legendFormat": "{{pod}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "cores"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Kubelet cAdvisor. 1.0 = one full core."
+    },
+    {
+      "id": 62,
+      "type": "timeseries",
+      "title": "Memory: Volga RSS vs cgroup working set",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (worker_id) (volga_worker_rss_bytes{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\"})",
+          "legendFormat": "rss {{worker_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (pod) (container_memory_working_set_bytes{container=~\"master|worker\"})",
+          "legendFormat": "cgroup {{pod}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "volga_worker_rss_bytes (process RSS, workers only) vs cAdvisor working set (master + workers). Shapes should match; RSS is often a bit below cgroup."
+    },
+    {
       "id": 50,
       "type": "row",
       "title": "Operator (poll gauges)",
@@ -673,7 +1009,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 55
       },
       "collapsed": false,
       "panels": []
@@ -686,7 +1022,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 56
       },
       "datasource": {
         "type": "prometheus",
@@ -748,6 +1084,137 @@
         }
       },
       "description": "Worker poll-time gauges, labeled by operator_id."
+    },
+    {
+      "id": 70,
+      "type": "row",
+      "title": "Transport",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 71,
+      "type": "timeseries",
+      "title": "Tx queue remaining",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 65
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (task_id, target_task_id) (volga_stream_task_tx_queue_rem{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "{{task_id}} \u2192 {{target_task_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Records of free space on each output edge. 0 = this task is blocked sending to that target."
+    },
+    {
+      "id": 72,
+      "type": "timeseries",
+      "title": "Rx queued records",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 65
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by (task_id, source_task_id) (volga_stream_task_rx_queued_records{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"})",
+          "legendFormat": "{{source_task_id}} \u2192 {{task_id}}",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Records waiting on each input channel. Full + dest idle = operator not polling. Empty + upstream tx rem 0 = not delivered yet."
     }
   ]
 }

--- a/kubevolga/hack/bench/kustomization.yaml
+++ b/kubevolga/hack/bench/kustomization.yaml
@@ -1,7 +1,8 @@
 # Lightweight Prom + Grafana for Volga bench (not kube-prometheus-stack).
 # Apply: kubectl apply -k kubevolga/hack/bench
 # UI:    kubectl -n volga-bench port-forward svc/grafana 3000:3000
-# Scrapes pods with prometheus.io/{scrape,port,path}. Requires infra nodes (kind-multi).
+# Scrapes: volga pods (prometheus.io/{scrape,port,path}) + kubelet cAdvisor
+# (container CPU / working set via nodes/proxy). Requires infra nodes (kind-multi).
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: volga-bench

--- a/kubevolga/hack/bench/prometheus.yml
+++ b/kubevolga/hack/bench/prometheus.yml
@@ -26,3 +26,33 @@ scrape_configs:
         target_label: kubernetes_namespace
       - source_labels: [__meta_kubernetes_pod_name]
         target_label: kubernetes_pod
+
+  # Kubelet cAdvisor via API proxy (container CPU / working set). Kind needs
+  # insecure_skip_verify: kubelet serving certs are not the API cert.
+  - job_name: kubernetes-cadvisor
+    scheme: https
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecure_skip_verify: true
+    kubernetes_sd_configs:
+      - role: node
+    relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: container_cpu_usage_seconds_total|container_memory_working_set_bytes
+        action: keep
+      - source_labels: [container]
+        regex: ^$|^POD$
+        action: drop
+      - source_labels: [pod]
+        regex: ^$
+        action: drop

--- a/kubevolga/hack/bench/unlimited.yaml
+++ b/kubevolga/hack/bench/unlimited.yaml
@@ -1,22 +1,21 @@
-# Bench spec for `volga-bench --config`. CLI only overrides `--env` and `--duration-secs`.
-# Count sink + Datagen source are fixed in code (`run_for_s` unset). `launch` is the job overlay.
+# Unlimited datagen, no kill / interval checkpoint / restore.
+# IncrementalTimestamp step_ms=1 (event-time density, not wall).
+# Lag oracles disabled: watermark sits ahead of wall, lag gauge saturates at 0.
 
 env: kube
-duration: 1h
-scenario: kill
-kill_after_checkpoint: 1
-dump: /tmp/soak
+duration: 180s
+scenario: steady
+dump: /tmp/soak-unlimited-nocp
 prom_url: http://127.0.0.1:9090
 launch:
   parallelism: 4
   slots_per_node: 2
   checkpoint:
-    interval: 30s
+    interval: 0s
     timeout: 60s
     retention: 1
   datagen:
-    # omit rate → 200/s. `rate: null` → unlimited (no sleep between batches).
-    rate: 200
+    rate: null
     batch_size: 20
   window:
     tiling: [1s, 5s]
@@ -33,13 +32,9 @@ launch:
     WINDOW w AS (PARTITION BY key ORDER BY timestamp
     RANGE BETWEEN INTERVAL '10000' MILLISECOND PRECEDING AND CURRENT ROW)
 oracles:
-  watermark_stale_while_sending: 30s
-  lag_p99: 15s
-  lag_p99_sustain: 60s
+  watermark_stale_while_sending: 24h
+  lag_p99: 24h
+  lag_p99_sustain: 24h
   checkpoint_silence_intervals: 3
-  restore_catchup: 90s
   allow_checkpoint_fail_outside_kill: false
   allow_unexpected_fatal: false
-# extra_prom_queries:
-#   - name: checkpoint_duration_p99
-#     query: 'histogram_quantile(0.99, sum by (le) (rate(volga_checkpoint_duration_ms_bucket{pipeline_id=~".*"}[1m])))'

--- a/src/bench/config.rs
+++ b/src/bench/config.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail, Context, Result};
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
@@ -82,7 +82,9 @@ pub struct CheckpointFile {
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DatagenFile {
-    pub rate: Option<f32>,
+    /// Omitted → 200/s. YAML `null` → unlimited (`DatagenSpec.rate = None`).
+    #[serde(default, deserialize_with = "deserialize_optional_rate")]
+    pub rate: Option<Option<f32>>,
     pub batch_size: Option<usize>,
     pub num_unique: Option<usize>,
 }
@@ -252,14 +254,16 @@ fn compile_launch(launch: Option<&LaunchFile>) -> Result<PipelineLaunchSpec> {
 
 fn checkpoint_from_file(file: Option<&CheckpointFile>) -> Result<(u64, u64, u64)> {
     let file = file.cloned().unwrap_or_default();
-    let interval_ms = duration_ms(
-        file.interval.as_deref(),
-        DEFAULT_CHECKPOINT_INTERVAL,
-        "launch.checkpoint.interval",
-    )?;
-    if interval_ms == 0 {
-        bail!("launch.checkpoint.interval must be > 0");
-    }
+    // `0` / `0s` disables interval checkpoints (engine `CheckpointSpec::interval()`).
+    let interval_ms = match file.interval.as_deref().map(str::trim) {
+        None => DEFAULT_CHECKPOINT_INTERVAL.as_millis() as u64,
+        Some("0" | "0s" | "0ms") => 0,
+        Some(raw) => duration_ms(
+            Some(raw),
+            DEFAULT_CHECKPOINT_INTERVAL,
+            "launch.checkpoint.interval",
+        )?,
+    };
     let timeout_ms = duration_ms(
         file.timeout.as_deref(),
         DEFAULT_CHECKPOINT_TIMEOUT,
@@ -277,10 +281,12 @@ fn checkpoint_from_file(file: Option<&CheckpointFile>) -> Result<(u64, u64, u64)
 
 fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<DatagenSpec> {
     let file = file.cloned().unwrap_or_default();
-    let rate = file.rate.unwrap_or(DEFAULT_DATAGEN_RATE);
-    if rate <= 0.0 {
-        bail!("launch.datagen.rate must be > 0");
-    }
+    let rate = match file.rate {
+        None => Some(DEFAULT_DATAGEN_RATE),
+        Some(None) => None,
+        Some(Some(rate)) if rate > 0.0 => Some(rate),
+        Some(Some(_)) => bail!("launch.datagen.rate must be > 0, or null for unlimited"),
+    };
     let batch_size = nonzero_usize(
         file.batch_size,
         DEFAULT_DATAGEN_BATCH,
@@ -292,11 +298,23 @@ fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<D
         "launch.datagen.num_unique",
     )?;
     let mut fields = HashMap::new();
-    // Wall-clock event time so watermark lag is `now − watermark`, not ~55 years
-    // (IncrementalTimestamp starts at 1s and lag uses UNIX epoch ms).
+    // Incremental from wall-clock now so lag is `now − watermark`, not ~55 years.
+    // Finite `rate`: step ≈ per-key inter-arrival so event time tracks wall.
+    // Unlimited: step is a stub until we pick a replayable wall-aligned heuristic.
+    let start_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before UNIX epoch")?
+        .as_millis() as i64;
+    let step_ms = match rate {
+        Some(r) => ((num_unique as f64) / f64::from(r) * 1000.0).round() as i64,
+        None => 1,
+    };
     fields.insert(
         "timestamp".to_string(),
-        FieldGenerator::ProcessingTimestamp,
+        FieldGenerator::IncrementalTimestamp {
+            start_ms,
+            step_ms: step_ms.max(1),
+        },
     );
     fields.insert(
         "key".to_string(),
@@ -312,7 +330,7 @@ fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<D
         },
     );
     Ok(DatagenSpec {
-        rate: Some(rate),
+        rate,
         limit: None,
         run_for_s: None,
         batch_size,
@@ -432,6 +450,15 @@ fn apply_oracles(oracles: &mut OracleConfig, file: &OracleFile) -> Result<()> {
         oracles.allow_unexpected_fatal = v;
     }
     Ok(())
+}
+
+/// Present YAML value: `null` → `Some(None)` (unlimited), number → `Some(Some(n))`.
+/// Missing field uses `Default` (`None`) → 200/s.
+fn deserialize_optional_rate<'de, D>(deserializer: D) -> Result<Option<Option<f32>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Some(Option::deserialize(deserializer)?))
 }
 
 fn parse_duration(raw: &str) -> Result<Duration> {

--- a/src/bench/dump.rs
+++ b/src/bench/dump.rs
@@ -167,6 +167,14 @@ pub const EXTRA_PROM_QUERIES: &[PromQuery] = &[
         ),
     ),
     (
+        "wo_wm_process_p99",
+        concat!(
+            "histogram_quantile(0.99, sum by (le) (rate(volga_wo_wm_process_ms_bucket",
+            r#"{pipeline_id=~".*"}"#,
+            "[1m])))"
+        ),
+    ),
+    (
         "wo_late_dropped_rate",
         concat!(
             "sum(rate(volga_wo_late_dropped_rows",
@@ -192,6 +200,60 @@ pub const EXTRA_PROM_QUERIES: &[PromQuery] = &[
             ") + sum(volga_wo_state_triggers_bytes",
             r#"{pipeline_id=~".*"}"#,
             ") + sum(volga_wo_state_key_states_bytes",
+            r#"{pipeline_id=~".*"}"#,
+            ")"
+        ),
+    ),
+    (
+        "wo_state_counts",
+        concat!(
+            "sum(volga_wo_state_raw_count",
+            r#"{pipeline_id=~".*"}"#,
+            ") + sum(volga_wo_state_tiles_count",
+            r#"{pipeline_id=~".*"}"#,
+            ") + sum(volga_wo_state_triggers_count",
+            r#"{pipeline_id=~".*"}"#,
+            ") + sum(volga_wo_state_key_states_count",
+            r#"{pipeline_id=~".*"}"#,
+            ")"
+        ),
+    ),
+    (
+        "worker_rss_bytes",
+        concat!(
+            "sum by (worker_id) (volga_worker_rss_bytes",
+            r#"{pipeline_id=~".*"}"#,
+            ")"
+        ),
+    ),
+    (
+        "container_cpu_cores",
+        concat!(
+            "sum by (pod) (rate(container_cpu_usage_seconds_total",
+            r#"{container=~"master|worker"}"#,
+            "[1m]))"
+        ),
+    ),
+    (
+        "container_memory_working_set_bytes",
+        concat!(
+            "sum by (pod) (container_memory_working_set_bytes",
+            r#"{container=~"master|worker"}"#,
+            ")"
+        ),
+    ),
+    (
+        "tx_queue_rem",
+        concat!(
+            "max by (task_id, target_task_id) (volga_stream_task_tx_queue_rem",
+            r#"{pipeline_id=~".*"}"#,
+            ")"
+        ),
+    ),
+    (
+        "rx_queued_records",
+        concat!(
+            "max by (task_id, source_task_id) (volga_stream_task_rx_queued_records",
             r#"{pipeline_id=~".*"}"#,
             ")"
         ),

--- a/src/bench/oracles.rs
+++ b/src/bench/oracles.rs
@@ -86,8 +86,10 @@ pub fn evaluate(
         if let Err(err) = lag_p99(oracles, prom) {
             failures.push(err.to_string());
         }
-        if let Err(err) = checkpoint_health(oracles, prom, kill, checkpoint) {
-            failures.push(err.to_string());
+        if !resolved_checkpoint_interval(checkpoint).is_zero() {
+            if let Err(err) = checkpoint_health(oracles, prom, kill, checkpoint) {
+                failures.push(err.to_string());
+            }
         }
         if let Some(kill) = kill {
             if let Err(err) = restore_catchup(oracles, prom, kill) {
@@ -311,6 +313,14 @@ mod tests {
         OracleConfig::default()
     }
 
+    fn ckpt_spec() -> CheckpointSpec {
+        CheckpointSpec {
+            interval_ms: Some(30_000),
+            timeout_ms: Some(60_000),
+            retention: Some(1),
+        }
+    }
+
     fn sample_range(start: f64, step: f64, values: &[f64]) -> Vec<Sample> {
         values
             .iter()
@@ -435,7 +445,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        assert!(checkpoint_health(&cfg(), &prom, None, &CheckpointSpec::default()).is_err());
+        assert!(checkpoint_health(&cfg(), &prom, None, &ckpt_spec()).is_err());
     }
 
     #[test]
@@ -448,7 +458,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        assert!(checkpoint_health(&cfg(), &prom, None, &CheckpointSpec::default()).is_err());
+        assert!(checkpoint_health(&cfg(), &prom, None, &ckpt_spec()).is_err());
     }
 
     #[test]

--- a/src/runtime/observability/metrics/names.rs
+++ b/src/runtime/observability/metrics/names.rs
@@ -19,6 +19,8 @@ pub const METRIC_STREAM_TASK_TX_QUEUE_SIZE: &str = "volga_stream_task_tx_queue_s
 pub const METRIC_STREAM_TASK_TX_QUEUE_REM: &str = "volga_stream_task_tx_queue_rem";
 pub const METRIC_STREAM_TASK_BACKPRESSURE_RATIO: &str = "volga_stream_task_backpressure_ratio";
 pub const METRIC_STREAM_TASK_BACKPRESSURE_MAX: &str = "volga_stream_task_backpressure_max";
+/// Records waiting on one input channel (`source_task_id` → this task).
+pub const METRIC_STREAM_TASK_RX_QUEUED_RECORDS: &str = "volga_stream_task_rx_queued_records";
 /// Event-time lag: `wall_now_ms − current_watermark` (omit for 0 / MAX).
 /// Refreshed on watermark advance and on the task metrics tick so idle lag grows.
 pub const METRIC_STREAM_TASK_WATERMARK_LAG_MS: &str = "volga_stream_task_watermark_lag_ms";
@@ -75,6 +77,7 @@ pub const METRIC_OPERATOR_PATH_LATENCY_AVG: &str = "volga_operator_path_latency_
 // Label constants
 pub const LABEL_TASK_ID: &str = "task_id";
 pub const LABEL_TARGET_TASK_ID: &str = "target_task_id";
+pub const LABEL_SOURCE_TASK_ID: &str = "source_task_id";
 pub const LABEL_WORKER_ID: &str = "worker_id";
 pub const LABEL_OPERATOR_ID: &str = "operator_id";
 pub const LABEL_PIPELINE_ID: &str = "pipeline_id";

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -788,10 +788,12 @@ impl StreamTask {
             
             let mut metrics_window_start = Instant::now();
 
+            let mut _rx_queue_publisher = None;
             if !is_source {
                 // Pre-process input stream for non-source operators
                 let reader = transport_client.reader.take()
                     .expect("Reader should be initialized for non-SOURCE operator");
+                _rx_queue_publisher = Some(reader.queue_snapshot().spawn_publisher());
                 let (input_stream, reader_control) = reader.message_stream_with_control();
                 data_reader_control = Some(reader_control.clone());
 

--- a/src/runtime/stream_task.rs
+++ b/src/runtime/stream_task.rs
@@ -788,12 +788,12 @@ impl StreamTask {
             
             let mut metrics_window_start = Instant::now();
 
-            let mut _rx_queue_publisher = None;
+            let mut _rx_queue_ticker = None;
             if !is_source {
                 // Pre-process input stream for non-source operators
                 let reader = transport_client.reader.take()
                     .expect("Reader should be initialized for non-SOURCE operator");
-                _rx_queue_publisher = Some(reader.queue_snapshot().spawn_publisher());
+                _rx_queue_ticker = Some(reader.spawn_rx_queue_ticker(metrics_labels.clone()));
                 let (input_stream, reader_control) = reader.message_stream_with_control();
                 data_reader_control = Some(reader_control.clone());
 

--- a/src/runtime/worker/tasks.rs
+++ b/src/runtime/worker/tasks.rs
@@ -173,7 +173,12 @@ impl WorkerInner {
         let config = self.config.clone();
 
         let mut backend: Box<dyn TransportBackendTrait> = match config.transport_backend_type {
-            TransportBackendType::Grpc => Box::new(TransportBackend::new(self.health.clone())),
+            TransportBackendType::Grpc => Box::new(
+                TransportBackend::new(self.health.clone()).with_metrics_labels(MetricsLabels {
+                    pipeline_id: config.pipeline_id.0.clone(),
+                    worker_id: config.worker_id.clone(),
+                }),
+            ),
         };
         let mut transport_client_configs =
             backend.init_channels(&config.graph, config.vertex_ids.clone());

--- a/src/runtime/worker/tasks.rs
+++ b/src/runtime/worker/tasks.rs
@@ -173,12 +173,7 @@ impl WorkerInner {
         let config = self.config.clone();
 
         let mut backend: Box<dyn TransportBackendTrait> = match config.transport_backend_type {
-            TransportBackendType::Grpc => Box::new(
-                TransportBackend::new(self.health.clone()).with_metrics_labels(MetricsLabels {
-                    pipeline_id: config.pipeline_id.0.clone(),
-                    worker_id: config.worker_id.clone(),
-                }),
-            ),
+            TransportBackendType::Grpc => Box::new(TransportBackend::new(self.health.clone())),
         };
         let mut transport_client_configs =
             backend.init_channels(&config.graph, config.vertex_ids.clone());

--- a/src/test_utils/transport.rs
+++ b/src/test_utils/transport.rs
@@ -24,7 +24,6 @@ impl TestDataReaderActor {
         let reader = DataReader::new(
             vertex_id,
             transport_client_config.reader_receivers.unwrap(),
-            None,
         );
         let (reader_message_stream, _control) = reader.message_stream_with_control();
         Self {

--- a/src/test_utils/transport.rs
+++ b/src/test_utils/transport.rs
@@ -21,7 +21,11 @@ pub struct TestDataReaderActor {
 
 impl TestDataReaderActor {
     pub fn new(vertex_id: VertexId, transport_client_config: TransportClientConfig) -> Self {
-        let reader = DataReader::new(vertex_id, transport_client_config.reader_receivers.unwrap());
+        let reader = DataReader::new(
+            vertex_id,
+            transport_client_config.reader_receivers.unwrap(),
+            None,
+        );
         let (reader_message_stream, _control) = reader.message_stream_with_control();
         Self {
             reader_message_stream,

--- a/src/transport/batch_channel.rs
+++ b/src/transport/batch_channel.rs
@@ -167,6 +167,14 @@ pub struct BatchReceiver {
 }
 
 impl BatchReceiver {
+    pub fn queued_records(&self) -> u32 {
+        self.queued_messages.load(Ordering::Relaxed)
+    }
+
+    pub fn queued_records_handle(&self) -> Arc<AtomicU32> {
+        self.queued_messages.clone()
+    }
+
     pub async fn recv(&mut self) -> Option<Message> {
         let item = self.rx.recv().await;
         if let Some(item) = &item {

--- a/src/transport/batch_channel.rs
+++ b/src/transport/batch_channel.rs
@@ -167,10 +167,6 @@ pub struct BatchReceiver {
 }
 
 impl BatchReceiver {
-    pub fn queued_records(&self) -> u32 {
-        self.queued_messages.load(Ordering::Relaxed)
-    }
-
     pub fn queued_records_handle(&self) -> Arc<AtomicU32> {
         self.queued_messages.clone()
     }

--- a/src/transport/transport_client.rs
+++ b/src/transport/transport_client.rs
@@ -3,7 +3,7 @@ use metrics::gauge;
 use std::collections::HashMap;
 use crate::{common::message::Message, runtime::{health::{WorkerFatalReason, WorkerHealth}, metrics::{MetricsLabels, LABEL_PIPELINE_ID, LABEL_SOURCE_TASK_ID, LABEL_TARGET_TASK_ID, LABEL_TASK_ID, LABEL_WORKER_ID, METRIC_STREAM_TASK_BACKPRESSURE_RATIO, METRIC_STREAM_TASK_RX_QUEUED_RECORDS, METRIC_STREAM_TASK_TX_QUEUE_REM, METRIC_STREAM_TASK_TX_QUEUE_SIZE}, operators::operator::MessageStream}, transport::{batch_channel::{BatchReceiver, BatchSender, BackpressureTracker}, channel::Channel}};
 use std::time::Duration;
-use tokio::{sync::mpsc::error::SendError, time};
+use tokio::{sync::mpsc::error::SendError, task::JoinHandle, time};
 use tokio::sync::Notify;
 use futures::stream;
 use crate::transport::batcher::BatcherConfig;
@@ -49,66 +49,12 @@ impl TransportClientConfig {
     }
 }
 
-/// Live input-queue depths for Prom. Survives `message_stream` consuming the receivers.
-#[derive(Debug, Clone)]
-pub struct RxQueueSnapshot {
-    vertex_id: VertexId,
-    /// `(source_task_id, queued_records)`
-    channels: Vec<(String, Arc<AtomicU32>)>,
-    metrics_labels: Option<MetricsLabels>,
-}
+/// Aborts the dest-side queue ticker when the stream task ends (close / panic).
+pub(crate) struct RxQueueTicker(JoinHandle<()>);
 
-impl RxQueueSnapshot {
-    pub fn publish(&self) {
-        for (source_task_id, queued) in &self.channels {
-            let value = queued.load(Ordering::Relaxed) as f64;
-            if let Some(labels) = &self.metrics_labels {
-                gauge!(
-                    METRIC_STREAM_TASK_RX_QUEUED_RECORDS,
-                    LABEL_TASK_ID => self.vertex_id.clone(),
-                    LABEL_SOURCE_TASK_ID => source_task_id.clone(),
-                    LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
-                    LABEL_WORKER_ID => labels.worker_id.clone(),
-                )
-                .set(value);
-            } else {
-                gauge!(
-                    METRIC_STREAM_TASK_RX_QUEUED_RECORDS,
-                    LABEL_TASK_ID => self.vertex_id.clone(),
-                    LABEL_SOURCE_TASK_ID => source_task_id.clone(),
-                )
-                .set(value);
-            }
-        }
-    }
-
-    /// 1s ticker so depths stay live while the task is blocked in `poll_next`.
-    pub fn spawn_publisher(self) -> RxQueuePublisher {
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_flag = stop.clone();
-        tokio::spawn(async move {
-            let mut interval = time::interval(Duration::from_secs(1));
-            interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
-            while !stop_flag.load(Ordering::Relaxed) {
-                interval.tick().await;
-                if stop_flag.load(Ordering::Relaxed) {
-                    break;
-                }
-                self.publish();
-            }
-        });
-        RxQueuePublisher { stop }
-    }
-}
-
-#[derive(Debug)]
-pub struct RxQueuePublisher {
-    stop: Arc<AtomicBool>,
-}
-
-impl Drop for RxQueuePublisher {
+impl Drop for RxQueueTicker {
     fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
+        self.0.abort();
     }
 }
 
@@ -116,7 +62,6 @@ impl Drop for RxQueuePublisher {
 pub struct DataReader {
     vertex_id: VertexId,
     receivers: HashMap<String, BatchReceiver>,
-    metrics_labels: Option<MetricsLabels>,
 }
 
 #[derive(Debug)]
@@ -175,21 +120,15 @@ impl DataReaderControl {
 }
 
 impl DataReader {
-    pub fn new(
-        vertex_id: VertexId,
-        receivers: HashMap<String, BatchReceiver>,
-        metrics_labels: Option<MetricsLabels>,
-    ) -> Self {
+    pub fn new(vertex_id: VertexId, receivers: HashMap<String, BatchReceiver>) -> Self {
         Self {
             vertex_id,
             receivers,
-            metrics_labels,
         }
     }
 
-    pub fn queue_snapshot(&self) -> RxQueueSnapshot {
-        let channels = self
-            .receivers
+    pub fn queued_by_source(&self) -> Vec<(String, Arc<AtomicU32>)> {
+        self.receivers
             .iter()
             .map(|(channel_id, receiver)| {
                 let source_task_id = channel_id
@@ -199,12 +138,40 @@ impl DataReader {
                     .to_string();
                 (source_task_id, receiver.queued_records_handle())
             })
-            .collect();
-        RxQueueSnapshot {
-            vertex_id: self.vertex_id.clone(),
-            channels,
-            metrics_labels: self.metrics_labels.clone(),
-        }
+            .collect()
+    }
+
+    /// 1s dest-side sample so depths stay live while the operator is in `process` / blocked on send.
+    pub(crate) fn spawn_rx_queue_ticker(&self, labels: Option<MetricsLabels>) -> RxQueueTicker {
+        let channels = self.queued_by_source();
+        let vertex_id = self.vertex_id.clone();
+        RxQueueTicker(tokio::spawn(async move {
+            let mut interval = time::interval(Duration::from_secs(1));
+            interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+            loop {
+                interval.tick().await;
+                for (source_task_id, queued) in &channels {
+                    let value = queued.load(Ordering::Relaxed) as f64;
+                    if let Some(labels) = &labels {
+                        gauge!(
+                            METRIC_STREAM_TASK_RX_QUEUED_RECORDS,
+                            LABEL_TASK_ID => vertex_id.clone(),
+                            LABEL_SOURCE_TASK_ID => source_task_id.clone(),
+                            LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                            LABEL_WORKER_ID => labels.worker_id.clone(),
+                        )
+                        .set(value);
+                    } else {
+                        gauge!(
+                            METRIC_STREAM_TASK_RX_QUEUED_RECORDS,
+                            LABEL_TASK_ID => vertex_id.clone(),
+                            LABEL_SOURCE_TASK_ID => source_task_id.clone(),
+                        )
+                        .set(value);
+                    }
+                }
+            }
+        }))
     }
 
     pub fn message_stream(self) -> MessageStream {
@@ -441,11 +408,7 @@ impl TransportClient {
         let TransportClientConfig { reader_receivers, writer_senders, metrics_labels, .. } = config;
 
         if let Some(receivers) = reader_receivers {
-            reader = Some(DataReader::new(
-                vertex_id.clone(),
-                receivers,
-                metrics_labels.clone(),
-            ));
+            reader = Some(DataReader::new(vertex_id.clone(), receivers));
         }
         if let Some(senders) = writer_senders {
             writer = Some(DataWriter::new(

--- a/src/transport/transport_client.rs
+++ b/src/transport/transport_client.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use metrics::gauge;
 use std::collections::HashMap;
-use crate::{common::message::Message, runtime::{health::{WorkerFatalReason, WorkerHealth}, metrics::{MetricsLabels, LABEL_PIPELINE_ID, LABEL_TARGET_TASK_ID, LABEL_TASK_ID, LABEL_WORKER_ID, METRIC_STREAM_TASK_BACKPRESSURE_RATIO, METRIC_STREAM_TASK_TX_QUEUE_REM, METRIC_STREAM_TASK_TX_QUEUE_SIZE}, operators::operator::MessageStream}, transport::{batch_channel::{BatchReceiver, BatchSender, BackpressureTracker}, channel::Channel}};
+use crate::{common::message::Message, runtime::{health::{WorkerFatalReason, WorkerHealth}, metrics::{MetricsLabels, LABEL_PIPELINE_ID, LABEL_SOURCE_TASK_ID, LABEL_TARGET_TASK_ID, LABEL_TASK_ID, LABEL_WORKER_ID, METRIC_STREAM_TASK_BACKPRESSURE_RATIO, METRIC_STREAM_TASK_RX_QUEUED_RECORDS, METRIC_STREAM_TASK_TX_QUEUE_REM, METRIC_STREAM_TASK_TX_QUEUE_SIZE}, operators::operator::MessageStream}, transport::{batch_channel::{BatchReceiver, BatchSender, BackpressureTracker}, channel::Channel}};
 use std::time::Duration;
 use tokio::{sync::mpsc::error::SendError, time};
 use tokio::sync::Notify;
 use futures::stream;
 use crate::transport::batcher::BatcherConfig;
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use std::sync::{Arc, atomic::{AtomicBool, AtomicU32, Ordering}};
 use crate::runtime::VertexId;
 
 // pub type MessageStream = Pin<Box<dyn Stream<Item = Message> + Send>>;
@@ -49,10 +49,74 @@ impl TransportClientConfig {
     }
 }
 
+/// Live input-queue depths for Prom. Survives `message_stream` consuming the receivers.
+#[derive(Debug, Clone)]
+pub struct RxQueueSnapshot {
+    vertex_id: VertexId,
+    /// `(source_task_id, queued_records)`
+    channels: Vec<(String, Arc<AtomicU32>)>,
+    metrics_labels: Option<MetricsLabels>,
+}
+
+impl RxQueueSnapshot {
+    pub fn publish(&self) {
+        for (source_task_id, queued) in &self.channels {
+            let value = queued.load(Ordering::Relaxed) as f64;
+            if let Some(labels) = &self.metrics_labels {
+                gauge!(
+                    METRIC_STREAM_TASK_RX_QUEUED_RECORDS,
+                    LABEL_TASK_ID => self.vertex_id.clone(),
+                    LABEL_SOURCE_TASK_ID => source_task_id.clone(),
+                    LABEL_PIPELINE_ID => labels.pipeline_id.clone(),
+                    LABEL_WORKER_ID => labels.worker_id.clone(),
+                )
+                .set(value);
+            } else {
+                gauge!(
+                    METRIC_STREAM_TASK_RX_QUEUED_RECORDS,
+                    LABEL_TASK_ID => self.vertex_id.clone(),
+                    LABEL_SOURCE_TASK_ID => source_task_id.clone(),
+                )
+                .set(value);
+            }
+        }
+    }
+
+    /// 1s ticker so depths stay live while the task is blocked in `poll_next`.
+    pub fn spawn_publisher(self) -> RxQueuePublisher {
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_flag = stop.clone();
+        tokio::spawn(async move {
+            let mut interval = time::interval(Duration::from_secs(1));
+            interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+            while !stop_flag.load(Ordering::Relaxed) {
+                interval.tick().await;
+                if stop_flag.load(Ordering::Relaxed) {
+                    break;
+                }
+                self.publish();
+            }
+        });
+        RxQueuePublisher { stop }
+    }
+}
+
+#[derive(Debug)]
+pub struct RxQueuePublisher {
+    stop: Arc<AtomicBool>,
+}
+
+impl Drop for RxQueuePublisher {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
+
 #[derive(Debug)]
 pub struct DataReader {
-    _vertex_id: VertexId,
+    vertex_id: VertexId,
     receivers: HashMap<String, BatchReceiver>,
+    metrics_labels: Option<MetricsLabels>,
 }
 
 #[derive(Debug)]
@@ -111,10 +175,35 @@ impl DataReaderControl {
 }
 
 impl DataReader {
-    pub fn new(vertex_id: VertexId, receivers: HashMap<String, BatchReceiver>) -> Self {
+    pub fn new(
+        vertex_id: VertexId,
+        receivers: HashMap<String, BatchReceiver>,
+        metrics_labels: Option<MetricsLabels>,
+    ) -> Self {
         Self {
-            _vertex_id: vertex_id,
+            vertex_id,
             receivers,
+            metrics_labels,
+        }
+    }
+
+    pub fn queue_snapshot(&self) -> RxQueueSnapshot {
+        let channels = self
+            .receivers
+            .iter()
+            .map(|(channel_id, receiver)| {
+                let source_task_id = channel_id
+                    .split("_to_")
+                    .next()
+                    .unwrap_or(channel_id)
+                    .to_string();
+                (source_task_id, receiver.queued_records_handle())
+            })
+            .collect();
+        RxQueueSnapshot {
+            vertex_id: self.vertex_id.clone(),
+            channels,
+            metrics_labels: self.metrics_labels.clone(),
         }
     }
 
@@ -352,7 +441,11 @@ impl TransportClient {
         let TransportClientConfig { reader_receivers, writer_senders, metrics_labels, .. } = config;
 
         if let Some(receivers) = reader_receivers {
-            reader = Some(DataReader::new(vertex_id.clone(), receivers));
+            reader = Some(DataReader::new(
+                vertex_id.clone(),
+                receivers,
+                metrics_labels.clone(),
+            ));
         }
         if let Some(senders) = writer_senders {
             writer = Some(DataWriter::new(


### PR DESCRIPTION
## Summary
- Datagen `rate: null` is unlimited; omitted rate stays 200/s. `interval: 0s` disables interval checkpoints and skips checkpoint oracles.
- Event time is IncrementalTimestamp from submit wall-clock (replayable). Unlimited soak YAML at `kubevolga/hack/bench/unlimited.yaml`.
- Transport Grafana/dump: **tx queue remaining** and **rx queued records** (backend-agnostic). No shared-gRPC demux metric — that hop is going away.

Stacked on #250.

## Test plan
- [ ] `kubectl apply -k kubevolga/hack/bench` to reload the dashboard (avoid `make bench` unless you want Prom TSDB wiped)
- [ ] Grafana Transport row shows tx rem + rx queued; no demux panel
- [ ] `volga-bench --config kubevolga/hack/bench/unlimited.yaml` runs without checkpoint oracles


Made with [Cursor](https://cursor.com)