### PR TITLE
obs: fix dump/Grafana PromQL and extend latency histogram tails

### DIFF
--- a/kubevolga/hack/bench/dashboards/volga-bench.json
+++ b/kubevolga/hack/bench/dashboards/volga-bench.json
@@ -7,7 +7,7 @@
   ],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 6,
+  "version": 8,
   "refresh": "5s",
   "time": {
     "from": "now-15m",
@@ -113,7 +113,7 @@
             "uid": "prometheus"
           },
           "expr": "increase(volga_checkpoint_completed{pipeline_id=~\"$pipeline\"}[5m])",
-          "legendFormat": "completed",
+          "legendFormat": "{{pipeline_id}} completed",
           "editorMode": "code",
           "instant": false,
           "range": true
@@ -125,7 +125,7 @@
             "uid": "prometheus"
           },
           "expr": "increase(volga_checkpoint_failed{pipeline_id=~\"$pipeline\"}[5m])",
-          "legendFormat": "failed",
+          "legendFormat": "{{pipeline_id}} failed",
           "editorMode": "code",
           "instant": false,
           "range": true
@@ -160,7 +160,7 @@
           "sort": "desc"
         }
       },
-      "description": "Master counters (metrics crate does not add _total). Empty if scrape missed the master."
+      "description": "Trailing 5m increase of master counters (not a per-second rate). metrics crate does not add _total. Empty if scrape missed the master."
     },
     {
       "id": 12,
@@ -239,6 +239,7 @@
       "id": 21,
       "type": "timeseries",
       "title": "Throughput",
+      "description": "Per-operator sent rate (subtasks summed). Do not add the series together — each hop counts the same row. Source = ingest, Window sent = WO emit, window recv = WO ingest, sink written = pipeline output. Sink(Count) sent should match sink written.",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -256,8 +257,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(volga_stream_task_records_sent{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
-          "legendFormat": "records sent / s",
+          "expr": "sum by (operator) (label_replace(rate(volga_stream_task_records_sent{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]), \"operator\", \"$1\", \"task_id\", \"^(.*)_[0-9]+$\"))",
+          "legendFormat": "{{operator}} sent / s",
           "editorMode": "code",
           "instant": false,
           "range": true
@@ -268,8 +269,20 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "expr": "sum(rate(volga_stream_task_records_recv{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\",task_id=~\"Window.*\"}[1m]))",
+          "legendFormat": "window recv / s",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(rate(volga_sink_records_written{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
-          "legendFormat": "sink records / s",
+          "legendFormat": "sink written / s",
           "editorMode": "code",
           "instant": false,
           "range": true
@@ -289,7 +302,8 @@
               "mode": "none",
               "group": "A"
             }
-          }
+          },
+          "unit": "ops"
         },
         "overrides": []
       },
@@ -375,7 +389,7 @@
           "sort": "desc"
         }
       },
-      "description": "wall_now_ms \u2212 watermark. Event time is IncrementalTimestamp starting at submit wall-clock (replayable)."
+      "description": "Gauge: wall_now_ms − watermark, then quantile() across selected tasks (not a histogram). 0 means WM ≥ wall (IncrementalTimestamp flying ahead of wall). Series omitted for WM 0 / MAX."
     },
     {
       "id": 30,
@@ -581,12 +595,12 @@
           "sort": "desc"
         }
       },
-      "description": "insert_batch (ingest) vs process_due on watermark advance. First histogram bucket is 1ms."
+      "description": "Wall time of insert_batch vs process_due. histogram_quantile over a merged histogram of selected tasks (weighted by call rate, not 'p99 of a typical task'). Buckets 1ms … 5m; +Inf is >5m."
     },
     {
       "id": 43,
       "type": "timeseries",
-      "title": "Window rows",
+      "title": "Window batches / late / prune",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -616,8 +630,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum(rate(volga_wo_late_dropped_rows{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
-          "legendFormat": "late dropped / s",
+          "expr": "sum(rate(volga_wo_wm_process_ms_count{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
+          "legendFormat": "wm process / s",
           "editorMode": "code",
           "instant": false,
           "range": true
@@ -628,8 +642,20 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
+          "expr": "sum(rate(volga_wo_late_dropped_rows{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
+          "legendFormat": "late dropped / s",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "expr": "sum(rate(volga_wo_maintain_pruned_rows{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[1m]))",
-          "legendFormat": "pruned / s",
+          "legendFormat": "pruned rows / s",
           "editorMode": "code",
           "instant": false,
           "range": true
@@ -664,7 +690,7 @@
           "sort": "desc"
         }
       },
-      "description": "Ingest batch rate vs late drops vs maintain prune. Prune should track sink rate on a tumbling RANGE window."
+      "description": "Histogram _count is calls, not rows: ingest batches = insert_batch, wm process = process_due. Late/prune are rows. Do not compare batches/s to sink rec/s. Prune should track sink on a caught-up RANGE window."
     },
     {
       "id": 42,
@@ -759,7 +785,8 @@
           "mode": "multi",
           "sort": "desc"
         }
-      }
+      },
+      "description": "In-mem backend size (Arrow buffers + trigger/key meta), summed across selected Window tasks. Not RSS and not a durable/remote size."
     },
     {
       "id": 44,
@@ -854,7 +881,7 @@
           "sort": "desc"
         }
       },
-      "description": "In-mem backend entries (not bytes). key_states \u2248 distinct keys in the window store."
+      "description": "In-mem backend entry counts (not bytes), summed across selected Window tasks. key_states ≈ distinct keys. Triggers can dwarf raw rows when process_due lags."
     },
     {
       "id": 60,
@@ -927,7 +954,7 @@
           "sort": "desc"
         }
       },
-      "description": "Kubelet cAdvisor. 1.0 = one full core."
+      "description": "Kubelet cAdvisor. 1.0 = one full core. Not labeled by pipeline_id — shows every master/worker container still running."
     },
     {
       "id": 62,
@@ -1004,20 +1031,20 @@
     {
       "id": 50,
       "type": "row",
-      "title": "Operator (poll gauges)",
+      "title": "Operator (poll gauges — cumulative, not rec/s)",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 55
       },
-      "collapsed": false,
+      "collapsed": true,
       "panels": []
     },
     {
       "id": 51,
       "type": "timeseries",
-      "title": "Operator records",
+      "title": "Operator records (cumulative counts)",
       "gridPos": {
         "h": 8,
         "w": 24,
@@ -1083,7 +1110,7 @@
           "sort": "desc"
         }
       },
-      "description": "Worker poll-time gauges, labeled by operator_id."
+      "description": "Worker poll-time gauges of lifetime totals, labeled by operator_id (no task_id; ignores the task dropdown). These are not rec/s — use Throughput for rates."
     },
     {
       "id": 70,
@@ -1155,7 +1182,7 @@
           "sort": "desc"
         }
       },
-      "description": "Records of free space on each output edge. 0 = this task is blocked sending to that target."
+      "description": "Remaining record credits on each output edge (bound DEFAULT_QUEUE_RECORDS=8192, not message count). 0 = this task is blocked sending to that target."
     },
     {
       "id": 72,
@@ -1258,7 +1285,8 @@
               "mode": "none",
               "group": "A"
             }
-          }
+          },
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -1296,7 +1324,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "increase(volga_stream_task_transport_disconnects_total{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[5m])",
+          "expr": "increase(volga_stream_task_transport_disconnects{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\",task_id=~\"$task\"}[5m])",
           "legendFormat": "{{task_id}} \u2192 {{target_task_id}}",
           "editorMode": "code",
           "instant": false,
@@ -1332,7 +1360,7 @@
           "sort": "desc"
         }
       },
-      "description": "Close is fatal. Count so Grafana shows a drop without scraping logs."
+      "description": "Trailing 5m increase. Close is fatal. Count so Grafana shows a drop without scraping logs."
     }
   ]
 }

--- a/src/bench/config.rs
+++ b/src/bench/config.rs
@@ -354,7 +354,6 @@ fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<D
 
 fn watermark_from_file(file: Option<&WatermarkFile>) -> Result<(u64, Option<u64>, Option<u64>)> {
     let file = file.cloned().unwrap_or_default();
-    // 0 → Duration::ZERO: emit on every advancing batch (pre-#267 / tests).
     Ok((
         file.out_of_orderness_ms.unwrap_or(0),
         file.idle_timeout_ms,

--- a/src/bench/config.rs
+++ b/src/bench/config.rs
@@ -354,9 +354,7 @@ fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<D
 
 fn watermark_from_file(file: Option<&WatermarkFile>) -> Result<(u64, Option<u64>, Option<u64>)> {
     let file = file.cloned().unwrap_or_default();
-    if let Some(0) = file.emit_interval_ms {
-        bail!("launch.watermark.emit_interval_ms must be > 0 (omit for planner default)");
-    }
+    // 0 → Duration::ZERO: emit on every advancing batch (pre-#267 / tests).
     Ok((
         file.out_of_orderness_ms.unwrap_or(0),
         file.idle_timeout_ms,

--- a/src/bench/dump.rs
+++ b/src/bench/dump.rs
@@ -65,10 +65,6 @@ impl PromQueryRange {
 }
 
 /// Named PromQL. Oracles require [`REQUIRED_PROM_QUERIES`]; extras are dump-only.
-///
-/// The `metrics` Prometheus exporter does **not** append `_total` to counters.
-/// Grafana already uses the bare names (`volga_stream_task_records_sent`, …).
-/// `container_*_total` is cAdvisor and does keep `_total`.
 pub type PromQuery = (&'static str, &'static str);
 
 pub const REQUIRED_PROM_QUERY_NAMES: &[&str] = &[

--- a/src/bench/dump.rs
+++ b/src/bench/dump.rs
@@ -65,6 +65,10 @@ impl PromQueryRange {
 }
 
 /// Named PromQL. Oracles require [`REQUIRED_PROM_QUERIES`]; extras are dump-only.
+///
+/// The `metrics` Prometheus exporter does **not** append `_total` to counters.
+/// Grafana already uses the bare names (`volga_stream_task_records_sent`, …).
+/// `container_*_total` is cAdvisor and does keep `_total`.
 pub type PromQuery = (&'static str, &'static str);
 
 pub const REQUIRED_PROM_QUERY_NAMES: &[&str] = &[
@@ -78,7 +82,7 @@ pub const REQUIRED_PROM_QUERIES: &[PromQuery] = &[
     (
         "checkpoint_completed",
         concat!(
-            "increase(volga_checkpoint_completed_total",
+            "increase(volga_checkpoint_completed",
             r#"{pipeline_id=~".*"}"#,
             "[5m])"
         ),
@@ -86,7 +90,7 @@ pub const REQUIRED_PROM_QUERIES: &[PromQuery] = &[
     (
         "checkpoint_failed",
         concat!(
-            "increase(volga_checkpoint_failed_total",
+            "increase(volga_checkpoint_failed",
             r#"{pipeline_id=~".*"}"#,
             "[5m])"
         ),
@@ -94,8 +98,8 @@ pub const REQUIRED_PROM_QUERIES: &[PromQuery] = &[
     (
         "records_sent_rate",
         concat!(
-            "sum(rate(volga_stream_task_records_sent_total",
-            r#"{pipeline_id=~".*"}"#,
+            "sum(rate(volga_stream_task_records_sent",
+            r#"{pipeline_id=~".*",task_id=~"Source.*"}"#,
             "[1m]))"
         ),
     ),
@@ -153,9 +157,33 @@ pub const EXTRA_PROM_QUERIES: &[PromQuery] = &[
     (
         "sink_records_rate",
         concat!(
-            "sum(rate(volga_sink_records_written_total",
+            "sum(rate(volga_sink_records_written",
             r#"{pipeline_id=~".*"}"#,
             "[1m]))"
+        ),
+    ),
+    (
+        "window_recv_rate",
+        concat!(
+            "sum(rate(volga_stream_task_records_recv",
+            r#"{pipeline_id=~".*",task_id=~"Window.*"}"#,
+            "[1m]))"
+        ),
+    ),
+    (
+        "window_sent_rate",
+        concat!(
+            "sum(rate(volga_stream_task_records_sent",
+            r#"{pipeline_id=~".*",task_id=~"Window.*"}"#,
+            "[1m]))"
+        ),
+    ),
+    (
+        "records_sent_rate_by_operator",
+        concat!(
+            r#"sum by (operator) (label_replace(rate(volga_stream_task_records_sent"#,
+            r#"{pipeline_id=~".*"}"#,
+            r#"[1m]), "operator", "$1", "task_id", "^(.*)_[0-9]+$"))"#
         ),
     ),
     (
@@ -175,9 +203,17 @@ pub const EXTRA_PROM_QUERIES: &[PromQuery] = &[
         ),
     ),
     (
+        "wo_wm_process_rate",
+        concat!(
+            "sum(rate(volga_wo_wm_process_ms_count",
+            r#"{pipeline_id=~".*"}"#,
+            "[1m]))"
+        ),
+    ),
+    (
         "wo_late_dropped_rate",
         concat!(
-            "sum(rate(volga_wo_late_dropped_rows_total",
+            "sum(rate(volga_wo_late_dropped_rows",
             r#"{pipeline_id=~".*"}"#,
             "[1m]))"
         ),
@@ -185,7 +221,7 @@ pub const EXTRA_PROM_QUERIES: &[PromQuery] = &[
     (
         "wo_maintain_pruned_rate",
         concat!(
-            "sum(rate(volga_wo_maintain_pruned_rows_total",
+            "sum(rate(volga_wo_maintain_pruned_rows",
             r#"{pipeline_id=~".*"}"#,
             "[1m]))"
         ),
@@ -269,7 +305,7 @@ pub const EXTRA_PROM_QUERIES: &[PromQuery] = &[
     (
         "transport_disconnects",
         concat!(
-            "increase(volga_stream_task_transport_disconnects_total",
+            "increase(volga_stream_task_transport_disconnects",
             r#"{pipeline_id=~".*"}"#,
             "[5m])"
         ),

--- a/src/runtime/observability/metrics/names.rs
+++ b/src/runtime/observability/metrics/names.rs
@@ -96,8 +96,6 @@ pub struct MetricsLabels {
 }
 
 // Histogram bucket boundaries, milliseconds (Prometheus also emits a trailing +Inf bucket).
-// Tail goes to 5m so WO `process_due` soak outliers are not collapsed into +Inf
-// (p99 used to report 5000 whenever a sample was ≥5s).
 pub const LATENCY_BUCKET_BOUNDARIES: [f64; 18] = [
     1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0,
     10_000.0, 30_000.0, 60_000.0, 120_000.0, 180_000.0, 300_000.0,

--- a/src/runtime/observability/metrics/names.rs
+++ b/src/runtime/observability/metrics/names.rs
@@ -96,8 +96,11 @@ pub struct MetricsLabels {
 }
 
 // Histogram bucket boundaries, milliseconds (Prometheus also emits a trailing +Inf bucket).
-pub const LATENCY_BUCKET_BOUNDARIES: [f64; 12] = [
+// Tail goes to 5m so WO `process_due` soak outliers are not collapsed into +Inf
+// (p99 used to report 5000 whenever a sample was ≥5s).
+pub const LATENCY_BUCKET_BOUNDARIES: [f64; 18] = [
     1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0,
+    10_000.0, 30_000.0, 60_000.0, 120_000.0, 180_000.0, 300_000.0,
 ];
 /// Finite Prom buckets plus the trailing `+Inf` cumulative count.
 pub const LATENCY_HISTOGRAM_LEN: usize = LATENCY_BUCKET_BOUNDARIES.len() + 1;

--- a/src/runtime/observability/metrics/registry.rs
+++ b/src/runtime/observability/metrics/registry.rs
@@ -236,7 +236,7 @@ mod tests {
     fn cumulative_histogram_buckets_and_overflow() {
         let hist = CumulativeHistogram::new();
         hist.record(10.0);
-        hist.record(10_000.0);
+        hist.record(LATENCY_BUCKET_BOUNDARIES.last().unwrap() * 2.0);
         let buckets = hist.snapshot_buckets();
         assert_eq!(buckets.len(), LATENCY_HISTOGRAM_LEN);
         assert_eq!(*buckets.last().unwrap(), 2);


### PR DESCRIPTION
## Summary
- Drop the false `_total` suffix on Volga counters in dump PromQL and Grafana (the `metrics` exporter does not add it; those series were empty).
- Plot throughput per operator (plus Window recv / sink written) so ingest is not a hop-sum of every stage.
- Extend latency histogram buckets to 5m so Window `process_due` p99 is not clipped at 5s.
- Allow `emit_interval_ms: 0` in bench YAML (every advancing batch).

## Test plan
- [ ] `kubectl apply -k kubevolga/hack/bench` and confirm Throughput shows Source / Window / sink as separate series (not one ~5× line).
- [ ] Rebuild `volga:latest` and `kind load` so workers pick up the new histogram buckets.
- [ ] Re-dump a 200ms unlimited soak and confirm `records_sent_rate` / `sink_records_rate` are non-empty; `wo_wm_process_p99` can exceed 5s.


Made with [Cursor](https://cursor.com)