### PR TITLE
Emit watermarks on event time (plus wall cap); yield process_due

### DIFF
--- a/config/runtime_consts.kube_test.json
+++ b/config/runtime_consts.kube_test.json
@@ -22,5 +22,9 @@
   "worker.register_connect_timeout": "3s",
   "worker.register_rpc_timeout": "3s",
   "transport.tcp_connect_max_retries": 10,
-  "transport.tcp_connect_retry_delay": "1s"
+  "transport.tcp_connect_retry_delay": "1s",
+  "window.ingest_max_records": 65536,
+  "window.partition_io_concurrency": 32,
+  "window.due_page_size": 256,
+  "window.process_due_concurrency": 16
 }

--- a/config/runtime_consts.kube_test.json
+++ b/config/runtime_consts.kube_test.json
@@ -24,7 +24,7 @@
   "transport.tcp_connect_max_retries": 10,
   "transport.tcp_connect_retry_delay": "1s",
   "window.ingest_max_records": 65536,
-  "window.partition_io_concurrency": 32,
+  "window.ingest_key_concurrency": 32,
   "window.due_page_size": 256,
   "window.process_due_concurrency": 16
 }

--- a/config/runtime_consts.kube_test.json
+++ b/config/runtime_consts.kube_test.json
@@ -25,6 +25,6 @@
   "transport.tcp_connect_retry_delay": "1s",
   "window.ingest_max_records": 65536,
   "window.ingest_key_concurrency": 32,
-  "window.due_page_size": 256,
-  "window.process_due_concurrency": 16
+  "window.process_page_size": 256,
+  "window.process_key_concurrency": 16
 }

--- a/config/runtime_consts.local_test.json
+++ b/config/runtime_consts.local_test.json
@@ -22,5 +22,9 @@
   "worker.register_connect_timeout": "200ms",
   "worker.register_rpc_timeout": "500ms",
   "transport.tcp_connect_max_retries": 2,
-  "transport.tcp_connect_retry_delay": "50ms"
+  "transport.tcp_connect_retry_delay": "50ms",
+  "window.ingest_max_records": 65536,
+  "window.partition_io_concurrency": 32,
+  "window.due_page_size": 256,
+  "window.process_due_concurrency": 16
 }

--- a/config/runtime_consts.local_test.json
+++ b/config/runtime_consts.local_test.json
@@ -24,7 +24,7 @@
   "transport.tcp_connect_max_retries": 2,
   "transport.tcp_connect_retry_delay": "50ms",
   "window.ingest_max_records": 65536,
-  "window.partition_io_concurrency": 32,
+  "window.ingest_key_concurrency": 32,
   "window.due_page_size": 256,
   "window.process_due_concurrency": 16
 }

--- a/config/runtime_consts.local_test.json
+++ b/config/runtime_consts.local_test.json
@@ -25,6 +25,6 @@
   "transport.tcp_connect_retry_delay": "50ms",
   "window.ingest_max_records": 65536,
   "window.ingest_key_concurrency": 32,
-  "window.due_page_size": 256,
-  "window.process_due_concurrency": 16
+  "window.process_page_size": 256,
+  "window.process_key_concurrency": 16
 }

--- a/config/runtime_consts.prod.json
+++ b/config/runtime_consts.prod.json
@@ -22,5 +22,9 @@
   "worker.register_connect_timeout": "3s",
   "worker.register_rpc_timeout": "3s",
   "transport.tcp_connect_max_retries": 10,
-  "transport.tcp_connect_retry_delay": "1s"
+  "transport.tcp_connect_retry_delay": "1s",
+  "window.ingest_max_records": 65536,
+  "window.partition_io_concurrency": 32,
+  "window.due_page_size": 256,
+  "window.process_due_concurrency": 16
 }

--- a/config/runtime_consts.prod.json
+++ b/config/runtime_consts.prod.json
@@ -24,7 +24,7 @@
   "transport.tcp_connect_max_retries": 10,
   "transport.tcp_connect_retry_delay": "1s",
   "window.ingest_max_records": 65536,
-  "window.partition_io_concurrency": 32,
+  "window.ingest_key_concurrency": 32,
   "window.due_page_size": 256,
   "window.process_due_concurrency": 16
 }

--- a/config/runtime_consts.prod.json
+++ b/config/runtime_consts.prod.json
@@ -25,6 +25,6 @@
   "transport.tcp_connect_retry_delay": "1s",
   "window.ingest_max_records": 65536,
   "window.ingest_key_concurrency": 32,
-  "window.due_page_size": 256,
-  "window.process_due_concurrency": 16
+  "window.process_page_size": 256,
+  "window.process_key_concurrency": 16
 }

--- a/docker/pipeline_spec.demo.json
+++ b/docker/pipeline_spec.demo.json
@@ -30,7 +30,7 @@
           "fields": {
             "value": {
               "Key": {
-                "num_unique": 1
+                "num_unique_keys": 1
               }
             }
           },

--- a/kubevolga/config/samples/volga_v1alpha1_pipeline.yaml
+++ b/kubevolga/config/samples/volga_v1alpha1_pipeline.yaml
@@ -82,7 +82,7 @@ spec:
               "run_for_s": null,
               "batch_size": 5,
               "fields": {
-                "value": { "Key": { "num_unique": 6 } }
+                "value": { "Key": { "num_unique_keys": 6 } }
               },
               "replayable": true
             }

--- a/kubevolga/hack/bench/dashboards/volga-bench.json
+++ b/kubevolga/hack/bench/dashboards/volga-bench.json
@@ -7,7 +7,7 @@
   ],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 8,
+  "version": 9,
   "refresh": "5s",
   "time": {
     "from": "now-15m",
@@ -79,9 +79,9 @@
   },
   "panels": [
     {
-      "id": 10,
+      "id": 20,
       "type": "row",
-      "title": "Job",
+      "title": "Flow",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -92,159 +92,15 @@
       "panels": []
     },
     {
-      "id": 11,
-      "type": "timeseries",
-      "title": "Checkpoints",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 1
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "increase(volga_checkpoint_completed{pipeline_id=~\"$pipeline\"}[5m])",
-          "legendFormat": "{{pipeline_id}} completed",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        },
-        {
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "increase(volga_checkpoint_failed{pipeline_id=~\"$pipeline\"}[5m])",
-          "legendFormat": "{{pipeline_id}} failed",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "fillOpacity": 10,
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "mode": "none",
-              "group": "A"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "description": "Trailing 5m increase of master counters (not a per-second rate). metrics crate does not add _total. Empty if scrape missed the master."
-    },
-    {
-      "id": 12,
-      "type": "timeseries",
-      "title": "Checkpoint duration p99",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 1
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(volga_checkpoint_duration_ms_bucket{pipeline_id=~\"$pipeline\"}[1m])))",
-          "legendFormat": "duration p99",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "fillOpacity": 10,
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "mode": "none",
-              "group": "A"
-            }
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "description": "Success-only histogram. Sparse on a 2-minute / 30s-checkpoint run \u2014 expect a flat-ish line."
-    },
-    {
-      "id": 20,
-      "type": "row",
-      "title": "Flow",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 9
-      },
-      "collapsed": false,
-      "panels": []
-    },
-    {
       "id": 21,
       "type": "timeseries",
       "title": "Throughput",
-      "description": "Per-operator sent rate (subtasks summed). Do not add the series together — each hop counts the same row. Source = ingest, Window sent = WO emit, window recv = WO ingest, sink written = pipeline output. Sink(Count) sent should match sink written.",
+      "description": "Per-operator sent rate (subtasks summed). Do not add the series together \u2014 each hop counts the same row. Source = ingest, Window sent = WO emit, window recv = WO ingest, sink written = pipeline output. Sink(Count) sent should match sink written.",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 10
+        "y": 1
       },
       "datasource": {
         "type": "prometheus",
@@ -327,7 +183,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 10
+        "y": 1
       },
       "datasource": {
         "type": "prometheus",
@@ -389,7 +245,7 @@
           "sort": "desc"
         }
       },
-      "description": "Gauge: wall_now_ms − watermark, then quantile() across selected tasks (not a histogram). 0 means WM ≥ wall (IncrementalTimestamp flying ahead of wall). Series omitted for WM 0 / MAX."
+      "description": "Gauge: wall_now_ms \u2212 watermark, then quantile() across selected tasks (not a histogram). 0 means WM \u2265 wall (IncrementalTimestamp flying ahead of wall). Series omitted for WM 0 / MAX."
     },
     {
       "id": 30,
@@ -399,7 +255,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 9
       },
       "collapsed": false,
       "panels": []
@@ -412,7 +268,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 10
       },
       "datasource": {
         "type": "prometheus",
@@ -496,7 +352,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 20
       },
       "collapsed": false,
       "panels": []
@@ -509,7 +365,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 21
       },
       "datasource": {
         "type": "prometheus",
@@ -595,7 +451,7 @@
           "sort": "desc"
         }
       },
-      "description": "Wall time of insert_batch vs process_due. histogram_quantile over a merged histogram of selected tasks (weighted by call rate, not 'p99 of a typical task'). Buckets 1ms … 5m; +Inf is >5m."
+      "description": "Wall time of insert_batch vs process_due. histogram_quantile over a merged histogram of selected tasks (weighted by call rate, not 'p99 of a typical task'). Buckets 1ms \u2026 5m; +Inf is >5m."
     },
     {
       "id": 43,
@@ -605,7 +461,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 21
       },
       "datasource": {
         "type": "prometheus",
@@ -700,7 +556,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 38
+        "y": 29
       },
       "datasource": {
         "type": "prometheus",
@@ -796,7 +652,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 38
+        "y": 29
       },
       "datasource": {
         "type": "prometheus",
@@ -881,7 +737,151 @@
           "sort": "desc"
         }
       },
-      "description": "In-mem backend entry counts (not bytes), summed across selected Window tasks. key_states ≈ distinct keys. Triggers can dwarf raw rows when process_due lags."
+      "description": "In-mem backend entry counts (not bytes), summed across selected Window tasks. key_states \u2248 distinct keys. Triggers can dwarf raw rows when process_due lags."
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "Job",
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Checkpoints",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "increase(volga_checkpoint_completed{pipeline_id=~\"$pipeline\"}[5m])",
+          "legendFormat": "{{pipeline_id}} completed",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "increase(volga_checkpoint_failed{pipeline_id=~\"$pipeline\"}[5m])",
+          "legendFormat": "{{pipeline_id}} failed",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Trailing 5m increase of master counters (not a per-second rate). metrics crate does not add _total. Empty if scrape missed the master."
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Checkpoint duration p99",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(volga_checkpoint_duration_ms_bucket{pipeline_id=~\"$pipeline\"}[1m])))",
+          "legendFormat": "duration p99",
+          "editorMode": "code",
+          "instant": false,
+          "range": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Success-only histogram. Sparse on a 2-minute / 30s-checkpoint run \u2014 expect a flat-ish line."
     },
     {
       "id": 60,
@@ -954,7 +954,7 @@
           "sort": "desc"
         }
       },
-      "description": "Kubelet cAdvisor. 1.0 = one full core. Not labeled by pipeline_id — shows every master/worker container still running."
+      "description": "Kubelet cAdvisor. 1.0 = one full core. Not labeled by pipeline_id \u2014 shows every master/worker container still running."
     },
     {
       "id": 62,
@@ -1029,90 +1029,6 @@
       "description": "volga_worker_rss_bytes (process RSS, workers only) vs cAdvisor working set (master + workers). Shapes should match; RSS is often a bit below cgroup."
     },
     {
-      "id": 50,
-      "type": "row",
-      "title": "Operator (poll gauges — cumulative, not rec/s)",
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 55
-      },
-      "collapsed": true,
-      "panels": []
-    },
-    {
-      "id": 51,
-      "type": "timeseries",
-      "title": "Operator records (cumulative counts)",
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 56
-      },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum by (operator_id) (volga_operator_records_sent{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\"})",
-          "legendFormat": "sent {{operator_id}}",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        },
-        {
-          "refId": "B",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "sum by (operator_id) (volga_operator_records_recv{pipeline_id=~\"$pipeline\",worker_id=~\"$worker\"})",
-          "legendFormat": "recv {{operator_id}}",
-          "editorMode": "code",
-          "instant": false,
-          "range": true
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "lineInterpolation": "smooth",
-            "fillOpacity": 10,
-            "lineWidth": 2,
-            "pointSize": 5,
-            "showPoints": "never",
-            "spanNulls": true,
-            "stacking": {
-              "mode": "none",
-              "group": "A"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "description": "Worker poll-time gauges of lifetime totals, labeled by operator_id (no task_id; ignores the task dropdown). These are not rec/s — use Throughput for rates."
-    },
-    {
       "id": 70,
       "type": "row",
       "title": "Transport",
@@ -1120,7 +1036,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 55
       },
       "collapsed": false,
       "panels": []
@@ -1133,7 +1049,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 65
+        "y": 56
       },
       "datasource": {
         "type": "prometheus",
@@ -1192,7 +1108,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 65
+        "y": 56
       },
       "datasource": {
         "type": "prometheus",
@@ -1251,7 +1167,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 73
+        "y": 64
       },
       "datasource": {
         "type": "prometheus",
@@ -1311,7 +1227,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 73
+        "y": 64
       },
       "datasource": {
         "type": "prometheus",

--- a/kubevolga/hack/bench/example.yaml
+++ b/kubevolga/hack/bench/example.yaml
@@ -16,6 +16,7 @@ launch:
     retention: 1
   datagen:
     # omit rate → 200/s. `rate: null` → unlimited (no sleep between batches).
+    # Finite rate derives step_ms from num_unique_keys/rate.
     rate: 200
     batch_size: 20
   watermark:

--- a/kubevolga/hack/bench/unlimited.yaml
+++ b/kubevolga/hack/bench/unlimited.yaml
@@ -1,5 +1,5 @@
 # Unlimited datagen, no kill / interval checkpoint / restore.
-# IncrementalTimestamp step_ms=1 (event-time density, not wall).
+# IncrementalTimestamp step_ms is event-time density (not wall).
 # Lag oracles disabled: watermark sits ahead of wall, lag gauge saturates at 0.
 
 env: kube
@@ -17,8 +17,9 @@ launch:
   datagen:
     rate: null
     batch_size: 20
+    step_ms: 1
   watermark:
-    out_of_orderness_ms: 0
+    out_of_orderness_ms: 1
     emit_interval_ms: 200
   window:
     tiling: [1s, 5s]

--- a/src/api/spec/event_time.rs
+++ b/src/api/spec/event_time.rs
@@ -22,9 +22,8 @@ pub struct WatermarkSpec {
     /// `None` keeps the runtime assigner default (`WatermarkAssignConfig::DEFAULT_IDLE_TIMEOUT_MS`).
     #[serde(default)]
     pub idle_timeout_ms: Option<u64>,
-    /// Processing-time interval for coalescing watermark emits (ms).
-    /// Unset uses the runtime default (200ms). Batch does not assign watermarks
-    /// (EOF flush only).
+    /// Event-time emit period and wall-clock cap (ms). Unset uses the runtime
+    /// default (200ms). Batch does not assign watermarks (EOF flush only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub emit_interval_ms: Option<u64>,
 }

--- a/src/api/spec/testdata/kube_embedded_json.yaml
+++ b/src/api/spec/testdata/kube_embedded_json.yaml
@@ -25,7 +25,7 @@ sources:
           "run_for_s": null,
           "batch_size": 5,
           "fields": {
-            "value": { "Key": { "num_unique": 1 } }
+            "value": { "Key": { "num_unique_keys": 1 } }
           },
           "replayable": true
         }

--- a/src/bench/config.rs
+++ b/src/bench/config.rs
@@ -87,13 +87,18 @@ pub struct DatagenFile {
     #[serde(default, deserialize_with = "deserialize_optional_rate")]
     pub rate: Option<Option<f32>>,
     pub batch_size: Option<usize>,
-    pub num_unique: Option<usize>,
+    pub num_unique_keys: Option<usize>,
+    /// Per-key IncrementalTimestamp step. Only valid when `rate` is `null`
+    /// (unlimited); omit → 1. Finite rate always derives
+    /// `num_unique_keys/rate` seconds in ms so event time tracks wall.
+    pub step_ms: Option<u64>,
 }
 
 /// Pipeline-wide watermark assigner knobs (`event_time.watermark`).
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct WatermarkFile {
+    /// Omit → 0. Independent of `datagen.step_ms`.
     pub out_of_orderness_ms: Option<u64>,
     pub idle_timeout_ms: Option<u64>,
     /// Event-time emit period and wall-clock cap. Omit → planner default (200ms).
@@ -310,31 +315,29 @@ fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<D
         DEFAULT_DATAGEN_BATCH,
         "launch.datagen.batch_size",
     )?;
-    let num_unique = nonzero_usize(
-        file.num_unique,
+    let num_unique_keys = nonzero_usize(
+        file.num_unique_keys,
         parallelism * 4,
-        "launch.datagen.num_unique",
+        "launch.datagen.num_unique_keys",
     )?;
+    let step_ms = resolve_step_ms(file.step_ms, rate, num_unique_keys)?;
     let mut fields = HashMap::new();
     // Incremental from wall-clock now so lag is `now − watermark`, not ~55 years.
-    // Finite `rate`: step ≈ per-key inter-arrival so event time tracks wall.
-    // Unlimited: step is a stub until we pick a replayable wall-aligned heuristic.
     let start_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .context("system clock before UNIX epoch")?
         .as_millis() as i64;
-    let step_ms = match rate {
-        Some(r) => ((num_unique as f64) / f64::from(r) * 1000.0).round() as i64,
-        None => 1,
-    };
     fields.insert(
         "timestamp".to_string(),
         FieldGenerator::IncrementalTimestamp {
             start_ms,
-            step_ms: step_ms.max(1),
+            step_ms: step_ms as i64,
         },
     );
-    fields.insert("key".to_string(), FieldGenerator::Key { num_unique });
+    fields.insert(
+        "key".to_string(),
+        FieldGenerator::Key { num_unique_keys },
+    );
     fields.insert(
         "value".to_string(),
         FieldGenerator::Values {
@@ -352,6 +355,21 @@ fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<D
         fields,
         replayable: true,
     })
+}
+
+fn resolve_step_ms(explicit: Option<u64>, rate: Option<f32>, num_unique_keys: usize) -> Result<u64> {
+    match (rate, explicit) {
+        (Some(_), Some(_)) => bail!(
+            "launch.datagen.step_ms is only valid when rate is null (unlimited); \
+             finite rate derives step from num_unique_keys/rate so event time tracks wall"
+        ),
+        (Some(r), None) => {
+            Ok(((num_unique_keys as f64) / f64::from(r) * 1000.0).round().max(1.0) as u64)
+        }
+        (None, None) => Ok(1),
+        (None, Some(0)) => bail!("launch.datagen.step_ms must be >= 1"),
+        (None, Some(n)) => Ok(n),
+    }
 }
 
 fn watermark_from_file(file: Option<&WatermarkFile>) -> Result<(u64, Option<u64>, Option<u64>)> {
@@ -406,10 +424,13 @@ fn parse_granularity(raw: &str) -> Result<TimeGranularity> {
             .trim()
             .parse()
             .map_err(|_| anyhow!("invalid window tiling `{raw}`"))?;
-        if n == 0 || n % 1000 != 0 {
-            bail!("window tiling `{raw}` must be a whole number of seconds");
+        if n == 0 {
+            bail!("window tiling must be > 0: `{raw}`");
         }
-        return Ok(TimeGranularity::Seconds(n / 1000));
+        if n % 1000 == 0 {
+            return Ok(TimeGranularity::Seconds(n / 1000));
+        }
+        return Ok(TimeGranularity::Milliseconds(n));
     }
     if let Some(rest) = raw.strip_suffix('h') {
         let n: u32 = rest
@@ -441,7 +462,7 @@ fn parse_granularity(raw: &str) -> Result<TimeGranularity> {
         }
         return Ok(TimeGranularity::Seconds(n));
     }
-    bail!("invalid window tiling `{raw}` (use Ns, Nm, or Nh)")
+    bail!("invalid window tiling `{raw}` (use Nms, Ns, Nm, or Nh)")
 }
 
 fn apply_oracles(oracles: &mut OracleConfig, file: &OracleFile) -> Result<()> {
@@ -540,7 +561,7 @@ launch:
     retention: 1
   datagen:
     rate: 100
-    num_unique: 32
+    num_unique_keys: 32
   watermark:
     out_of_orderness_ms: 0
     emit_interval_ms: 200

--- a/src/bench/config.rs
+++ b/src/bench/config.rs
@@ -21,7 +21,7 @@ use crate::runtime::operators::window::tile::TileConfig;
 use crate::test_utils::harness::{PipelineLaunchSpec, RuntimeEnv};
 
 use super::dump::extra_prom_queries;
-use super::spec::{OracleConfig, Scenario, BenchSpec};
+use super::spec::{BenchSpec, OracleConfig, Scenario};
 
 const DEFAULT_PARALLELISM: usize = 4;
 const DEFAULT_SLOTS_PER_NODE: usize = 2;
@@ -96,7 +96,7 @@ pub struct DatagenFile {
 pub struct WatermarkFile {
     pub out_of_orderness_ms: Option<u64>,
     pub idle_timeout_ms: Option<u64>,
-    /// Processing-time coalesce. Omit → planner default (200ms).
+    /// Event-time emit period and wall-clock cap. Omit → planner default (200ms).
     pub emit_interval_ms: Option<u64>,
 }
 
@@ -195,9 +195,16 @@ pub fn apply_file(file: &BenchFile) -> Result<BenchSpec> {
 
 fn compile_launch(launch: Option<&LaunchFile>) -> Result<PipelineLaunchSpec> {
     let launch = launch.cloned().unwrap_or_default();
-    let parallelism = nonzero_usize(launch.parallelism, DEFAULT_PARALLELISM, "launch.parallelism")?;
-    let slots_per_node =
-        nonzero_usize(launch.slots_per_node, DEFAULT_SLOTS_PER_NODE, "launch.slots_per_node")?;
+    let parallelism = nonzero_usize(
+        launch.parallelism,
+        DEFAULT_PARALLELISM,
+        "launch.parallelism",
+    )?;
+    let slots_per_node = nonzero_usize(
+        launch.slots_per_node,
+        DEFAULT_SLOTS_PER_NODE,
+        "launch.slots_per_node",
+    )?;
     if parallelism % slots_per_node != 0 {
         bail!(
             "launch.parallelism {parallelism} is not divisible by slots_per_node {slots_per_node}"
@@ -259,10 +266,8 @@ fn compile_launch(launch: Option<&LaunchFile>) -> Result<PipelineLaunchSpec> {
         .with_checkpoint(Some(interval_ms), Some(timeout_ms), Some(retention))
         .build();
 
-    Ok(
-        PipelineLaunchSpec::new(pipeline, worker_count, None)
-            .with_runtime_consts_profile(RuntimeConstsProfile::Prod),
-    )
+    Ok(PipelineLaunchSpec::new(pipeline, worker_count, None)
+        .with_runtime_consts_profile(RuntimeConstsProfile::Prod))
 }
 
 fn checkpoint_from_file(file: Option<&CheckpointFile>) -> Result<(u64, u64, u64)> {
@@ -329,10 +334,7 @@ fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<D
             step_ms: step_ms.max(1),
         },
     );
-    fields.insert(
-        "key".to_string(),
-        FieldGenerator::Key { num_unique },
-    );
+    fields.insert("key".to_string(), FieldGenerator::Key { num_unique });
     fields.insert(
         "value".to_string(),
         FieldGenerator::Values {
@@ -564,22 +566,25 @@ extra_prom_queries:
         );
         assert_eq!(spec.launch.worker_count, 4);
         assert_eq!(spec.launch.pipeline.parallelism, 8);
-        assert_eq!(spec.launch.pipeline.state.checkpoint.interval_ms, Some(30_000));
+        assert_eq!(
+            spec.launch.pipeline.state.checkpoint.interval_ms,
+            Some(30_000)
+        );
         assert!(matches!(spec.launch.pipeline.sink, Some(SinkSpec::Count)));
         assert_eq!(
             spec.launch.pipeline.sql.as_deref(),
             Some("SELECT timestamp, key, value FROM datagen_source")
         );
         assert_eq!(
+            spec.launch.pipeline.event_time.watermark.emit_interval_ms,
+            Some(200)
+        );
+        assert_eq!(
             spec.launch
                 .pipeline
                 .event_time
                 .watermark
-                .emit_interval_ms,
-            Some(200)
-        );
-        assert_eq!(
-            spec.launch.pipeline.event_time.watermark.out_of_orderness_ms,
+                .out_of_orderness_ms,
             0
         );
         assert_eq!(spec.oracles.lag_p99, Duration::from_secs(15));

--- a/src/runtime/consts.rs
+++ b/src/runtime/consts.rs
@@ -42,8 +42,10 @@ pub const TRANSPORT_TCP_CONNECT_RETRY_DELAY: &str = "transport.tcp_connect_retry
 pub const WINDOW_INGEST_MAX_RECORDS: &str = "window.ingest_max_records";
 /// In-flight keys for ingest `insert_batch` and WRO `process_key`.
 pub const WINDOW_INGEST_KEY_CONCURRENCY: &str = "window.ingest_key_concurrency";
-pub const WINDOW_DUE_PAGE_SIZE: &str = "window.due_page_size";
-pub const WINDOW_PROCESS_DUE_CONCURRENCY: &str = "window.process_due_concurrency";
+/// Triggers per `stream_due` page (eval + emit before the next page).
+pub const WINDOW_PROCESS_PAGE_SIZE: &str = "window.process_page_size";
+/// In-flight keys evaluating one process page.
+pub const WINDOW_PROCESS_KEY_CONCURRENCY: &str = "window.process_key_concurrency";
 
 /// Explicit profile: `local_test` | `kube_test` | `prod`.
 pub const VOLGA_RUNTIME_CONSTS_PROFILE_ENV: &str = "VOLGA_RUNTIME_CONSTS_PROFILE";
@@ -84,8 +86,8 @@ const U64_KEYS: &[&str] = &[
     TRANSPORT_TCP_CONNECT_MAX_RETRIES,
     WINDOW_INGEST_MAX_RECORDS,
     WINDOW_INGEST_KEY_CONCURRENCY,
-    WINDOW_DUE_PAGE_SIZE,
-    WINDOW_PROCESS_DUE_CONCURRENCY,
+    WINDOW_PROCESS_PAGE_SIZE,
+    WINDOW_PROCESS_KEY_CONCURRENCY,
 ];
 
 const EMBEDDED_LOCAL_TEST: &str = include_str!("../../config/runtime_consts.local_test.json");
@@ -388,8 +390,8 @@ mod tests {
         for profile in [&prod, &kube, &local] {
             assert_eq!(profile.u64(WINDOW_INGEST_MAX_RECORDS), 65536);
             assert_eq!(profile.u64(WINDOW_INGEST_KEY_CONCURRENCY), 32);
-            assert_eq!(profile.u64(WINDOW_DUE_PAGE_SIZE), 256);
-            assert_eq!(profile.u64(WINDOW_PROCESS_DUE_CONCURRENCY), 16);
+            assert_eq!(profile.u64(WINDOW_PROCESS_PAGE_SIZE), 256);
+            assert_eq!(profile.u64(WINDOW_PROCESS_KEY_CONCURRENCY), 16);
         }
     }
 

--- a/src/runtime/consts.rs
+++ b/src/runtime/consts.rs
@@ -31,14 +31,18 @@ pub const KUBE_WORKER_HEALTH_POLL_INTERVAL: &str = "kube.worker_health_poll_inte
 pub const KUBE_WORKER_HEALTH_UNHEALTHY_GRACE_TICKS: &str =
     "kube.worker_health_unhealthy_grace_ticks";
 pub const WORKER_HEARTBEAT_SEND_INTERVAL: &str = "worker.heartbeat_send_interval";
-pub const WORKER_HEARTBEAT_MASTER_SILENCE_TIMEOUT: &str =
-    "worker.heartbeat_master_silence_timeout";
+pub const WORKER_HEARTBEAT_MASTER_SILENCE_TIMEOUT: &str = "worker.heartbeat_master_silence_timeout";
 pub const WORKER_REGISTER_MAX_RETRIES: &str = "worker.register_max_retries";
 pub const WORKER_REGISTER_RETRY_DELAY: &str = "worker.register_retry_delay";
 pub const WORKER_REGISTER_CONNECT_TIMEOUT: &str = "worker.register_connect_timeout";
 pub const WORKER_REGISTER_RPC_TIMEOUT: &str = "worker.register_rpc_timeout";
 pub const TRANSPORT_TCP_CONNECT_MAX_RETRIES: &str = "transport.tcp_connect_max_retries";
 pub const TRANSPORT_TCP_CONNECT_RETRY_DELAY: &str = "transport.tcp_connect_retry_delay";
+/// Mailbox drain cap for one processor ingest (`drain_ready_after`).
+pub const WINDOW_INGEST_MAX_RECORDS: &str = "window.ingest_max_records";
+pub const WINDOW_PARTITION_IO_CONCURRENCY: &str = "window.partition_io_concurrency";
+pub const WINDOW_DUE_PAGE_SIZE: &str = "window.due_page_size";
+pub const WINDOW_PROCESS_DUE_CONCURRENCY: &str = "window.process_due_concurrency";
 
 /// Explicit profile: `local_test` | `kube_test` | `prod`.
 pub const VOLGA_RUNTIME_CONSTS_PROFILE_ENV: &str = "VOLGA_RUNTIME_CONSTS_PROFILE";
@@ -77,6 +81,10 @@ const U64_KEYS: &[&str] = &[
     KUBE_WORKER_HEALTH_UNHEALTHY_GRACE_TICKS,
     WORKER_REGISTER_MAX_RETRIES,
     TRANSPORT_TCP_CONNECT_MAX_RETRIES,
+    WINDOW_INGEST_MAX_RECORDS,
+    WINDOW_PARTITION_IO_CONCURRENCY,
+    WINDOW_DUE_PAGE_SIZE,
+    WINDOW_PROCESS_DUE_CONCURRENCY,
 ];
 
 const EMBEDDED_LOCAL_TEST: &str = include_str!("../../config/runtime_consts.local_test.json");
@@ -209,14 +217,17 @@ fn resolve_consts_path(profile: RuntimeConstsProfile) -> Option<PathBuf> {
 }
 
 fn parse_consts_json(raw: &str) -> RuntimeConsts {
-    let map: HashMap<String, serde_json::Value> = serde_json::from_str(raw)
-        .unwrap_or_else(|e| panic!("invalid runtime consts JSON: {e}"));
+    let map: HashMap<String, serde_json::Value> =
+        serde_json::from_str(raw).unwrap_or_else(|e| panic!("invalid runtime consts JSON: {e}"));
     let mut values = HashMap::new();
     for &key in DURATION_KEYS {
         let value = map
             .get(key)
             .unwrap_or_else(|| panic!("runtime consts missing duration key {key}"));
-        values.insert(key.to_string(), RuntimeValue::Duration(json_duration(key, value)));
+        values.insert(
+            key.to_string(),
+            RuntimeValue::Duration(json_duration(key, value)),
+        );
     }
     for &key in U64_KEYS {
         let value = map
@@ -229,12 +240,13 @@ fn parse_consts_json(raw: &str) -> RuntimeConsts {
 
 fn json_duration(key: &str, value: &serde_json::Value) -> Duration {
     match value {
-        serde_json::Value::String(s) => parse_duration(s)
-            .unwrap_or_else(|e| panic!("runtime consts {key}: {e}")),
+        serde_json::Value::String(s) => {
+            parse_duration(s).unwrap_or_else(|e| panic!("runtime consts {key}: {e}"))
+        }
         serde_json::Value::Number(n) => {
-            let ms = n
-                .as_u64()
-                .unwrap_or_else(|| panic!("runtime consts {key}: expected non-negative integer ms"));
+            let ms = n.as_u64().unwrap_or_else(|| {
+                panic!("runtime consts {key}: expected non-negative integer ms")
+            });
             Duration::from_millis(ms)
         }
         _ => panic!("runtime consts {key}: expected duration string or integer ms"),
@@ -270,9 +282,7 @@ fn parse_duration(s: &str) -> Result<Duration, String> {
             .map_err(|_| format!("invalid duration '{s}'"))?;
         return Ok(Duration::from_secs(n));
     }
-    Err(format!(
-        "invalid duration '{s}' (use Ns, Nms, or Nus)"
-    ))
+    Err(format!("invalid duration '{s}' (use Ns, Nms, or Nus)"))
 }
 
 static RUNTIME_CONSTS: OnceLock<RuntimeConsts> = OnceLock::new();
@@ -302,10 +312,7 @@ fn select_runtime_consts() -> RuntimeConsts {
             RuntimeConstsProfile::Prod
         }
     });
-    println!(
-        "[MASTER] using {} runtime consts",
-        profile.as_str()
-    );
+    println!("[MASTER] using {} runtime consts", profile.as_str());
     RuntimeConsts::for_profile(profile)
 }
 
@@ -349,7 +356,10 @@ mod tests {
     #[test]
     fn parses_embedded_profiles() {
         let prod = parse_consts_json(EMBEDDED_PROD);
-        assert_eq!(prod.duration(MASTER_DISCOVERY_TIMEOUT), Duration::from_secs(30));
+        assert_eq!(
+            prod.duration(MASTER_DISCOVERY_TIMEOUT),
+            Duration::from_secs(30)
+        );
         assert_eq!(prod.u64(MASTER_RECOVERY_BUDGET), 20);
         assert_eq!(
             prod.duration(MASTER_FAILURE_AGGREGATION_WINDOW),
@@ -364,12 +374,22 @@ mod tests {
         assert_eq!(kube.u64(KUBE_WORKER_HEALTH_UNHEALTHY_GRACE_TICKS), 2);
 
         let local = parse_consts_json(EMBEDDED_LOCAL_TEST);
-        assert_eq!(local.duration(MASTER_DISCOVERY_TIMEOUT), Duration::from_secs(2));
+        assert_eq!(
+            local.duration(MASTER_DISCOVERY_TIMEOUT),
+            Duration::from_secs(2)
+        );
         assert_eq!(
             local.duration(MASTER_WORKER_CONNECT_TIMEOUT),
             Duration::from_millis(200)
         );
         assert_eq!(local.u64(MASTER_RECOVERY_BUDGET), 5);
+
+        for profile in [&prod, &kube, &local] {
+            assert_eq!(profile.u64(WINDOW_INGEST_MAX_RECORDS), 65536);
+            assert_eq!(profile.u64(WINDOW_PARTITION_IO_CONCURRENCY), 32);
+            assert_eq!(profile.u64(WINDOW_DUE_PAGE_SIZE), 256);
+            assert_eq!(profile.u64(WINDOW_PROCESS_DUE_CONCURRENCY), 16);
+        }
     }
 
     #[test]

--- a/src/runtime/consts.rs
+++ b/src/runtime/consts.rs
@@ -40,7 +40,8 @@ pub const TRANSPORT_TCP_CONNECT_MAX_RETRIES: &str = "transport.tcp_connect_max_r
 pub const TRANSPORT_TCP_CONNECT_RETRY_DELAY: &str = "transport.tcp_connect_retry_delay";
 /// Mailbox drain cap for one processor ingest (`drain_ready_after`).
 pub const WINDOW_INGEST_MAX_RECORDS: &str = "window.ingest_max_records";
-pub const WINDOW_PARTITION_IO_CONCURRENCY: &str = "window.partition_io_concurrency";
+/// In-flight keys for ingest `insert_batch` and WRO `process_key`.
+pub const WINDOW_INGEST_KEY_CONCURRENCY: &str = "window.ingest_key_concurrency";
 pub const WINDOW_DUE_PAGE_SIZE: &str = "window.due_page_size";
 pub const WINDOW_PROCESS_DUE_CONCURRENCY: &str = "window.process_due_concurrency";
 
@@ -82,7 +83,7 @@ const U64_KEYS: &[&str] = &[
     WORKER_REGISTER_MAX_RETRIES,
     TRANSPORT_TCP_CONNECT_MAX_RETRIES,
     WINDOW_INGEST_MAX_RECORDS,
-    WINDOW_PARTITION_IO_CONCURRENCY,
+    WINDOW_INGEST_KEY_CONCURRENCY,
     WINDOW_DUE_PAGE_SIZE,
     WINDOW_PROCESS_DUE_CONCURRENCY,
 ];
@@ -386,7 +387,7 @@ mod tests {
 
         for profile in [&prod, &kube, &local] {
             assert_eq!(profile.u64(WINDOW_INGEST_MAX_RECORDS), 65536);
-            assert_eq!(profile.u64(WINDOW_PARTITION_IO_CONCURRENCY), 32);
+            assert_eq!(profile.u64(WINDOW_INGEST_KEY_CONCURRENCY), 32);
             assert_eq!(profile.u64(WINDOW_DUE_PAGE_SIZE), 256);
             assert_eq!(profile.u64(WINDOW_PROCESS_DUE_CONCURRENCY), 16);
         }

--- a/src/runtime/functions/source/datagen_source.rs
+++ b/src/runtime/functions/source/datagen_source.rs
@@ -72,7 +72,11 @@ pub enum FieldGenerator {
     IncrementalTimestamp { start_ms: i64, step_ms: i64 },
     ProcessingTimestamp, // Uses current SystemTime
     String { length: usize }, // Simple random string
-    Key { num_unique: usize }, // Key field with unique values
+    Key {
+        // Cluster image still deserializes `num_unique` until volga:latest is rebuilt.
+        #[serde(rename = "num_unique", alias = "num_unique_keys")]
+        num_unique_keys: usize,
+    },
     Increment {
         #[serde_as(as = "utils::ScalarValueAsBytes")]
         start: ScalarValue,
@@ -222,9 +226,9 @@ impl DatagenSourceFunction {
         // Initialize key values
         if let Some(key_idx) = key_field_index {
             let key_field_name = self.schema.fields()[key_idx].name();
-            if let Some(FieldGenerator::Key { num_unique }) = self.config.spec.fields.get(key_field_name) {
+            if let Some(FieldGenerator::Key { num_unique_keys }) = self.config.spec.fields.get(key_field_name) {
                 // Distribute unique keys across all tasks
-                self.key_values = Self::gen_key_values_for_task(parallelism as usize, task_index as usize, *num_unique);
+                self.key_values = Self::gen_key_values_for_task(parallelism as usize, task_index as usize, *num_unique_keys);
                 
                 // Initialize per-key state for distributed keys
                 for key in self.key_values.iter() {
@@ -243,11 +247,11 @@ impl DatagenSourceFunction {
         }
     }
 
-    pub fn gen_key_values_for_task(parallelism: usize, task_index: usize, num_unique: usize) -> Vec<String> {
+    pub fn gen_key_values_for_task(parallelism: usize, task_index: usize, num_unique_keys: usize) -> Vec<String> {
         let mut key_values = Vec::new();
         
-        let keys_per_task = num_unique / parallelism as usize;
-        let remainder = num_unique % parallelism as usize;
+        let keys_per_task = num_unique_keys / parallelism as usize;
+        let remainder = num_unique_keys % parallelism as usize;
         
         // If there's a remainder, give it to the last task
         let num_keys_for_task = if remainder != 0 && task_index == parallelism - 1 {
@@ -692,7 +696,7 @@ mod tests {
                 step_ms: 100 
             }),
             ("key".to_string(), FieldGenerator::Key { 
-                num_unique: 6  // 6 keys total across all tasks
+                num_unique_keys: 6  // 6 keys total across all tasks
             }),
             ("id".to_string(), FieldGenerator::Increment { 
                 start: ScalarValue::Int64(Some(1)), 
@@ -846,7 +850,7 @@ mod tests {
 
         let fields = HashMap::from([
             ("processing_time".to_string(), FieldGenerator::ProcessingTimestamp),
-            ("key".to_string(), FieldGenerator::Key { num_unique: 4 }),
+            ("key".to_string(), FieldGenerator::Key { num_unique_keys: 4 }),
             ("id".to_string(), FieldGenerator::Increment { 
                 start: ScalarValue::Int64(Some(1)), 
                 step: ScalarValue::Int64(Some(1))
@@ -967,7 +971,7 @@ mod tests {
         fields.insert(
             "key".to_string(),
             FieldGenerator::Key {
-                num_unique: num_unique_keys,
+                num_unique_keys,
             },
         );
         fields.insert(

--- a/src/runtime/operators/operator.rs
+++ b/src/runtime/operators/operator.rs
@@ -2,28 +2,30 @@ use async_trait::async_trait;
 use futures::stream::Peekable;
 use futures::{FutureExt, Stream, StreamExt};
 
+use crate::common::message::{CheckpointBarrierMessage, Message, WatermarkMessage};
 use crate::runtime::checkpoint::{SerializedCheckpoint, SerializedRestore};
 use crate::runtime::functions::join::join_function::JoinFunction;
-use crate::runtime::operators::aggregate::aggregate_operator::{AggregateConfig, AggregateOperator};
+use crate::runtime::functions::source::FetchResult;
+use crate::runtime::functions::{
+    function_trait::FunctionTrait, key_by::KeyByFunction, map::MapFunction,
+};
+use crate::runtime::operators::aggregate::aggregate_operator::{
+    AggregateConfig, AggregateOperator,
+};
 use crate::runtime::operators::join::join_operator::JoinOperator;
 use crate::runtime::operators::key_by::key_by_operator::KeyByOperator;
 use crate::runtime::operators::map::map_operator::MapOperator;
 use crate::runtime::operators::sink::sink_operator::{SinkConfig, SinkOperator};
-use crate::runtime::operators::source::source_operator::{SourceConfig, SourceOperator as SourceOp};
+use crate::runtime::operators::source::source_operator::{
+    SourceConfig, SourceOperator as SourceOp,
+};
 use crate::runtime::operators::window::operator::{WindowOperator, WindowOperatorConfig};
 use crate::runtime::operators::window::request::WindowRequestOperatorConfig;
 use crate::runtime::operators::window::WindowRequestOperator;
 use crate::runtime::runtime_context::RuntimeContext;
-use crate::runtime::functions::source::FetchResult;
-use crate::common::message::{CheckpointBarrierMessage, Message, WatermarkMessage};
 use anyhow::Result;
 use std::fmt;
 use std::pin::Pin;
-use crate::runtime::functions::{
-    function_trait::FunctionTrait,
-    map::MapFunction,
-    key_by::{KeyByFunction},
-};
 
 pub type MessageStream = Pin<Box<dyn Stream<Item = Message> + Send + Sync>>;
 
@@ -37,9 +39,6 @@ pub enum OperatorType {
     Sink,
     Processor,
 }
-
-/// Cap for one processor ingest (`drain_ready_after`).
-pub(crate) const INGEST_MAX_RECORDS: usize = 64 * 1024;
 
 #[async_trait]
 pub trait Output: Send {
@@ -239,7 +238,10 @@ impl OperatorBase {
         }
     }
 
-    pub fn new_with_function<F: FunctionTrait + 'static>(function: F, operator_config: OperatorConfig) -> Self {
+    pub fn new_with_function<F: FunctionTrait + 'static>(
+        function: F,
+        operator_config: OperatorConfig,
+    ) -> Self {
         Self {
             runtime_context: None,
             function: Some(Box::new(function)),
@@ -248,7 +250,8 @@ impl OperatorBase {
     }
 
     pub fn get_function_mut<T: 'static>(&mut self) -> Option<&mut T> {
-        self.function.as_mut()
+        self.function
+            .as_mut()
             .and_then(|f| f.as_any_mut().downcast_mut::<T>())
     }
 
@@ -264,7 +267,7 @@ impl OperatorTrait for OperatorBase {
         if let Some(function) = &mut self.function {
             function.open(context).await?;
         }
-        
+
         Ok(())
     }
 
@@ -272,26 +275,27 @@ impl OperatorTrait for OperatorBase {
         if let Some(function) = &mut self.function {
             function.close().await?;
         }
-        
+
         Ok(())
     }
 
     fn operator_type(&self) -> OperatorType {
         self.operator_config.role()
-    } 
+    }
 
     fn operator_config(&self) -> &OperatorConfig {
         &self.operator_config
     }
 }
 
-
 pub fn create_operator(operator_config: OperatorConfig) -> Operator {
     match operator_config {
         OperatorConfig::SourceConfig(_) => {
             Operator::Source(Box::new(SourceOp::new(operator_config)))
         }
-        OperatorConfig::MapConfig(_) => Operator::Stream(Box::new(MapOperator::new(operator_config))),
+        OperatorConfig::MapConfig(_) => {
+            Operator::Stream(Box::new(MapOperator::new(operator_config)))
+        }
         OperatorConfig::JoinConfig(_) => {
             Operator::Stream(Box::new(JoinOperator::new(operator_config)))
         }

--- a/src/runtime/operators/window/mod.rs
+++ b/src/runtime/operators/window/mod.rs
@@ -28,9 +28,6 @@ pub use tile::TileConfig;
 
 pub const SEQ_NO_COLUMN_NAME: &str = "__seq_no";
 
-/// Concurrent per-key store ops for one ingest/request batch (remote RTT overlap).
-pub(crate) const PARTITION_IO_CONCURRENCY: usize = 32;
-
 pub use aggs::{
     create_window_accumulator, merge_accumulator_state, retract_accumulator_state,
     window_supports_tile_slide, AccumulatorType,

--- a/src/runtime/operators/window/model.rs
+++ b/src/runtime/operators/window/model.rs
@@ -117,6 +117,7 @@ pub struct WindowTrigger {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum TimeGranularity {
+    Milliseconds(u32),
     Seconds(u32),
     Minutes(u32),
     Hours(u32),
@@ -127,6 +128,7 @@ pub enum TimeGranularity {
 impl TimeGranularity {
     pub fn to_millis(&self) -> i64 {
         match self {
+            TimeGranularity::Milliseconds(ms) => *ms as i64,
             TimeGranularity::Seconds(s) => *s as i64 * 1000,
             TimeGranularity::Minutes(m) => *m as i64 * 60 * 1000,
             TimeGranularity::Hours(h) => *h as i64 * 60 * 60 * 1000,

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -12,25 +12,27 @@ use async_trait::async_trait;
 use futures::{stream, StreamExt, TryStreamExt};
 
 use crate::common::key::Key;
-use crate::common::message::Message;
+use crate::common::message::{Message, WatermarkMessage};
 use crate::common::MAX_WATERMARK_VALUE;
-use crate::runtime::functions::key_by::pack::split_by_key_exprs;
 use crate::runtime::checkpoint::{SerializedCheckpoint, SerializedRestore};
+use crate::runtime::consts::{
+    runtime_consts, WINDOW_PARTITION_IO_CONCURRENCY, WINDOW_PROCESS_DUE_CONCURRENCY,
+};
+use crate::runtime::functions::key_by::pack::split_by_key_exprs;
+use crate::runtime::metrics::MetricsLabels;
+use crate::runtime::observability::TaskMetadata;
 use crate::runtime::operators::operator::{
     OperatorBase, OperatorConfig, OperatorTrait, OperatorType, Output, StreamOperator,
 };
 use crate::runtime::operators::window::config::{BuiltWindows, WindowConfig};
 use crate::runtime::operators::window::eval::advance_key;
 use crate::runtime::operators::window::frame_utils::{get_window_length_ms, require_range_frame};
-use crate::runtime::metrics::MetricsLabels;
 use crate::runtime::operators::window::metrics;
 use crate::runtime::operators::window::model::{Cursor, WindowId};
 use crate::runtime::operators::window::spec::WindowSpec;
 use crate::runtime::operators::window::state::{WindowOperatorState, WindowStateSnapshot};
 use crate::runtime::operators::window::store::{open_window_operator_store, StateNamespace};
 use crate::runtime::operators::window::TileConfig;
-use crate::runtime::operators::window::PARTITION_IO_CONCURRENCY;
-use crate::runtime::observability::TaskMetadata;
 use crate::runtime::runtime_context::RuntimeContext;
 use crate::runtime::state::{OperatorTaskState, StateRegistry};
 use crate::runtime::VertexId;
@@ -177,27 +179,25 @@ impl WindowOperator {
         self.state_ref().clone()
     }
 
+    #[cfg(test)]
+    pub(crate) fn output_schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
+
     fn state_ref(&self) -> &Arc<WindowOperatorState> {
         self.state
             .as_ref()
             .expect("WindowOperator must be opened first")
     }
 
-    async fn process_due(&self, through: Cursor) -> RecordBatch {
-        const PROCESS_DUE_CONCURRENCY: usize = 8;
+    async fn emit_due_pages(&self, through: Cursor, out: &mut dyn Output) -> Result<()> {
+        let concurrency = runtime_consts().u64(WINDOW_PROCESS_DUE_CONCURRENCY).max(1) as usize;
         let state = self.state_ref();
         let after = state
             .watermark_frontier()
             .map(|timestamp| Cursor::new(timestamp, u64::MAX));
-        let mut pages = state
-            .store()
-            .stream_due(state.namespace(), after, through);
-        let mut batches = Vec::new();
-        while let Some(work) = pages
-            .try_next()
-            .await
-            .expect("stream due window triggers")
-        {
+        let mut pages = state.store().stream_due(state.namespace(), after, through);
+        while let Some(work) = pages.try_next().await.expect("stream due window triggers") {
             let page = stream::iter(work)
                 .map(|work| {
                     advance_key(
@@ -209,16 +209,18 @@ impl WindowOperator {
                         &self.input_schema,
                     )
                 })
-                .buffered(PROCESS_DUE_CONCURRENCY)
+                .buffered(concurrency)
                 .try_collect::<Vec<_>>()
                 .await
                 .expect("advance due window triggers");
-            batches.extend(page);
+            let batch = if page.is_empty() {
+                RecordBatch::new_empty(self.output_schema.clone())
+            } else {
+                concat_batches(&self.output_schema, &page).expect("concat")
+            };
+            out.emit(Message::new(None, batch, None, None)).await?;
         }
-        if batches.is_empty() {
-            return RecordBatch::new_empty(self.output_schema.clone());
-        }
-        arrow::compute::concat_batches(&self.output_schema, &batches).expect("concat")
+        Ok(())
     }
 
     async fn ingest_data(&mut self, messages: Vec<Message>) {
@@ -249,14 +251,12 @@ impl WindowOperator {
                 let state = state.clone();
                 async move { state.insert_batch(&key, payload, emit).await }
             })
-            .buffer_unordered(PARTITION_IO_CONCURRENCY)
+            .buffer_unordered(runtime_consts().u64(WINDOW_PARTITION_IO_CONCURRENCY).max(1) as usize)
             .fold(0usize, |acc, n| async move { acc + n })
             .await;
         debug_assert!(dropped <= input_rows);
-        self.task_metadata.increment_u64(
-            TASK_METADATA_ROWS_ACCEPTED,
-            (input_rows - dropped) as u64,
-        );
+        self.task_metadata
+            .increment_u64(TASK_METADATA_ROWS_ACCEPTED, (input_rows - dropped) as u64);
         self.task_metadata
             .increment_u64(TASK_METADATA_ROWS_DROPPED_LATE, dropped as u64);
         if let Some((task_id, labels)) = self.metrics_target() {
@@ -271,7 +271,7 @@ impl WindowOperator {
 
     async fn handle_watermark_inner(
         &mut self,
-        watermark: crate::common::message::WatermarkMessage,
+        watermark: WatermarkMessage,
         out: &mut dyn Output,
     ) -> Result<()> {
         let wm_ts = if watermark.watermark_value == MAX_WATERMARK_VALUE {
@@ -279,15 +279,14 @@ impl WindowOperator {
         } else {
             watermark.watermark_value as i64
         };
-        let advance_to = Cursor::new(wm_ts, u64::MAX);
-        let state = self.state_ref();
-
-        let advances_frontier = state
+        let advances_frontier = self
+            .state_ref()
             .watermark_frontier()
             .map_or(true, |frontier| wm_ts > frontier);
-        let result = if advances_frontier && self.output_mode == WindowOutputMode::Emit {
+        if advances_frontier && self.output_mode == WindowOutputMode::Emit {
             let started = Instant::now();
-            let batch = self.process_due(advance_to).await;
+            self.emit_due_pages(Cursor::new(wm_ts, u64::MAX), out)
+                .await?;
             if let Some((task_id, labels)) = self.metrics_target() {
                 metrics::record_wm_process_ms(
                     task_id,
@@ -295,16 +294,11 @@ impl WindowOperator {
                     started.elapsed().as_secs_f64() * 1000.0,
                 );
             }
-            batch
-        } else {
-            RecordBatch::new_empty(self.output_schema.clone())
-        };
-        if advances_frontier {
-            state.watermark_frontier.store(wm_ts, Ordering::Release);
         }
-
-        if self.output_mode == WindowOutputMode::Emit {
-            out.emit(Message::new(None, result, None, None)).await?;
+        if advances_frontier {
+            self.state_ref()
+                .watermark_frontier
+                .store(wm_ts, Ordering::Release);
         }
         out.emit(Message::Watermark(watermark)).await
     }
@@ -316,8 +310,7 @@ impl OperatorTrait for WindowOperator {
         self.base.open(context).await?;
         self.task_metadata = context.task_metadata();
         self.task_metadata.set(TASK_METADATA_ROWS_ACCEPTED, 0);
-        self.task_metadata
-            .set(TASK_METADATA_ROWS_DROPPED_LATE, 0);
+        self.task_metadata.set(TASK_METADATA_ROWS_DROPPED_LATE, 0);
 
         if self.state.is_none() {
             let backend = context
@@ -346,10 +339,8 @@ impl OperatorTrait for WindowOperator {
                 self.lateness_ms,
                 self.max_window_length_ms,
             ));
-            registry.insert_task_state(
-                task_id.clone(),
-                state.clone() as Arc<dyn OperatorTaskState>,
-            );
+            registry
+                .insert_task_state(task_id.clone(), state.clone() as Arc<dyn OperatorTaskState>);
             self.state_registry = Some(registry.clone());
             self.vertex_id = Some(task_id);
             self.metrics_labels = context.metrics_labels();

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -16,7 +16,7 @@ use crate::common::message::{Message, WatermarkMessage};
 use crate::common::MAX_WATERMARK_VALUE;
 use crate::runtime::checkpoint::{SerializedCheckpoint, SerializedRestore};
 use crate::runtime::consts::{
-    runtime_consts, WINDOW_PARTITION_IO_CONCURRENCY, WINDOW_PROCESS_DUE_CONCURRENCY,
+    runtime_consts, WINDOW_INGEST_KEY_CONCURRENCY, WINDOW_PROCESS_DUE_CONCURRENCY,
 };
 use crate::runtime::functions::key_by::pack::split_by_key_exprs;
 use crate::runtime::metrics::MetricsLabels;
@@ -251,7 +251,7 @@ impl WindowOperator {
                 let state = state.clone();
                 async move { state.insert_batch(&key, payload, emit).await }
             })
-            .buffer_unordered(runtime_consts().u64(WINDOW_PARTITION_IO_CONCURRENCY).max(1) as usize)
+            .buffer_unordered(runtime_consts().u64(WINDOW_INGEST_KEY_CONCURRENCY).max(1) as usize)
             .fold(0usize, |acc, n| async move { acc + n })
             .await;
         debug_assert!(dropped <= input_rows);

--- a/src/runtime/operators/window/operator.rs
+++ b/src/runtime/operators/window/operator.rs
@@ -16,7 +16,7 @@ use crate::common::message::{Message, WatermarkMessage};
 use crate::common::MAX_WATERMARK_VALUE;
 use crate::runtime::checkpoint::{SerializedCheckpoint, SerializedRestore};
 use crate::runtime::consts::{
-    runtime_consts, WINDOW_INGEST_KEY_CONCURRENCY, WINDOW_PROCESS_DUE_CONCURRENCY,
+    runtime_consts, WINDOW_INGEST_KEY_CONCURRENCY, WINDOW_PROCESS_KEY_CONCURRENCY,
 };
 use crate::runtime::functions::key_by::pack::split_by_key_exprs;
 use crate::runtime::metrics::MetricsLabels;
@@ -191,7 +191,7 @@ impl WindowOperator {
     }
 
     async fn emit_due_pages(&self, through: Cursor, out: &mut dyn Output) -> Result<()> {
-        let concurrency = runtime_consts().u64(WINDOW_PROCESS_DUE_CONCURRENCY).max(1) as usize;
+        let concurrency = runtime_consts().u64(WINDOW_PROCESS_KEY_CONCURRENCY).max(1) as usize;
         let state = self.state_ref();
         let after = state
             .watermark_frontier()

--- a/src/runtime/operators/window/request.rs
+++ b/src/runtime/operators/window/request.rs
@@ -13,6 +13,7 @@ use futures::{stream, StreamExt};
 
 use crate::common::message::Message;
 use crate::common::Key;
+use crate::runtime::consts::{runtime_consts, WINDOW_PARTITION_IO_CONCURRENCY};
 use crate::runtime::functions::key_by::pack::split_by_key_exprs;
 use crate::runtime::operators::operator::{
     OperatorBase, OperatorConfig, OperatorTrait, OperatorType, Output, StreamOperator,
@@ -27,7 +28,6 @@ use crate::runtime::operators::window::store::{
     open_window_request_store, PartitionKey, StateNamespace, WindowRequestStore,
 };
 use crate::runtime::operators::window::TileConfig;
-use crate::runtime::operators::window::PARTITION_IO_CONCURRENCY;
 use crate::runtime::runtime_context::RuntimeContext;
 
 #[derive(Debug, Clone)]
@@ -163,10 +163,8 @@ impl WindowRequestOperator {
 
     async fn process_groups(&self, groups: Vec<(Key, RecordBatch)>) -> RecordBatch {
         let mut batches: Vec<(usize, RecordBatch)> = stream::iter(groups.into_iter().enumerate())
-            .map(|(i, (key, payload))| async move {
-                (i, self.process_key(&key, &payload).await)
-            })
-            .buffer_unordered(PARTITION_IO_CONCURRENCY)
+            .map(|(i, (key, payload))| async move { (i, self.process_key(&key, &payload).await) })
+            .buffer_unordered(runtime_consts().u64(WINDOW_PARTITION_IO_CONCURRENCY).max(1) as usize)
             .collect()
             .await;
         batches.sort_by_key(|(i, _)| *i);

--- a/src/runtime/operators/window/request.rs
+++ b/src/runtime/operators/window/request.rs
@@ -13,7 +13,7 @@ use futures::{stream, StreamExt};
 
 use crate::common::message::Message;
 use crate::common::Key;
-use crate::runtime::consts::{runtime_consts, WINDOW_PARTITION_IO_CONCURRENCY};
+use crate::runtime::consts::{runtime_consts, WINDOW_INGEST_KEY_CONCURRENCY};
 use crate::runtime::functions::key_by::pack::split_by_key_exprs;
 use crate::runtime::operators::operator::{
     OperatorBase, OperatorConfig, OperatorTrait, OperatorType, Output, StreamOperator,
@@ -164,7 +164,7 @@ impl WindowRequestOperator {
     async fn process_groups(&self, groups: Vec<(Key, RecordBatch)>) -> RecordBatch {
         let mut batches: Vec<(usize, RecordBatch)> = stream::iter(groups.into_iter().enumerate())
             .map(|(i, (key, payload))| async move { (i, self.process_key(&key, &payload).await) })
-            .buffer_unordered(runtime_consts().u64(WINDOW_PARTITION_IO_CONCURRENCY).max(1) as usize)
+            .buffer_unordered(runtime_consts().u64(WINDOW_INGEST_KEY_CONCURRENCY).max(1) as usize)
             .collect()
             .await;
         batches.sort_by_key(|(i, _)| *i);

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use std::any::Any;
 
-use crate::runtime::consts::{runtime_consts, WINDOW_DUE_PAGE_SIZE};
+use crate::runtime::consts::{runtime_consts, WINDOW_PROCESS_PAGE_SIZE};
 use crate::runtime::metrics::MetricsLabels;
 use crate::runtime::operators::window::metrics;
 use crate::runtime::operators::window::model::{Cursor, RawRun, TileRun, WindowTrigger};
@@ -372,7 +372,7 @@ impl WindowOperatorStore for InMemWindowStore {
         after: Option<Cursor>,
         through: Cursor,
     ) -> DueWorkStream<'a> {
-        let page_size = runtime_consts().u64(WINDOW_DUE_PAGE_SIZE).max(1) as usize;
+        let page_size = runtime_consts().u64(WINDOW_PROCESS_PAGE_SIZE).max(1) as usize;
 
         let store = self.clone();
         let namespace = namespace.bytes.clone();
@@ -596,7 +596,7 @@ impl OperatorStore for InMemWindowStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::runtime::consts::{runtime_consts, WINDOW_DUE_PAGE_SIZE};
+    use crate::runtime::consts::{runtime_consts, WINDOW_PROCESS_PAGE_SIZE};
     use futures::TryStreamExt;
 
     use crate::runtime::operators::window::model::{
@@ -1007,7 +1007,7 @@ mod tests {
         let first = due.try_next().await.unwrap().unwrap();
         assert_eq!(
             first[0].triggers.len(),
-            runtime_consts().u64(WINDOW_DUE_PAGE_SIZE) as usize
+            runtime_consts().u64(WINDOW_PROCESS_PAGE_SIZE) as usize
         );
         let second = due.try_next().await.unwrap().unwrap();
         assert_eq!(second[0].triggers.len(), 34);

--- a/src/runtime/operators/window/store/backend/inmem.rs
+++ b/src/runtime/operators/window/store/backend/inmem.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use std::any::Any;
 
+use crate::runtime::consts::{runtime_consts, WINDOW_DUE_PAGE_SIZE};
 use crate::runtime::metrics::MetricsLabels;
 use crate::runtime::operators::window::metrics;
 use crate::runtime::operators::window::model::{Cursor, RawRun, TileRun, WindowTrigger};
@@ -371,7 +372,7 @@ impl WindowOperatorStore for InMemWindowStore {
         after: Option<Cursor>,
         through: Cursor,
     ) -> DueWorkStream<'a> {
-        const PAGE_SIZE: usize = 256;
+        let page_size = runtime_consts().u64(WINDOW_DUE_PAGE_SIZE).max(1) as usize;
 
         let store = self.clone();
         let namespace = namespace.bytes.clone();
@@ -392,7 +393,7 @@ impl WindowOperatorStore for InMemWindowStore {
                                 .as_ref()
                                 .map_or(true, |resume_after| *trigger > resume_after)
                         })
-                        .take(PAGE_SIZE)
+                        .take(page_size)
                         .cloned()
                         .collect::<Vec<_>>();
                     let Some(next) = selected.last().cloned() else {
@@ -595,15 +596,16 @@ impl OperatorStore for InMemWindowStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::runtime::consts::{runtime_consts, WINDOW_DUE_PAGE_SIZE};
     use futures::TryStreamExt;
 
-    use crate::test_utils::window_aggs as test_utils;
     use crate::runtime::operators::window::model::{
         KeyEvaluationState, TileRun, TimeGranularity, WindowTiles, WindowTriggerKind,
     };
     use crate::runtime::operators::window::state::WindowOperatorState;
     use crate::runtime::operators::window::store::{data::RowIdx, StateVersion};
     use crate::runtime::state::OperatorStore;
+    use crate::test_utils::window_aggs as test_utils;
 
     fn partition() -> PartitionKey {
         PartitionKey {
@@ -654,7 +656,12 @@ mod tests {
     }
 
     fn assert_packed(batches: &[RecordBatch], rows: usize) {
-        assert_eq!(batches.len(), 1, "expected one packed batch, got {}", batches.len());
+        assert_eq!(
+            batches.len(),
+            1,
+            "expected one packed batch, got {}",
+            batches.len()
+        );
         assert_eq!(batches[0].num_rows(), rows);
     }
 
@@ -998,7 +1005,10 @@ mod tests {
             Cursor::new(299, u64::MAX),
         );
         let first = due.try_next().await.unwrap().unwrap();
-        assert_eq!(first[0].triggers.len(), 256);
+        assert_eq!(
+            first[0].triggers.len(),
+            runtime_consts().u64(WINDOW_DUE_PAGE_SIZE) as usize
+        );
         let second = due.try_next().await.unwrap().unwrap();
         assert_eq!(second[0].triggers.len(), 34);
         assert!(due.try_next().await.unwrap().is_none());
@@ -1101,10 +1111,7 @@ mod tests {
         let partition = partition();
         let namespace = StateNamespace::new(&partition.namespace);
         let mut accumulators = BTreeMap::new();
-        accumulators.insert(
-            7,
-            vec![datafusion::scalar::ScalarValue::Float64(Some(3.0))],
-        );
+        accumulators.insert(7, vec![datafusion::scalar::ScalarValue::Float64(Some(3.0))]);
         let meta = KeyState {
             next_seq: 3,
             evaluation: Some(KeyEvaluationState {

--- a/src/runtime/operators/window/tests/smoke.rs
+++ b/src/runtime/operators/window/tests/smoke.rs
@@ -6,12 +6,12 @@ use crate::common::message::Message;
 use crate::common::MAX_WATERMARK_VALUE;
 use crate::runtime::operators::operator::{StreamOperator, VecOutput};
 use crate::runtime::operators::window::operator::WindowOperatorConfig;
+use crate::runtime::operators::window::{
+    TileConfig, TimeGranularity, TASK_METADATA_ROWS_ACCEPTED, TASK_METADATA_ROWS_DROPPED_LATE,
+};
 use crate::test_utils::window::harness::{
     assert_window_values, batch, keyed_message, run_wo, watermark_message, window_exec_from_sql,
     Harness, WoWroHarness,
-};
-use crate::runtime::operators::window::{
-    TileConfig, TimeGranularity, TASK_METADATA_ROWS_ACCEPTED, TASK_METADATA_ROWS_DROPPED_LATE,
 };
 
 #[tokio::test]
@@ -187,5 +187,75 @@ WINDOW w AS (
             vec![ScalarValue::Float64(Some(3.0))],
         ],
         "both data messages ingested before the watermark",
+    );
+}
+
+#[tokio::test]
+async fn process_due_emits_pages_before_watermark() {
+    let sql = r#"SELECT timestamp, value, partition_key, SUM(value) OVER w as sum_val
+FROM test_table
+WINDOW w AS (
+  PARTITION BY partition_key
+  ORDER BY timestamp
+  RANGE BETWEEN INTERVAL '5000' MILLISECOND PRECEDING AND CURRENT ROW
+)"#;
+    let n = 300i64;
+    let ts: Vec<i64> = (1..=n).map(|i| i * 10).collect();
+    let vals: Vec<f64> = (1..=n).map(|i| i as f64).collect();
+    let keys: Vec<&str> = vec!["A"; n as usize];
+    let exec = window_exec_from_sql(sql).await;
+    let mut h = Harness::new(WindowOperatorConfig::new(exec)).await;
+    h.ingest(batch(ts, vals, keys), "A").await;
+    assert_eq!(
+        h.task_metadata.get(TASK_METADATA_ROWS_ACCEPTED).as_deref(),
+        Some("300")
+    );
+
+    let mut out = VecOutput::default();
+    h.op.handle_watermark(
+        match watermark_message(3_000) {
+            Message::Watermark(w) => w,
+            other => panic!("expected watermark, got {other:?}"),
+        },
+        &mut out,
+    )
+    .await
+    .expect("watermark");
+
+    let mut pages = 0usize;
+    let mut rows = 0usize;
+    let mut saw_wm = false;
+    for msg in &out.messages {
+        match msg {
+            Message::Regular(base) => {
+                assert!(!saw_wm, "due pages must emit before the watermark");
+                pages += 1;
+                rows += base.record_batch.num_rows();
+            }
+            Message::Watermark(w) => {
+                assert_eq!(w.watermark_value, 3_000);
+                saw_wm = true;
+            }
+            other => panic!("expected due page or watermark, got {other:?}"),
+        }
+    }
+    assert!(saw_wm);
+    assert!(
+        pages >= 2,
+        "300 triggers should span more than one due page"
+    );
+    assert_eq!(rows, 300);
+
+    let mut extra = VecOutput::default();
+    h.op.process_data(
+        vec![keyed_message(batch(vec![4_000], vec![1.0], vec!["A"]), "A")],
+        &mut extra,
+    )
+    .await
+    .expect("ingest after watermark");
+    assert!(extra.messages.is_empty());
+    assert_eq!(
+        h.task_metadata.get(TASK_METADATA_ROWS_ACCEPTED).as_deref(),
+        Some("301")
     );
 }

--- a/src/runtime/operators/window/tile.rs
+++ b/src/runtime/operators/window/tile.rs
@@ -235,6 +235,11 @@ mod tests {
             TimeGranularity::Minutes(7),
         ])
         .is_err());
+        assert!(TileConfig::new(vec![
+            TimeGranularity::Milliseconds(100),
+            TimeGranularity::Milliseconds(500),
+        ])
+        .is_ok());
     }
 
     #[test]

--- a/src/runtime/stream_task/processor.rs
+++ b/src/runtime/stream_task/processor.rs
@@ -4,9 +4,8 @@ use anyhow::Result;
 use futures::StreamExt;
 
 use crate::common::message::Message;
-use crate::runtime::operators::operator::{
-    drain_ready_after, MessageStream, StreamOperator, INGEST_MAX_RECORDS,
-};
+use crate::runtime::consts::{runtime_consts, WINDOW_INGEST_MAX_RECORDS};
+use crate::runtime::operators::operator::{drain_ready_after, MessageStream, StreamOperator};
 use crate::transport::transport_client::DataReaderControl;
 
 use super::checkpoint::on_checkpoint_barrier;
@@ -93,7 +92,12 @@ pub(super) async fn processor_loop(
                             assigned.push(wm);
                         }
                         let batch =
-                            drain_ready_after(first, &mut mailbox, INGEST_MAX_RECORDS).await;
+                            drain_ready_after(
+                                first,
+                                &mut mailbox,
+                                runtime_consts().u64(WINDOW_INGEST_MAX_RECORDS).max(1) as usize,
+                            )
+                            .await;
                         for extra in &batch[1..] {
                             ctx.record_recv(extra);
                             if let Some(wm) = progress.assign_and_merge(extra).await {

--- a/src/runtime/stream_task/watermark.rs
+++ b/src/runtime/stream_task/watermark.rs
@@ -47,14 +47,24 @@ impl WatermarkAssignerState {
             .saturating_sub(out_of_orderness_ms)
     }
 
-    fn is_due(progress: &UpstreamWatermarkProgress, interval: Duration, now: Instant) -> bool {
+    /// Emit when event time moved by `interval` since last emit, or wall clock
+    /// moved by the same interval (quiet source with an unpublished candidate).
+    fn is_due(
+        progress: &UpstreamWatermarkProgress,
+        interval: Duration,
+        now: Instant,
+        candidate: u64,
+    ) -> bool {
         if interval.is_zero() {
             return true;
         }
-        match progress.last_emit_at {
-            None => true,
-            Some(t) => now.saturating_duration_since(t) >= interval,
-        }
+        let Some(last_emit_at) = progress.last_emit_at else {
+            return true;
+        };
+        let interval_ms = interval.as_millis() as u64;
+        let event_due = candidate.saturating_sub(progress.last_emitted_wm_ms) >= interval_ms;
+        let wall_due = now.saturating_duration_since(last_emit_at) >= interval;
+        event_due || wall_due
     }
 
     fn emit(
@@ -81,7 +91,8 @@ impl WatermarkAssignerState {
         force: bool,
     ) -> Option<WatermarkMessage> {
         let candidate = Self::candidate(progress, out_of_orderness_ms);
-        if candidate > progress.last_emitted_wm_ms && (force || Self::is_due(progress, interval, now))
+        if candidate > progress.last_emitted_wm_ms
+            && (force || Self::is_due(progress, interval, now, candidate))
         {
             Some(Self::emit(progress, upstream_vertex_id, candidate, now))
         } else {
@@ -102,13 +113,16 @@ impl WatermarkAssignerState {
     }
 
     fn resolve_ts_column_index(&self, batch: &RecordBatch) -> usize {
-        batch.schema().index_of(&self.ts_column_name).unwrap_or_else(|_| {
-            panic!(
-                "WatermarkAssign failed: missing column '{}' in schema {:?}",
-                self.ts_column_name,
-                batch.schema()
-            )
-        })
+        batch
+            .schema()
+            .index_of(&self.ts_column_name)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "WatermarkAssign failed: missing column '{}' in schema {:?}",
+                    self.ts_column_name,
+                    batch.schema()
+                )
+            })
     }
 
     fn batch_max_ts_ms(&self, batch: &RecordBatch, ts_column_index: usize) -> Option<u64> {
@@ -229,7 +243,9 @@ impl WatermarkManager {
         upstream_watermarks: Arc<Mutex<HashMap<String, u64>>>,
         current_watermark: Arc<AtomicU64>,
     ) -> Self {
-        let idle_timeout_ms = watermark_assign.as_ref().and_then(|cfg| cfg.idle_timeout_ms);
+        let idle_timeout_ms = watermark_assign
+            .as_ref()
+            .and_then(|cfg| cfg.idle_timeout_ms);
         let assigner = watermark_assign.map(WatermarkAssignerState::new);
         let last_seen_processing_time = upstream_vertices
             .iter()
@@ -249,7 +265,11 @@ impl WatermarkManager {
         self.assigner.is_some()
     }
 
-    pub fn on_data_message(&mut self, upstream_vertex_id: &str, message: &Message) -> Option<WatermarkMessage> {
+    pub fn on_data_message(
+        &mut self,
+        upstream_vertex_id: &str,
+        message: &Message,
+    ) -> Option<WatermarkMessage> {
         let now = Instant::now();
         self.last_seen_processing_time
             .insert(upstream_vertex_id.to_string(), now);
@@ -337,7 +357,12 @@ pub async fn advance_watermark_min(
         .metadata
         .upstream_vertex_id
         .clone()
-        .unwrap_or_else(|| panic!("Watermark must have upstream_vertex_id set: {:?}", watermark));
+        .unwrap_or_else(|| {
+            panic!(
+                "Watermark must have upstream_vertex_id set: {:?}",
+                watermark
+            )
+        });
 
     let mut upstream_wms = upstream_watermarks.lock().await;
     if let Some(&prev) = upstream_wms.get(&upstream_id) {
@@ -372,4 +397,3 @@ pub async fn advance_watermark_min(
         None
     }
 }
-

--- a/src/runtime/stream_task/watermark_test.rs
+++ b/src/runtime/stream_task/watermark_test.rs
@@ -115,11 +115,7 @@ fn coalesce_holds_until_interval() {
         .unwrap();
     assert_eq!(first.watermark_value, 100);
 
-    let held = assigner.on_data_message_at(
-        "u",
-        &ts_message(150),
-        t0 + Duration::from_millis(10),
-    );
+    let held = assigner.on_data_message_at("u", &ts_message(150), t0 + Duration::from_millis(10));
     assert!(held.is_none());
     assert!(assigner
         .try_emit_due(t0 + Duration::from_millis(10))
@@ -172,6 +168,22 @@ fn data_path_emits_when_interval_elapsed() {
         .on_data_message_at("u", &ts_message(300), t0 + Duration::from_millis(200))
         .unwrap();
     assert_eq!(late.watermark_value, 300);
+}
+
+#[test]
+fn event_time_interval_emits_without_waiting_for_wall() {
+    let mut assigner = assigner_with_interval(Duration::from_millis(200));
+    let t0 = Instant::now();
+    assigner
+        .on_data_message_at("u", &ts_message(100), t0)
+        .unwrap();
+    assert!(assigner
+        .on_data_message_at("u", &ts_message(299), t0 + Duration::from_millis(1))
+        .is_none());
+    let crossed = assigner
+        .on_data_message_at("u", &ts_message(300), t0 + Duration::from_millis(1))
+        .unwrap();
+    assert_eq!(crossed.watermark_value, 300);
 }
 
 #[tokio::test]
@@ -249,10 +261,7 @@ async fn input_progress_is_per_upstream_and_min_merged() {
 async fn input_progress_preserves_upstream_watermark_extras() {
     let mut progress = InputProgress::for_test(None, &["u0"]);
     let mut wm = WatermarkMessage::new("u0".to_string(), 100, Some(1));
-    wm.metadata.extras = Some(HashMap::from([(
-        "trace".to_string(),
-        "u0".to_string(),
-    )]));
+    wm.metadata.extras = Some(HashMap::from([("trace".to_string(), "u0".to_string())]));
     let out = progress.on_upstream_watermark(wm).await;
     assert_eq!(out.len(), 1);
     assert_eq!(out[0].watermark_value, 100);

--- a/src/runtime/stream_task/watermark_test.rs
+++ b/src/runtime/stream_task/watermark_test.rs
@@ -342,12 +342,13 @@ async fn input_progress_timer_emits_held_watermark() {
 
     let first = progress.assign_and_merge(&ts_up("u0", 100)).await.unwrap();
     assert_eq!(first.watermark_value, 100);
-    assert!(progress.assign_on_data(&ts_up("u0", 150)).is_none());
+    // Event time moved by less than `interval`, so only the wall timer should emit.
+    assert!(progress.assign_on_data(&ts_up("u0", 120)).is_none());
 
     tokio::time::sleep(interval + Duration::from_millis(10)).await;
     let due = progress.on_timer().await;
     assert_eq!(due.len(), 1);
-    assert_eq!(due[0].watermark_value, 150);
+    assert_eq!(due[0].watermark_value, 120);
 }
 
 #[tokio::test]

--- a/src/runtime/watermark/confg.rs
+++ b/src/runtime/watermark/confg.rs
@@ -5,7 +5,8 @@ pub struct WatermarkAssignConfig {
     pub out_of_orderness_ms: u64,
     pub time_hint: TimeHint,
     pub idle_timeout_ms: Option<u64>,
-    /// Processing-time coalesce. `Duration::ZERO` emits on every advance (tests only).
+    /// Event-time period and wall-clock cap. `Duration::ZERO` emits on every
+    /// candidate advance (tests only).
     pub emit_interval: Duration,
 }
 

--- a/src/test_utils/checkpoint/launch.rs
+++ b/src/test_utils/checkpoint/launch.rs
@@ -78,7 +78,7 @@ pub(super) fn checkpoint_datagen_parts(
     fields.insert(
         "key".to_string(),
         FieldGenerator::Key {
-            num_unique: parallelism
+            num_unique_keys: parallelism
                 * match workload {
                     CheckpointWorkload::PassThrough => 8,
                     CheckpointWorkload::Window => 4,

--- a/src/test_utils/smoke.rs
+++ b/src/test_utils/smoke.rs
@@ -68,7 +68,7 @@ pub fn docker_smoke_launch_spec() -> PipelineLaunchSpec {
 }
 
 pub fn kube_smoke_launch_spec() -> PipelineLaunchSpec {
-    deployment_smoke_launch_spec(FieldGenerator::Key { num_unique: 6 })
+    deployment_smoke_launch_spec(FieldGenerator::Key { num_unique_keys: 6 })
         .with_kube_worker_health_poll(true)
         .with_state_maintenance(true, 100)
 }

--- a/src/test_utils/window/harness.rs
+++ b/src/test_utils/window/harness.rs
@@ -14,6 +14,7 @@ use crate::api::planner::{Planner, PlanningContext};
 use crate::common::message::Message;
 use crate::common::{Key, WatermarkMessage};
 use crate::runtime::functions::key_by::key_by_function::extract_datafusion_window_exec;
+use crate::runtime::observability::TaskMetadata;
 use crate::runtime::operators::operator::{
     OperatorConfig, OperatorTrait, StreamOperator, VecOutput,
 };
@@ -30,7 +31,6 @@ use crate::runtime::operators::window::store::{
 };
 use crate::runtime::operators::window::TileConfig;
 use crate::runtime::runtime_context::RuntimeContext;
-use crate::runtime::observability::TaskMetadata;
 use crate::runtime::state::{OperatorStore, OperatorTaskState};
 
 pub fn test_input_schema() -> SchemaRef {
@@ -168,18 +168,21 @@ impl Harness {
             )
             .await
             .expect("watermark");
-        let mut batch = None;
+        let mut pages = Vec::new();
         for msg in out.messages {
             match msg {
-                Message::Regular(base) => {
-                    assert!(batch.is_none(), "multiple emit batches");
-                    batch = Some(base.record_batch);
-                }
+                Message::Regular(base) => pages.push(base.record_batch),
                 other => self.pending.push(other),
             }
         }
         self.run_maintenance().await;
-        batch.expect("expected output on watermark")
+        if pages.is_empty() {
+            RecordBatch::new_empty(self.op.output_schema())
+        } else if pages.len() == 1 {
+            pages.pop().unwrap()
+        } else {
+            concat_batches(&pages)
+        }
     }
 
     pub async fn drain_passthrough_watermark(&mut self) -> u64 {

--- a/src/tests/benchmark/window_operator_benchmark.rs
+++ b/src/tests/benchmark/window_operator_benchmark.rs
@@ -239,7 +239,7 @@ pub async fn run_window_benchmark(config: WindowBenchmarkConfig) -> Result<Bench
         (
             "key".to_string(),
             FieldGenerator::Key {
-                num_unique: config.num_keys,
+                num_unique_keys: config.num_keys,
             },
         ),
         (

--- a/src/tests/benchmark/window_request_operator_benchmark.rs
+++ b/src/tests/benchmark/window_request_operator_benchmark.rs
@@ -59,7 +59,7 @@ fn create_datagen_config(
         (
             "key".to_string(),
             FieldGenerator::Key {
-                num_unique: num_unique_keys,
+                num_unique_keys: num_unique_keys,
             },
         ),
         (

--- a/src/tests/inprocess/watermark_streaming.rs
+++ b/src/tests/inprocess/watermark_streaming.rs
@@ -67,7 +67,7 @@ pub(crate) async fn run_watermark_window_pipeline(
     fields.insert(
         "partition_key".to_string(),
         FieldGenerator::Key {
-            num_unique: num_unique_keys,
+            num_unique_keys: num_unique_keys,
         },
     );
     fields.insert(


### PR DESCRIPTION
## Summary
- `emit_interval_ms` is event-time (emit when candidate moved by X) with the same X as a wall-clock cap for a quiet source that still has an unpublished candidate. `idle_timeout_ms` stays merge-only.
- Window `process_due` yields after one `stream_due` page (`Ready`); the same WM owns remaining pages — no `next_inputs()` until the due-set is done. `wo_wm_process_ms` is recorded once per WM.

Send-policy / reserved FIFO slot (#273 item 3) is **not** in this PR.

Fixes #273. Child of #261.

## Test plan
- [ ] `unset RUSTC_WRAPPER && ./scripts/test unit --filter 'test(/watermark::|operators::window::/)'`
- [ ] `./scripts/test unit` (or default) after review
- [ ] Kind soak 180s `unlimited.yaml` p=4, 16384 keys, RANGE 10s, `emit_interval_ms: 200` (now ET): no 5s `process_due` / GB state vs emit=0 baseline (~80 MB, p99 ~20 ms)
- [ ] Quiet source: one wall-cap advance then stop (no idle WM spam)
- [ ] Rebuild `volga:latest` + `kind load` before soak (worker/runtime change)