### PR TITLE
Test window recovery with shared keys across source tasks

### DIFF
--- a/src/bench/config.rs
+++ b/src/bench/config.rs
@@ -14,7 +14,7 @@ use crate::api::spec::operators::{OperatorOverride, OperatorTuningSpec};
 use crate::api::spec::pipeline::ExecutionProfile;
 use crate::api::{DatagenSpec, PipelineSpecBuilder, TaskWorkerAssignmentStrategyType};
 use crate::runtime::consts::RuntimeConstsProfile;
-use crate::runtime::functions::source::datagen_source::FieldGenerator;
+use crate::runtime::functions::source::datagen_source::{FieldGenerator, KeyDistribution};
 use crate::runtime::operators::window::model::TimeGranularity;
 use crate::runtime::operators::window::spec::WindowSpec;
 use crate::runtime::operators::window::tile::TileConfig;
@@ -336,7 +336,10 @@ fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<D
     );
     fields.insert(
         "key".to_string(),
-        FieldGenerator::key(num_unique_keys),
+        FieldGenerator::Key {
+            num_unique_keys,
+            distribution: KeyDistribution::Partitioned,
+        },
     );
     fields.insert(
         "value".to_string(),

--- a/src/bench/config.rs
+++ b/src/bench/config.rs
@@ -336,7 +336,7 @@ fn datagen_from_file(file: Option<&DatagenFile>, parallelism: usize) -> Result<D
     );
     fields.insert(
         "key".to_string(),
-        FieldGenerator::Key { num_unique_keys },
+        FieldGenerator::key(num_unique_keys),
     );
     fields.insert(
         "value".to_string(),

--- a/src/runtime/functions/source/datagen_source.rs
+++ b/src/runtime/functions/source/datagen_source.rs
@@ -115,22 +115,6 @@ pub enum FieldGenerator {
     }, // Round-robin through provided values
 }
 
-impl FieldGenerator {
-    pub fn key(num_unique_keys: usize) -> Self {
-        Self::Key {
-            num_unique_keys,
-            distribution: KeyDistribution::Partitioned,
-        }
-    }
-
-    pub fn shared_key(num_unique_keys: usize) -> Self {
-        Self::Key {
-            num_unique_keys,
-            distribution: KeyDistribution::Shared,
-        }
-    }
-}
-
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct DatagenSourcePosition {
@@ -311,7 +295,7 @@ impl DatagenSourceFunction {
         }
     }
 
-    fn timestamp_lane(&self) -> i64 {
+    fn event_time_lane(&self) -> i64 {
         let shared = self.config.spec.fields.values().any(|g| {
             matches!(g, FieldGenerator::Key { distribution: KeyDistribution::Shared, .. })
         });
@@ -353,7 +337,7 @@ impl DatagenSourceFunction {
                         &mut self.per_key_timestamps,
                         *start_ms,
                         *step_ms,
-                        self.timestamp_lane(),
+                        self.event_time_lane(),
                         &batch_keys,
                     )?
                 },
@@ -762,7 +746,10 @@ mod tests {
                 start_ms: 1000000, 
                 step_ms: 100 
             }),
-            ("key".to_string(), FieldGenerator::key(6)), // 6 keys total across all tasks
+            ("key".to_string(), FieldGenerator::Key {
+                num_unique_keys: 6,
+                distribution: KeyDistribution::Partitioned,
+            }),
             ("id".to_string(), FieldGenerator::Increment { 
                 start: ScalarValue::Int64(Some(1)), 
                 step: ScalarValue::Int64(Some(1))
@@ -915,7 +902,10 @@ mod tests {
 
         let fields = HashMap::from([
             ("processing_time".to_string(), FieldGenerator::ProcessingTimestamp),
-            ("key".to_string(), FieldGenerator::key(4)),
+            ("key".to_string(), FieldGenerator::Key {
+                num_unique_keys: 4,
+                distribution: KeyDistribution::Partitioned,
+            }),
             ("id".to_string(), FieldGenerator::Increment { 
                 start: ScalarValue::Int64(Some(1)), 
                 step: ScalarValue::Int64(Some(1))
@@ -1035,7 +1025,10 @@ mod tests {
         );
         fields.insert(
             "key".to_string(),
-            FieldGenerator::key(num_unique_keys),
+            FieldGenerator::Key {
+                num_unique_keys,
+                distribution: KeyDistribution::Partitioned,
+            },
         );
         fields.insert(
             "value".to_string(),
@@ -1175,66 +1168,5 @@ mod tests {
                 task_index
             );
         }
-    }
-
-    #[tokio::test]
-    async fn test_shared_keys_are_identical_across_tasks_with_unique_timestamps() {
-        let parallelism = 4;
-        let records_per_task = 16;
-        let mut fields = HashMap::new();
-        fields.insert(
-            "timestamp".to_string(),
-            FieldGenerator::IncrementalTimestamp {
-                start_ms: 1000,
-                step_ms: 10,
-            },
-        );
-        fields.insert("key".to_string(), FieldGenerator::shared_key(4));
-        fields.insert(
-            "value".to_string(),
-            FieldGenerator::Values {
-                values: vec![ScalarValue::Float64(Some(1.0))],
-            },
-        );
-        let cfg = DatagenSourceConfig::new(
-            Arc::new(Schema::new(vec![
-                Field::new("timestamp", DataType::Timestamp(TimeUnit::Millisecond, None), false),
-                Field::new("key", DataType::Utf8, false),
-                Field::new("value", DataType::Float64, false),
-            ])),
-            DatagenSpec {
-                rate: None,
-                limit: Some(records_per_task * parallelism),
-                run_for_s: None,
-                batch_size: 4,
-                fields,
-                replayable: true,
-            },
-        );
-
-        let mut all_keys = HashSet::new();
-        let mut identity = HashSet::new();
-        for task_index in 0..parallelism {
-            let mut source = DatagenSourceFunction::new(cfg.clone());
-            let ctx = RuntimeContext::new(
-                "test".to_string().into(),
-                task_index as i32,
-                parallelism as i32,
-                None,
-                None,
-                None,
-            );
-            source.open(&ctx).await.unwrap();
-            for row in collect_all_rows(&mut source).await {
-                all_keys.insert(row.key.clone());
-                assert!(
-                    identity.insert((row.key.clone(), row.ts)),
-                    "duplicate (key, timestamp) ({}, {})",
-                    row.key,
-                    row.ts
-                );
-            }
-        }
-        assert_eq!(all_keys.len(), 4);
     }
 }

--- a/src/runtime/functions/source/datagen_source.rs
+++ b/src/runtime/functions/source/datagen_source.rs
@@ -65,6 +65,24 @@ impl DatagenSourceConfig {
     // replayable is part of DatagenSpec
 }
 
+/// How `FieldGenerator::Key` values are assigned across source tasks.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KeyDistribution {
+    /// Disjoint keys: `key-{task_index}-{key_id}`.
+    #[default]
+    Partitioned,
+    /// Every task emits `key-0` .. `key-{num_unique_keys-1}`.
+    /// Timestamps are offset by `task_index` so `(key, timestamp)` stays unique.
+    Shared,
+}
+
+impl KeyDistribution {
+    fn is_partitioned(self) -> bool {
+        matches!(self, Self::Partitioned)
+    }
+}
+
 /// Data generation strategies
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -76,9 +94,8 @@ pub enum FieldGenerator {
         // Cluster image still deserializes `num_unique` until volga:latest is rebuilt.
         #[serde(rename = "num_unique", alias = "num_unique_keys")]
         num_unique_keys: usize,
-        /// When true, every task emits `key-0`..`key-{n-1}` and offsets timestamps by task_index.
-        #[serde(default)]
-        shared: bool,
+        #[serde(default, skip_serializing_if = "KeyDistribution::is_partitioned")]
+        distribution: KeyDistribution,
     },
     Increment {
         #[serde_as(as = "utils::ScalarValueAsBytes")]
@@ -102,7 +119,14 @@ impl FieldGenerator {
     pub fn key(num_unique_keys: usize) -> Self {
         Self::Key {
             num_unique_keys,
-            shared: false,
+            distribution: KeyDistribution::Partitioned,
+        }
+    }
+
+    pub fn shared_key(num_unique_keys: usize) -> Self {
+        Self::Key {
+            num_unique_keys,
+            distribution: KeyDistribution::Shared,
         }
     }
 }
@@ -238,12 +262,12 @@ impl DatagenSourceFunction {
         // Initialize key values
         if let Some(key_idx) = key_field_index {
             let key_field_name = self.schema.fields()[key_idx].name();
-            if let Some(FieldGenerator::Key { num_unique_keys, shared }) = self.config.spec.fields.get(key_field_name) {
+            if let Some(FieldGenerator::Key { num_unique_keys, distribution }) = self.config.spec.fields.get(key_field_name) {
                 self.key_values = Self::gen_key_values_for_task(
                     parallelism as usize,
                     task_index as usize,
                     *num_unique_keys,
-                    *shared,
+                    *distribution,
                 );
 
                 for key in self.key_values.iter() {
@@ -266,27 +290,30 @@ impl DatagenSourceFunction {
         parallelism: usize,
         task_index: usize,
         num_unique_keys: usize,
-        shared: bool,
+        distribution: KeyDistribution,
     ) -> Vec<String> {
-        if shared {
-            return (0..num_unique_keys).map(|id| format!("key-{id}")).collect();
+        match distribution {
+            KeyDistribution::Shared => {
+                (0..num_unique_keys).map(|id| format!("key-{id}")).collect()
+            }
+            KeyDistribution::Partitioned => {
+                let keys_per_task = num_unique_keys / parallelism;
+                let remainder = num_unique_keys % parallelism;
+                let num_keys_for_task = if remainder != 0 && task_index == parallelism - 1 {
+                    keys_per_task + remainder
+                } else {
+                    keys_per_task
+                };
+                (0..num_keys_for_task)
+                    .map(|key_id| format!("key-{task_index}-{key_id}"))
+                    .collect()
+            }
         }
-
-        let keys_per_task = num_unique_keys / parallelism;
-        let remainder = num_unique_keys % parallelism;
-        let num_keys_for_task = if remainder != 0 && task_index == parallelism - 1 {
-            keys_per_task + remainder
-        } else {
-            keys_per_task
-        };
-        (0..num_keys_for_task)
-            .map(|key_id| format!("key-{task_index}-{key_id}"))
-            .collect()
     }
 
     fn timestamp_lane(&self) -> i64 {
         let shared = self.config.spec.fields.values().any(|g| {
-            matches!(g, FieldGenerator::Key { shared: true, .. })
+            matches!(g, FieldGenerator::Key { distribution: KeyDistribution::Shared, .. })
         });
         if shared {
             self.task_index.unwrap_or(0) as i64
@@ -1162,13 +1189,7 @@ mod tests {
                 step_ms: 10,
             },
         );
-        fields.insert(
-            "key".to_string(),
-            FieldGenerator::Key {
-                num_unique_keys: 4,
-                shared: true,
-            },
-        );
+        fields.insert("key".to_string(), FieldGenerator::shared_key(4));
         fields.insert(
             "value".to_string(),
             FieldGenerator::Values {

--- a/src/runtime/functions/source/datagen_source.rs
+++ b/src/runtime/functions/source/datagen_source.rs
@@ -65,6 +65,24 @@ impl DatagenSourceConfig {
     // replayable is part of DatagenSpec
 }
 
+/// How `FieldGenerator::Key` values are assigned across source tasks.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KeyDistribution {
+    /// Disjoint keys: `key-{task_index}-{key_id}`.
+    #[default]
+    Partitioned,
+    /// Every task emits the same set: `key-0` .. `key-{num_unique_keys-1}`.
+    /// Pair with per-task event-time lanes so `(key, timestamp)` stays unique.
+    Shared,
+}
+
+impl KeyDistribution {
+    fn is_partitioned(self) -> bool {
+        matches!(self, Self::Partitioned)
+    }
+}
+
 /// Data generation strategies
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -76,6 +94,9 @@ pub enum FieldGenerator {
         // Cluster image still deserializes `num_unique` until volga:latest is rebuilt.
         #[serde(rename = "num_unique", alias = "num_unique_keys")]
         num_unique_keys: usize,
+        /// Default `Partitioned` keeps serialized specs backward-compatible.
+        #[serde(default, skip_serializing_if = "KeyDistribution::is_partitioned")]
+        distribution: KeyDistribution,
     },
     Increment {
         #[serde_as(as = "utils::ScalarValueAsBytes")]
@@ -93,6 +114,22 @@ pub enum FieldGenerator {
         #[serde_as(as = "Vec<utils::ScalarValueAsBytes>")]
         values: Vec<ScalarValue>,
     }, // Round-robin through provided values
+}
+
+impl FieldGenerator {
+    pub fn key(num_unique_keys: usize) -> Self {
+        Self::Key {
+            num_unique_keys,
+            distribution: KeyDistribution::Partitioned,
+        }
+    }
+
+    pub fn shared_key(num_unique_keys: usize) -> Self {
+        Self::Key {
+            num_unique_keys,
+            distribution: KeyDistribution::Shared,
+        }
+    }
 }
 
 #[serde_as]
@@ -133,6 +170,8 @@ pub struct DatagenSourceFunction {
     // Key-based state tracking
     key_values: Vec<String>, // All possible key values for this task
     current_key_index: usize, // Round-robin index for key selection
+    /// Offset added to IncrementalTimestamp start so shared keys keep unique (key, ts).
+    event_time_lane: i64,
     per_key_timestamps: HashMap<String, i64>, // Timestamp state per key
     per_key_increments: HashMap<String, HashMap<usize, ScalarValue>>, // Increment state per key per field
     per_key_values_indices: HashMap<String, HashMap<usize, usize>>, // Values indices per key per field
@@ -155,6 +194,7 @@ impl DatagenSourceFunction {
             schema,
             key_values: Vec::new(),
             current_key_index: 0,
+            event_time_lane: 0,
             per_key_timestamps: HashMap::new(),
             per_key_increments: HashMap::new(),
             per_key_values_indices: HashMap::new(),
@@ -226,10 +266,21 @@ impl DatagenSourceFunction {
         // Initialize key values
         if let Some(key_idx) = key_field_index {
             let key_field_name = self.schema.fields()[key_idx].name();
-            if let Some(FieldGenerator::Key { num_unique_keys }) = self.config.spec.fields.get(key_field_name) {
-                // Distribute unique keys across all tasks
-                self.key_values = Self::gen_key_values_for_task(parallelism as usize, task_index as usize, *num_unique_keys);
-                
+            if let Some(FieldGenerator::Key { num_unique_keys, distribution }) = self.config.spec.fields.get(key_field_name) {
+                self.key_values = Self::gen_key_values_for_task(
+                    parallelism as usize,
+                    task_index as usize,
+                    *num_unique_keys,
+                    *distribution,
+                );
+                self.event_time_lane = match distribution {
+                    KeyDistribution::Shared => task_index as i64,
+                    KeyDistribution::Partitioned => 0,
+                };
+                if *distribution == KeyDistribution::Shared {
+                    self.validate_shared_event_time_lanes(parallelism as i64);
+                }
+
                 // Initialize per-key state for distributed keys
                 for key in self.key_values.iter() {
                     self.per_key_timestamps.insert(key.clone(), 0);
@@ -247,24 +298,47 @@ impl DatagenSourceFunction {
         }
     }
 
-    pub fn gen_key_values_for_task(parallelism: usize, task_index: usize, num_unique_keys: usize) -> Vec<String> {
-        let mut key_values = Vec::new();
-        
-        let keys_per_task = num_unique_keys / parallelism as usize;
-        let remainder = num_unique_keys % parallelism as usize;
-        
-        // If there's a remainder, give it to the last task
-        let num_keys_for_task = if remainder != 0 && task_index == parallelism - 1 {
-            keys_per_task + remainder
-        } else {
-            keys_per_task
-        };
-        
-        for key_id in 0..num_keys_for_task {
-            let key = format!("key-{}-{}", task_index, key_id);
-            key_values.push(key.clone());
+    pub fn gen_key_values_for_task(
+        parallelism: usize,
+        task_index: usize,
+        num_unique_keys: usize,
+        distribution: KeyDistribution,
+    ) -> Vec<String> {
+        match distribution {
+            KeyDistribution::Shared => (0..num_unique_keys).map(|id| format!("key-{id}")).collect(),
+            KeyDistribution::Partitioned => {
+                let mut key_values = Vec::new();
+
+                let keys_per_task = num_unique_keys / parallelism;
+                let remainder = num_unique_keys % parallelism;
+
+                // If there's a remainder, give it to the last task
+                let num_keys_for_task = if remainder != 0 && task_index == parallelism - 1 {
+                    keys_per_task + remainder
+                } else {
+                    keys_per_task
+                };
+
+                for key_id in 0..num_keys_for_task {
+                    key_values.push(format!("key-{task_index}-{key_id}"));
+                }
+                key_values
+            }
         }
-        key_values
+    }
+
+    fn validate_shared_event_time_lanes(&self, parallelism: i64) {
+        for (field_name, gen) in &self.config.spec.fields {
+            if let FieldGenerator::IncrementalTimestamp { step_ms, .. } = gen {
+                if *step_ms < parallelism {
+                    panic!(
+                        "Shared key distribution requires IncrementalTimestamp step_ms >= parallelism \
+                         so per-task event-time lanes stay unique; field '{field_name}' has \
+                         step_ms={step_ms} parallelism={parallelism}"
+                    );
+                }
+            }
+        }
     }
 
     /// Build a batch and advance the emit counter (offline materialize / unit helpers).
@@ -294,7 +368,13 @@ impl DatagenSourceFunction {
             
             let column = match generator {
                 FieldGenerator::IncrementalTimestamp { start_ms, step_ms } => {
-                    Self::generate_incremental_timestamp_column(&mut self.per_key_timestamps, *start_ms, *step_ms, &batch_keys)?
+                    Self::generate_incremental_timestamp_column(
+                        &mut self.per_key_timestamps,
+                        *start_ms,
+                        *step_ms,
+                        self.event_time_lane,
+                        &batch_keys,
+                    )?
                 },
                 
                 FieldGenerator::ProcessingTimestamp => {
@@ -330,13 +410,19 @@ impl DatagenSourceFunction {
     }
 
     /// Generate incremental timestamp column with per-key increment
-    fn generate_incremental_timestamp_column(per_key_timestamps: &mut HashMap<String, i64>, start_ms: i64, step_ms: i64, batch_keys: &[String]) -> Result<ArrayRef> {
+    fn generate_incremental_timestamp_column(
+        per_key_timestamps: &mut HashMap<String, i64>,
+        start_ms: i64,
+        step_ms: i64,
+        event_time_lane: i64,
+        batch_keys: &[String],
+    ) -> Result<ArrayRef> {
         let mut builder = TimestampMillisecondBuilder::with_capacity(batch_keys.len());
         
         for key in batch_keys {
             let current_ts = per_key_timestamps.get_mut(key).unwrap();
             if *current_ts == 0 {
-                *current_ts = start_ms;
+                *current_ts = start_ms + event_time_lane;
             }
             builder.append_value(*current_ts);
             *current_ts += step_ms;
@@ -695,9 +781,7 @@ mod tests {
                 start_ms: 1000000, 
                 step_ms: 100 
             }),
-            ("key".to_string(), FieldGenerator::Key { 
-                num_unique_keys: 6  // 6 keys total across all tasks
-            }),
+            ("key".to_string(), FieldGenerator::key(6)), // 6 keys total across all tasks
             ("id".to_string(), FieldGenerator::Increment { 
                 start: ScalarValue::Int64(Some(1)), 
                 step: ScalarValue::Int64(Some(1))
@@ -850,7 +934,7 @@ mod tests {
 
         let fields = HashMap::from([
             ("processing_time".to_string(), FieldGenerator::ProcessingTimestamp),
-            ("key".to_string(), FieldGenerator::Key { num_unique_keys: 4 }),
+            ("key".to_string(), FieldGenerator::key(4)),
             ("id".to_string(), FieldGenerator::Increment { 
                 start: ScalarValue::Int64(Some(1)), 
                 step: ScalarValue::Int64(Some(1))
@@ -970,9 +1054,7 @@ mod tests {
         );
         fields.insert(
             "key".to_string(),
-            FieldGenerator::Key {
-                num_unique_keys,
-            },
+            FieldGenerator::key(num_unique_keys),
         );
         fields.insert(
             "value".to_string(),
@@ -1112,5 +1194,226 @@ mod tests {
                 task_index
             );
         }
+    }
+
+    fn create_shared_key_replayable_config(
+        total_records: usize,
+        batch_size: usize,
+        num_unique_keys: usize,
+        step_ms: i64,
+    ) -> DatagenSourceConfig {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Timestamp(TimeUnit::Millisecond, None), false),
+            Field::new("key", DataType::Utf8, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+
+        let mut fields = HashMap::new();
+        fields.insert(
+            "timestamp".to_string(),
+            FieldGenerator::IncrementalTimestamp {
+                start_ms: 1000,
+                step_ms,
+            },
+        );
+        fields.insert("key".to_string(), FieldGenerator::shared_key(num_unique_keys));
+        fields.insert(
+            "value".to_string(),
+            FieldGenerator::Values {
+                values: vec![
+                    ScalarValue::Float64(Some(1.0)),
+                    ScalarValue::Float64(Some(2.0)),
+                ],
+            },
+        );
+
+        let spec = DatagenSpec {
+            rate: None,
+            limit: Some(total_records),
+            run_for_s: None,
+            batch_size,
+            fields,
+            replayable: true,
+        };
+        DatagenSourceConfig::new(schema, spec)
+    }
+
+    #[tokio::test]
+    async fn test_partitioned_event_time_starts_at_configured_start_ms() {
+        let cfg = create_replayable_checkpoint_test_config(8, 4, 8);
+        let parallelism = 4;
+        for task_index in 0..parallelism {
+            let mut source = DatagenSourceFunction::new(cfg.clone());
+            let ctx = RuntimeContext::new(
+                "test".to_string().into(),
+                task_index,
+                parallelism,
+                None,
+                None,
+                None,
+            );
+            source.open(&ctx).await.unwrap();
+            let rows = collect_all_rows(&mut source).await;
+            let min_ts = rows.iter().map(|row| row.ts).min().unwrap();
+            assert_eq!(
+                min_ts, 1000,
+                "partitioned task {task_index} must not apply an event-time lane"
+            );
+        }
+    }
+
+    #[test]
+    fn test_key_distribution_partitioned_vs_shared() {
+        let partitioned_0 = DatagenSourceFunction::gen_key_values_for_task(
+            4,
+            0,
+            8,
+            KeyDistribution::Partitioned,
+        );
+        let partitioned_1 = DatagenSourceFunction::gen_key_values_for_task(
+            4,
+            1,
+            8,
+            KeyDistribution::Partitioned,
+        );
+        assert_eq!(partitioned_0, vec!["key-0-0".to_string(), "key-0-1".to_string()]);
+        assert_eq!(partitioned_1, vec!["key-1-0".to_string(), "key-1-1".to_string()]);
+        assert!(partitioned_0.iter().all(|k| !partitioned_1.contains(k)));
+
+        let shared_0 =
+            DatagenSourceFunction::gen_key_values_for_task(4, 0, 4, KeyDistribution::Shared);
+        let shared_3 =
+            DatagenSourceFunction::gen_key_values_for_task(4, 3, 4, KeyDistribution::Shared);
+        assert_eq!(
+            shared_0,
+            vec![
+                "key-0".to_string(),
+                "key-1".to_string(),
+                "key-2".to_string(),
+                "key-3".to_string()
+            ]
+        );
+        assert_eq!(shared_0, shared_3);
+    }
+
+    #[tokio::test]
+    async fn test_shared_keys_use_unique_event_time_lanes() {
+        let parallelism = 4;
+        let num_unique_keys = 4;
+        let records_per_task = 16;
+        let cfg = create_shared_key_replayable_config(records_per_task * parallelism, 4, num_unique_keys, 10);
+
+        let mut all_keys = HashSet::new();
+        let mut identity = HashSet::new();
+        for task_index in 0..parallelism {
+            let mut source = DatagenSourceFunction::new(cfg.clone());
+            let ctx = RuntimeContext::new(
+                "test".to_string().into(),
+                task_index as i32,
+                parallelism as i32,
+                None,
+                None,
+                None,
+            );
+            source.open(&ctx).await.unwrap();
+            let rows = collect_all_rows(&mut source).await;
+            assert_eq!(rows.len(), records_per_task);
+            for row in rows {
+                all_keys.insert(row.key.clone());
+                assert!(
+                    identity.insert((row.key.clone(), row.ts)),
+                    "duplicate (key, timestamp) ({}, {}) from task {task_index}",
+                    row.key,
+                    row.ts
+                );
+                assert_eq!(
+                    (row.ts - 1000) % 10,
+                    task_index as i64,
+                    "task {task_index} should occupy event-time lane {task_index}, got ts {}",
+                    row.ts
+                );
+            }
+        }
+        assert_eq!(all_keys.len(), num_unique_keys);
+        assert!(all_keys.contains("key-0"));
+        assert!(all_keys.contains("key-3"));
+    }
+
+    #[tokio::test]
+    async fn test_shared_keys_checkpoint_restore_matches_uninterrupted() {
+        let parallelism = 4;
+        let batch_size = 8;
+        let total_records = 128;
+        let checkpoint_after = 16;
+        assert_eq!(checkpoint_after % batch_size, 0);
+
+        let cfg = create_shared_key_replayable_config(total_records, batch_size, 4, 10);
+
+        for task_index in 0..parallelism {
+            let mut baseline = DatagenSourceFunction::new(cfg.clone());
+            let ctx = RuntimeContext::new(
+                "test".to_string().into(),
+                task_index,
+                parallelism,
+                None,
+                None,
+                None,
+            );
+            baseline.open(&ctx).await.unwrap();
+            let baseline_rows = collect_all_rows(&mut baseline).await;
+
+            let mut first = DatagenSourceFunction::new(cfg.clone());
+            let ctx_first = RuntimeContext::new(
+                "test".to_string().into(),
+                task_index,
+                parallelism,
+                None,
+                None,
+                None,
+            );
+            first.open(&ctx_first).await.unwrap();
+            let mut resumed_rows = collect_rows(&mut first, Some(checkpoint_after)).await;
+            let snapshot = first.snapshot_position().await.unwrap();
+
+            let mut second = DatagenSourceFunction::new(cfg.clone());
+            let ctx_second = RuntimeContext::new(
+                "test".to_string().into(),
+                task_index,
+                parallelism,
+                None,
+                None,
+                None,
+            );
+            second.open(&ctx_second).await.unwrap();
+            second.restore_position(&snapshot).await.unwrap();
+            resumed_rows.extend(collect_rows(&mut second, None).await);
+
+            assert_eq!(
+                baseline_rows,
+                resumed_rows,
+                "shared-key checkpoint+restore must produce identical rows for task_index={task_index}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_key_distribution_serde_defaults_to_partitioned() {
+        let json = r#"{"Key":{"num_unique":4}}"#;
+        let gen: FieldGenerator = serde_json::from_str(json).unwrap();
+        match gen {
+            FieldGenerator::Key {
+                num_unique_keys,
+                distribution,
+            } => {
+                assert_eq!(num_unique_keys, 4);
+                assert_eq!(distribution, KeyDistribution::Partitioned);
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+
+        let shared = FieldGenerator::shared_key(4);
+        let serialized = serde_json::to_value(&shared).unwrap();
+        assert_eq!(serialized["Key"]["distribution"], "shared");
+        assert_eq!(serialized["Key"]["num_unique"], 4);
     }
 }

--- a/src/runtime/functions/source/datagen_source.rs
+++ b/src/runtime/functions/source/datagen_source.rs
@@ -65,24 +65,6 @@ impl DatagenSourceConfig {
     // replayable is part of DatagenSpec
 }
 
-/// How `FieldGenerator::Key` values are assigned across source tasks.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum KeyDistribution {
-    /// Disjoint keys: `key-{task_index}-{key_id}`.
-    #[default]
-    Partitioned,
-    /// Every task emits the same set: `key-0` .. `key-{num_unique_keys-1}`.
-    /// Pair with per-task event-time lanes so `(key, timestamp)` stays unique.
-    Shared,
-}
-
-impl KeyDistribution {
-    fn is_partitioned(self) -> bool {
-        matches!(self, Self::Partitioned)
-    }
-}
-
 /// Data generation strategies
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -94,9 +76,9 @@ pub enum FieldGenerator {
         // Cluster image still deserializes `num_unique` until volga:latest is rebuilt.
         #[serde(rename = "num_unique", alias = "num_unique_keys")]
         num_unique_keys: usize,
-        /// Default `Partitioned` keeps serialized specs backward-compatible.
-        #[serde(default, skip_serializing_if = "KeyDistribution::is_partitioned")]
-        distribution: KeyDistribution,
+        /// When true, every task emits `key-0`..`key-{n-1}` and offsets timestamps by task_index.
+        #[serde(default)]
+        shared: bool,
     },
     Increment {
         #[serde_as(as = "utils::ScalarValueAsBytes")]
@@ -120,14 +102,7 @@ impl FieldGenerator {
     pub fn key(num_unique_keys: usize) -> Self {
         Self::Key {
             num_unique_keys,
-            distribution: KeyDistribution::Partitioned,
-        }
-    }
-
-    pub fn shared_key(num_unique_keys: usize) -> Self {
-        Self::Key {
-            num_unique_keys,
-            distribution: KeyDistribution::Shared,
+            shared: false,
         }
     }
 }
@@ -170,8 +145,6 @@ pub struct DatagenSourceFunction {
     // Key-based state tracking
     key_values: Vec<String>, // All possible key values for this task
     current_key_index: usize, // Round-robin index for key selection
-    /// Offset added to IncrementalTimestamp start so shared keys keep unique (key, ts).
-    event_time_lane: i64,
     per_key_timestamps: HashMap<String, i64>, // Timestamp state per key
     per_key_increments: HashMap<String, HashMap<usize, ScalarValue>>, // Increment state per key per field
     per_key_values_indices: HashMap<String, HashMap<usize, usize>>, // Values indices per key per field
@@ -194,7 +167,6 @@ impl DatagenSourceFunction {
             schema,
             key_values: Vec::new(),
             current_key_index: 0,
-            event_time_lane: 0,
             per_key_timestamps: HashMap::new(),
             per_key_increments: HashMap::new(),
             per_key_values_indices: HashMap::new(),
@@ -266,22 +238,14 @@ impl DatagenSourceFunction {
         // Initialize key values
         if let Some(key_idx) = key_field_index {
             let key_field_name = self.schema.fields()[key_idx].name();
-            if let Some(FieldGenerator::Key { num_unique_keys, distribution }) = self.config.spec.fields.get(key_field_name) {
+            if let Some(FieldGenerator::Key { num_unique_keys, shared }) = self.config.spec.fields.get(key_field_name) {
                 self.key_values = Self::gen_key_values_for_task(
                     parallelism as usize,
                     task_index as usize,
                     *num_unique_keys,
-                    *distribution,
+                    *shared,
                 );
-                self.event_time_lane = match distribution {
-                    KeyDistribution::Shared => task_index as i64,
-                    KeyDistribution::Partitioned => 0,
-                };
-                if *distribution == KeyDistribution::Shared {
-                    self.validate_shared_event_time_lanes(parallelism as i64);
-                }
 
-                // Initialize per-key state for distributed keys
                 for key in self.key_values.iter() {
                     self.per_key_timestamps.insert(key.clone(), 0);
                     self.per_key_increments.insert(key.clone(), HashMap::new());
@@ -302,42 +266,32 @@ impl DatagenSourceFunction {
         parallelism: usize,
         task_index: usize,
         num_unique_keys: usize,
-        distribution: KeyDistribution,
+        shared: bool,
     ) -> Vec<String> {
-        match distribution {
-            KeyDistribution::Shared => (0..num_unique_keys).map(|id| format!("key-{id}")).collect(),
-            KeyDistribution::Partitioned => {
-                let mut key_values = Vec::new();
-
-                let keys_per_task = num_unique_keys / parallelism;
-                let remainder = num_unique_keys % parallelism;
-
-                // If there's a remainder, give it to the last task
-                let num_keys_for_task = if remainder != 0 && task_index == parallelism - 1 {
-                    keys_per_task + remainder
-                } else {
-                    keys_per_task
-                };
-
-                for key_id in 0..num_keys_for_task {
-                    key_values.push(format!("key-{task_index}-{key_id}"));
-                }
-                key_values
-            }
+        if shared {
+            return (0..num_unique_keys).map(|id| format!("key-{id}")).collect();
         }
+
+        let keys_per_task = num_unique_keys / parallelism;
+        let remainder = num_unique_keys % parallelism;
+        let num_keys_for_task = if remainder != 0 && task_index == parallelism - 1 {
+            keys_per_task + remainder
+        } else {
+            keys_per_task
+        };
+        (0..num_keys_for_task)
+            .map(|key_id| format!("key-{task_index}-{key_id}"))
+            .collect()
     }
 
-    fn validate_shared_event_time_lanes(&self, parallelism: i64) {
-        for (field_name, gen) in &self.config.spec.fields {
-            if let FieldGenerator::IncrementalTimestamp { step_ms, .. } = gen {
-                if *step_ms < parallelism {
-                    panic!(
-                        "Shared key distribution requires IncrementalTimestamp step_ms >= parallelism \
-                         so per-task event-time lanes stay unique; field '{field_name}' has \
-                         step_ms={step_ms} parallelism={parallelism}"
-                    );
-                }
-            }
+    fn timestamp_lane(&self) -> i64 {
+        let shared = self.config.spec.fields.values().any(|g| {
+            matches!(g, FieldGenerator::Key { shared: true, .. })
+        });
+        if shared {
+            self.task_index.unwrap_or(0) as i64
+        } else {
+            0
         }
     }
 
@@ -372,7 +326,7 @@ impl DatagenSourceFunction {
                         &mut self.per_key_timestamps,
                         *start_ms,
                         *step_ms,
-                        self.event_time_lane,
+                        self.timestamp_lane(),
                         &batch_keys,
                     )?
                 },
@@ -1196,112 +1150,46 @@ mod tests {
         }
     }
 
-    fn create_shared_key_replayable_config(
-        total_records: usize,
-        batch_size: usize,
-        num_unique_keys: usize,
-        step_ms: i64,
-    ) -> DatagenSourceConfig {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("timestamp", DataType::Timestamp(TimeUnit::Millisecond, None), false),
-            Field::new("key", DataType::Utf8, false),
-            Field::new("value", DataType::Float64, false),
-        ]));
-
+    #[tokio::test]
+    async fn test_shared_keys_are_identical_across_tasks_with_unique_timestamps() {
+        let parallelism = 4;
+        let records_per_task = 16;
         let mut fields = HashMap::new();
         fields.insert(
             "timestamp".to_string(),
             FieldGenerator::IncrementalTimestamp {
                 start_ms: 1000,
-                step_ms,
+                step_ms: 10,
             },
         );
-        fields.insert("key".to_string(), FieldGenerator::shared_key(num_unique_keys));
+        fields.insert(
+            "key".to_string(),
+            FieldGenerator::Key {
+                num_unique_keys: 4,
+                shared: true,
+            },
+        );
         fields.insert(
             "value".to_string(),
             FieldGenerator::Values {
-                values: vec![
-                    ScalarValue::Float64(Some(1.0)),
-                    ScalarValue::Float64(Some(2.0)),
-                ],
+                values: vec![ScalarValue::Float64(Some(1.0))],
             },
         );
-
-        let spec = DatagenSpec {
-            rate: None,
-            limit: Some(total_records),
-            run_for_s: None,
-            batch_size,
-            fields,
-            replayable: true,
-        };
-        DatagenSourceConfig::new(schema, spec)
-    }
-
-    #[tokio::test]
-    async fn test_partitioned_event_time_starts_at_configured_start_ms() {
-        let cfg = create_replayable_checkpoint_test_config(8, 4, 8);
-        let parallelism = 4;
-        for task_index in 0..parallelism {
-            let mut source = DatagenSourceFunction::new(cfg.clone());
-            let ctx = RuntimeContext::new(
-                "test".to_string().into(),
-                task_index,
-                parallelism,
-                None,
-                None,
-                None,
-            );
-            source.open(&ctx).await.unwrap();
-            let rows = collect_all_rows(&mut source).await;
-            let min_ts = rows.iter().map(|row| row.ts).min().unwrap();
-            assert_eq!(
-                min_ts, 1000,
-                "partitioned task {task_index} must not apply an event-time lane"
-            );
-        }
-    }
-
-    #[test]
-    fn test_key_distribution_partitioned_vs_shared() {
-        let partitioned_0 = DatagenSourceFunction::gen_key_values_for_task(
-            4,
-            0,
-            8,
-            KeyDistribution::Partitioned,
+        let cfg = DatagenSourceConfig::new(
+            Arc::new(Schema::new(vec![
+                Field::new("timestamp", DataType::Timestamp(TimeUnit::Millisecond, None), false),
+                Field::new("key", DataType::Utf8, false),
+                Field::new("value", DataType::Float64, false),
+            ])),
+            DatagenSpec {
+                rate: None,
+                limit: Some(records_per_task * parallelism),
+                run_for_s: None,
+                batch_size: 4,
+                fields,
+                replayable: true,
+            },
         );
-        let partitioned_1 = DatagenSourceFunction::gen_key_values_for_task(
-            4,
-            1,
-            8,
-            KeyDistribution::Partitioned,
-        );
-        assert_eq!(partitioned_0, vec!["key-0-0".to_string(), "key-0-1".to_string()]);
-        assert_eq!(partitioned_1, vec!["key-1-0".to_string(), "key-1-1".to_string()]);
-        assert!(partitioned_0.iter().all(|k| !partitioned_1.contains(k)));
-
-        let shared_0 =
-            DatagenSourceFunction::gen_key_values_for_task(4, 0, 4, KeyDistribution::Shared);
-        let shared_3 =
-            DatagenSourceFunction::gen_key_values_for_task(4, 3, 4, KeyDistribution::Shared);
-        assert_eq!(
-            shared_0,
-            vec![
-                "key-0".to_string(),
-                "key-1".to_string(),
-                "key-2".to_string(),
-                "key-3".to_string()
-            ]
-        );
-        assert_eq!(shared_0, shared_3);
-    }
-
-    #[tokio::test]
-    async fn test_shared_keys_use_unique_event_time_lanes() {
-        let parallelism = 4;
-        let num_unique_keys = 4;
-        let records_per_task = 16;
-        let cfg = create_shared_key_replayable_config(records_per_task * parallelism, 4, num_unique_keys, 10);
 
         let mut all_keys = HashSet::new();
         let mut identity = HashSet::new();
@@ -1316,104 +1204,16 @@ mod tests {
                 None,
             );
             source.open(&ctx).await.unwrap();
-            let rows = collect_all_rows(&mut source).await;
-            assert_eq!(rows.len(), records_per_task);
-            for row in rows {
+            for row in collect_all_rows(&mut source).await {
                 all_keys.insert(row.key.clone());
                 assert!(
                     identity.insert((row.key.clone(), row.ts)),
-                    "duplicate (key, timestamp) ({}, {}) from task {task_index}",
+                    "duplicate (key, timestamp) ({}, {})",
                     row.key,
                     row.ts
                 );
-                assert_eq!(
-                    (row.ts - 1000) % 10,
-                    task_index as i64,
-                    "task {task_index} should occupy event-time lane {task_index}, got ts {}",
-                    row.ts
-                );
             }
         }
-        assert_eq!(all_keys.len(), num_unique_keys);
-        assert!(all_keys.contains("key-0"));
-        assert!(all_keys.contains("key-3"));
-    }
-
-    #[tokio::test]
-    async fn test_shared_keys_checkpoint_restore_matches_uninterrupted() {
-        let parallelism = 4;
-        let batch_size = 8;
-        let total_records = 128;
-        let checkpoint_after = 16;
-        assert_eq!(checkpoint_after % batch_size, 0);
-
-        let cfg = create_shared_key_replayable_config(total_records, batch_size, 4, 10);
-
-        for task_index in 0..parallelism {
-            let mut baseline = DatagenSourceFunction::new(cfg.clone());
-            let ctx = RuntimeContext::new(
-                "test".to_string().into(),
-                task_index,
-                parallelism,
-                None,
-                None,
-                None,
-            );
-            baseline.open(&ctx).await.unwrap();
-            let baseline_rows = collect_all_rows(&mut baseline).await;
-
-            let mut first = DatagenSourceFunction::new(cfg.clone());
-            let ctx_first = RuntimeContext::new(
-                "test".to_string().into(),
-                task_index,
-                parallelism,
-                None,
-                None,
-                None,
-            );
-            first.open(&ctx_first).await.unwrap();
-            let mut resumed_rows = collect_rows(&mut first, Some(checkpoint_after)).await;
-            let snapshot = first.snapshot_position().await.unwrap();
-
-            let mut second = DatagenSourceFunction::new(cfg.clone());
-            let ctx_second = RuntimeContext::new(
-                "test".to_string().into(),
-                task_index,
-                parallelism,
-                None,
-                None,
-                None,
-            );
-            second.open(&ctx_second).await.unwrap();
-            second.restore_position(&snapshot).await.unwrap();
-            resumed_rows.extend(collect_rows(&mut second, None).await);
-
-            assert_eq!(
-                baseline_rows,
-                resumed_rows,
-                "shared-key checkpoint+restore must produce identical rows for task_index={task_index}"
-            );
-        }
-    }
-
-    #[test]
-    fn test_key_distribution_serde_defaults_to_partitioned() {
-        let json = r#"{"Key":{"num_unique":4}}"#;
-        let gen: FieldGenerator = serde_json::from_str(json).unwrap();
-        match gen {
-            FieldGenerator::Key {
-                num_unique_keys,
-                distribution,
-            } => {
-                assert_eq!(num_unique_keys, 4);
-                assert_eq!(distribution, KeyDistribution::Partitioned);
-            }
-            other => panic!("unexpected {other:?}"),
-        }
-
-        let shared = FieldGenerator::shared_key(4);
-        let serialized = serde_json::to_value(&shared).unwrap();
-        assert_eq!(serialized["Key"]["distribution"], "shared");
-        assert_eq!(serialized["Key"]["num_unique"], 4);
+        assert_eq!(all_keys.len(), 4);
     }
 }

--- a/src/runtime/functions/source/datagen_source.rs
+++ b/src/runtime/functions/source/datagen_source.rs
@@ -295,17 +295,6 @@ impl DatagenSourceFunction {
         }
     }
 
-    fn event_time_lane(&self) -> i64 {
-        let shared = self.config.spec.fields.values().any(|g| {
-            matches!(g, FieldGenerator::Key { distribution: KeyDistribution::Shared, .. })
-        });
-        if shared {
-            self.task_index.unwrap_or(0) as i64
-        } else {
-            0
-        }
-    }
-
     /// Build a batch and advance the emit counter (offline materialize / unit helpers).
     pub(crate) fn generate_batch(&mut self, batch_size: usize) -> Result<RecordBatch> {
         let batch = self.build_batch(batch_size)?;
@@ -316,6 +305,10 @@ impl DatagenSourceFunction {
     fn build_batch(&mut self, batch_size: usize) -> Result<RecordBatch> {
         let schema = self.schema.clone();
         let mut columns: Vec<ArrayRef> = Vec::new();
+        let shared_keys = self.config.spec.fields.values().any(|g| {
+            matches!(g, FieldGenerator::Key { distribution: KeyDistribution::Shared, .. })
+        });
+        let task_index = self.task_index.unwrap_or(0) as i64;
         
         // Generate records with round-robin key selection
         let mut batch_keys = Vec::with_capacity(batch_size);
@@ -333,11 +326,17 @@ impl DatagenSourceFunction {
             
             let column = match generator {
                 FieldGenerator::IncrementalTimestamp { start_ms, step_ms } => {
+                    // Shared keys reuse the same strings across tasks, so start
+                    // at start_ms + task_index to keep (key, timestamp) unique.
+                    let start_ms = if shared_keys {
+                        *start_ms + task_index
+                    } else {
+                        *start_ms
+                    };
                     Self::generate_incremental_timestamp_column(
                         &mut self.per_key_timestamps,
-                        *start_ms,
+                        start_ms,
                         *step_ms,
-                        self.event_time_lane(),
                         &batch_keys,
                     )?
                 },
@@ -379,7 +378,6 @@ impl DatagenSourceFunction {
         per_key_timestamps: &mut HashMap<String, i64>,
         start_ms: i64,
         step_ms: i64,
-        event_time_lane: i64,
         batch_keys: &[String],
     ) -> Result<ArrayRef> {
         let mut builder = TimestampMillisecondBuilder::with_capacity(batch_keys.len());
@@ -387,7 +385,7 @@ impl DatagenSourceFunction {
         for key in batch_keys {
             let current_ts = per_key_timestamps.get_mut(key).unwrap();
             if *current_ts == 0 {
-                *current_ts = start_ms + event_time_lane;
+                *current_ts = start_ms;
             }
             builder.append_value(*current_ts);
             *current_ts += step_ms;

--- a/src/runtime/functions/source/datagen_source.rs
+++ b/src/runtime/functions/source/datagen_source.rs
@@ -78,7 +78,7 @@ pub enum KeyDistribution {
 }
 
 impl KeyDistribution {
-    fn is_partitioned(self) -> bool {
+    fn is_partitioned(&self) -> bool {
         matches!(self, Self::Partitioned)
     }
 }

--- a/src/test_utils/checkpoint/kill_recovery.rs
+++ b/src/test_utils/checkpoint/kill_recovery.rs
@@ -171,7 +171,7 @@ pub async fn run_checkpoint_sequential_failures(
                     )
                     .await?
                 }
-                CheckpointWorkload::Window => {
+                CheckpointWorkload::Window | CheckpointWorkload::WindowSharedKeys => {
                     wait_for_sink_progress(&cluster, 0, timeouts.attempt_running).await?;
                     advance_lifecycle_cursor(&cluster.master(), &mut cursor).await?;
                     let checkpoint_id = wait_for_checkpoint_started(

--- a/src/test_utils/checkpoint/kill_recovery.rs
+++ b/src/test_utils/checkpoint/kill_recovery.rs
@@ -133,6 +133,7 @@ pub async fn run_checkpoint_sequential_failures(
     }
     let timeouts = RecoveryTimeouts::for_env(env);
     let idle_timeout = checkpoint_idle_timeout(env);
+    let pipeline = launch.pipeline.clone();
     let cluster = VolgaCluster::launch(env, launch).await?;
     let result = async {
         let worker_ids = cluster.worker_ids();
@@ -171,7 +172,7 @@ pub async fn run_checkpoint_sequential_failures(
                     )
                     .await?
                 }
-                CheckpointWorkload::Window | CheckpointWorkload::WindowSharedKeys => {
+                CheckpointWorkload::Window => {
                     wait_for_sink_progress(&cluster, 0, timeouts.attempt_running).await?;
                     advance_lifecycle_cursor(&cluster.master(), &mut cursor).await?;
                     let checkpoint_id = wait_for_checkpoint_started(
@@ -242,7 +243,8 @@ pub async fn run_checkpoint_sequential_failures(
         harness_finish_pipeline(&cluster, &mut cursor, env, failure_count).await?;
 
         let snapshot = cluster.storage().snapshot().await?;
-        assert_sink_matches_offline_datagen(&cluster.master(), &snapshot, env, workload).await?;
+        assert_sink_matches_offline_datagen(&cluster.master(), &snapshot, env, workload, &pipeline)
+            .await?;
 
         let events = cluster.master().lifecycle_events_since(0).await?;
         let report = RecoveryReport::from_events(&events);

--- a/src/test_utils/checkpoint/launch.rs
+++ b/src/test_utils/checkpoint/launch.rs
@@ -10,7 +10,9 @@ use crate::api::spec::connectors::{SinkSpec, SourceSpec, SourceSpecKind};
 use crate::api::spec::operators::{OperatorOverride, OperatorTuningSpec};
 use crate::api::spec::pipeline::ExecutionProfile;
 use crate::api::{CheckpointSpec, PipelineSpecBuilder, TaskWorkerAssignmentStrategyType};
-use crate::runtime::functions::source::datagen_source::{DatagenSpec, FieldGenerator};
+use crate::runtime::functions::source::datagen_source::{
+    DatagenSpec, FieldGenerator, KeyDistribution,
+};
 use crate::runtime::operators::window::spec::WindowSpec;
 use crate::runtime::operators::window::{TileConfig, TimeGranularity};
 use crate::test_utils::harness::PipelineLaunchSpec;
@@ -68,9 +70,18 @@ impl CheckpointWorkload {
 
     fn key_generator(self, parallelism: usize) -> FieldGenerator {
         match self {
-            Self::PassThrough => FieldGenerator::key(parallelism * 8),
-            Self::Window => FieldGenerator::key(parallelism * 4),
-            Self::WindowSharedKeys => FieldGenerator::shared_key(SHARED_WINDOW_KEYS),
+            Self::PassThrough => FieldGenerator::Key {
+                num_unique_keys: parallelism * 8,
+                distribution: KeyDistribution::Partitioned,
+            },
+            Self::Window => FieldGenerator::Key {
+                num_unique_keys: parallelism * 4,
+                distribution: KeyDistribution::Partitioned,
+            },
+            Self::WindowSharedKeys => FieldGenerator::Key {
+                num_unique_keys: SHARED_WINDOW_KEYS,
+                distribution: KeyDistribution::Shared,
+            },
         }
     }
 }

--- a/src/test_utils/checkpoint/launch.rs
+++ b/src/test_utils/checkpoint/launch.rs
@@ -70,10 +70,7 @@ impl CheckpointWorkload {
         match self {
             Self::PassThrough => FieldGenerator::key(parallelism * 8),
             Self::Window => FieldGenerator::key(parallelism * 4),
-            Self::WindowSharedKeys => FieldGenerator::Key {
-                num_unique_keys: SHARED_WINDOW_KEYS,
-                shared: true,
-            },
+            Self::WindowSharedKeys => FieldGenerator::shared_key(SHARED_WINDOW_KEYS),
         }
     }
 }

--- a/src/test_utils/checkpoint/launch.rs
+++ b/src/test_utils/checkpoint/launch.rs
@@ -28,6 +28,8 @@ pub const MULTI_FAILURE_COUNT: usize = 2;
 const SAFETY_DATAGEN_RUN_FOR_S: f64 = 300.0;
 const DATAGEN_RATE: f32 = 200.0;
 pub const WINDOW_RANGE_MS: i64 = 10_000;
+/// Shared-key window workload: every source task emits this many keys (`key-0`..).
+pub const SHARED_WINDOW_KEYS: usize = 4;
 
 pub fn local_checkpoint_spec() -> CheckpointSpec {
     CheckpointSpec {
@@ -49,6 +51,29 @@ pub fn kube_checkpoint_spec() -> CheckpointSpec {
 pub enum CheckpointWorkload {
     PassThrough,
     Window,
+    /// Same window SQL as `Window`, but all source tasks share `key-0`..`key-{SHARED_WINDOW_KEYS-1}`.
+    WindowSharedKeys,
+}
+
+impl CheckpointWorkload {
+    pub fn is_window(self) -> bool {
+        matches!(self, Self::Window | Self::WindowSharedKeys)
+    }
+
+    fn timestamp_step_ms(self) -> i64 {
+        match self {
+            Self::PassThrough => 1,
+            Self::Window | Self::WindowSharedKeys => 1_000,
+        }
+    }
+
+    fn key_generator(self, parallelism: usize) -> FieldGenerator {
+        match self {
+            Self::PassThrough => FieldGenerator::key(parallelism * 8),
+            Self::Window => FieldGenerator::key(parallelism * 4),
+            Self::WindowSharedKeys => FieldGenerator::shared_key(SHARED_WINDOW_KEYS),
+        }
+    }
 }
 
 pub(super) fn checkpoint_datagen_parts(
@@ -69,22 +94,10 @@ pub(super) fn checkpoint_datagen_parts(
         "timestamp".to_string(),
         FieldGenerator::IncrementalTimestamp {
             start_ms: 1_000,
-            step_ms: match workload {
-                CheckpointWorkload::PassThrough => 1,
-                CheckpointWorkload::Window => 1_000,
-            },
+            step_ms: workload.timestamp_step_ms(),
         },
     );
-    fields.insert(
-        "key".to_string(),
-        FieldGenerator::Key {
-            num_unique_keys: parallelism
-                * match workload {
-                    CheckpointWorkload::PassThrough => 8,
-                    CheckpointWorkload::Window => 4,
-                },
-        },
-    );
+    fields.insert("key".to_string(), workload.key_generator(parallelism));
     fields.insert(
         "value".to_string(),
         FieldGenerator::Values {
@@ -132,7 +145,7 @@ pub fn checkpoint_recovery_launch_spec(
 
     let sql = match workload {
         CheckpointWorkload::PassThrough => "SELECT timestamp, key, value FROM datagen_source",
-        CheckpointWorkload::Window => {
+        CheckpointWorkload::Window | CheckpointWorkload::WindowSharedKeys => {
             let tiling = TileConfig::new(vec![
                 TimeGranularity::Seconds(1),
                 TimeGranularity::Seconds(5),
@@ -180,4 +193,9 @@ pub fn checkpoint_recovery_launch_spec(
 /// Multi-worker launch for sequential multi-failure stress (same indefinite datagen).
 pub fn checkpoint_multi_failure_launch_spec() -> PipelineLaunchSpec {
     checkpoint_recovery_launch_spec(MULTI_WORKER_PARALLELISM, CheckpointWorkload::PassThrough)
+}
+
+/// Window recovery with shared keys across source tasks (hash repartition + multi-input WM merge).
+pub fn checkpoint_shared_key_window_launch_spec(parallelism: usize) -> PipelineLaunchSpec {
+    checkpoint_recovery_launch_spec(parallelism, CheckpointWorkload::WindowSharedKeys)
 }

--- a/src/test_utils/checkpoint/launch.rs
+++ b/src/test_utils/checkpoint/launch.rs
@@ -28,8 +28,7 @@ pub const MULTI_FAILURE_COUNT: usize = 2;
 const SAFETY_DATAGEN_RUN_FOR_S: f64 = 300.0;
 const DATAGEN_RATE: f32 = 200.0;
 pub const WINDOW_RANGE_MS: i64 = 10_000;
-/// Shared-key window workload: every source task emits this many keys (`key-0`..).
-pub const SHARED_WINDOW_KEYS: usize = 4;
+const SHARED_WINDOW_KEYS: usize = 4;
 
 pub fn local_checkpoint_spec() -> CheckpointSpec {
     CheckpointSpec {
@@ -51,7 +50,7 @@ pub fn kube_checkpoint_spec() -> CheckpointSpec {
 pub enum CheckpointWorkload {
     PassThrough,
     Window,
-    /// Same window SQL as `Window`, but all source tasks share `key-0`..`key-{SHARED_WINDOW_KEYS-1}`.
+    /// Same window SQL as `Window`, but every source task emits `key-0`..`key-3`.
     WindowSharedKeys,
 }
 
@@ -71,7 +70,10 @@ impl CheckpointWorkload {
         match self {
             Self::PassThrough => FieldGenerator::key(parallelism * 8),
             Self::Window => FieldGenerator::key(parallelism * 4),
-            Self::WindowSharedKeys => FieldGenerator::shared_key(SHARED_WINDOW_KEYS),
+            Self::WindowSharedKeys => FieldGenerator::Key {
+                num_unique_keys: SHARED_WINDOW_KEYS,
+                shared: true,
+            },
         }
     }
 }
@@ -193,9 +195,4 @@ pub fn checkpoint_recovery_launch_spec(
 /// Multi-worker launch for sequential multi-failure stress (same indefinite datagen).
 pub fn checkpoint_multi_failure_launch_spec() -> PipelineLaunchSpec {
     checkpoint_recovery_launch_spec(MULTI_WORKER_PARALLELISM, CheckpointWorkload::PassThrough)
-}
-
-/// Window recovery with shared keys across source tasks (hash repartition + multi-input WM merge).
-pub fn checkpoint_shared_key_window_launch_spec(parallelism: usize) -> PipelineLaunchSpec {
-    checkpoint_recovery_launch_spec(parallelism, CheckpointWorkload::WindowSharedKeys)
 }

--- a/src/test_utils/checkpoint/launch.rs
+++ b/src/test_utils/checkpoint/launch.rs
@@ -52,41 +52,9 @@ pub fn kube_checkpoint_spec() -> CheckpointSpec {
 pub enum CheckpointWorkload {
     PassThrough,
     Window,
-    /// Same window SQL as `Window`, but every source task emits `key-0`..`key-3`.
-    WindowSharedKeys,
 }
 
-impl CheckpointWorkload {
-    pub fn is_window(self) -> bool {
-        matches!(self, Self::Window | Self::WindowSharedKeys)
-    }
-
-    fn timestamp_step_ms(self) -> i64 {
-        match self {
-            Self::PassThrough => 1,
-            Self::Window | Self::WindowSharedKeys => 1_000,
-        }
-    }
-
-    fn key_generator(self, parallelism: usize) -> FieldGenerator {
-        match self {
-            Self::PassThrough => FieldGenerator::Key {
-                num_unique_keys: parallelism * 8,
-                distribution: KeyDistribution::Partitioned,
-            },
-            Self::Window => FieldGenerator::Key {
-                num_unique_keys: parallelism * 4,
-                distribution: KeyDistribution::Partitioned,
-            },
-            Self::WindowSharedKeys => FieldGenerator::Key {
-                num_unique_keys: SHARED_WINDOW_KEYS,
-                distribution: KeyDistribution::Shared,
-            },
-        }
-    }
-}
-
-pub(super) fn checkpoint_datagen_parts(
+fn checkpoint_datagen_parts(
     parallelism: usize,
     workload: CheckpointWorkload,
 ) -> (Arc<Schema>, DatagenSpec) {
@@ -104,10 +72,22 @@ pub(super) fn checkpoint_datagen_parts(
         "timestamp".to_string(),
         FieldGenerator::IncrementalTimestamp {
             start_ms: 1_000,
-            step_ms: workload.timestamp_step_ms(),
+            step_ms: match workload {
+                CheckpointWorkload::PassThrough => 1,
+                CheckpointWorkload::Window => 1_000,
+            },
         },
     );
-    fields.insert("key".to_string(), workload.key_generator(parallelism));
+    fields.insert(
+        "key".to_string(),
+        FieldGenerator::Key {
+            num_unique_keys: match workload {
+                CheckpointWorkload::PassThrough => parallelism * 8,
+                CheckpointWorkload::Window => parallelism * 4,
+            },
+            distribution: KeyDistribution::Partitioned,
+        },
+    );
     fields.insert(
         "value".to_string(),
         FieldGenerator::Values {
@@ -155,7 +135,7 @@ pub fn checkpoint_recovery_launch_spec(
 
     let sql = match workload {
         CheckpointWorkload::PassThrough => "SELECT timestamp, key, value FROM datagen_source",
-        CheckpointWorkload::Window | CheckpointWorkload::WindowSharedKeys => {
+        CheckpointWorkload::Window => {
             let tiling = TileConfig::new(vec![
                 TimeGranularity::Seconds(1),
                 TimeGranularity::Seconds(5),
@@ -203,4 +183,23 @@ pub fn checkpoint_recovery_launch_spec(
 /// Multi-worker launch for sequential multi-failure stress (same indefinite datagen).
 pub fn checkpoint_multi_failure_launch_spec() -> PipelineLaunchSpec {
     checkpoint_recovery_launch_spec(MULTI_WORKER_PARALLELISM, CheckpointWorkload::PassThrough)
+}
+
+/// Window SQL with every source task emitting the same keys.
+pub fn checkpoint_shared_key_window_launch_spec(parallelism: usize) -> PipelineLaunchSpec {
+    let mut launch = checkpoint_recovery_launch_spec(parallelism, CheckpointWorkload::Window);
+    let SourceSpecKind::Datagen(datagen) = &mut launch.pipeline.sources[0].source else {
+        panic!("checkpoint launch spec uses datagen");
+    };
+    for gen in datagen.fields.values_mut() {
+        if let FieldGenerator::Key {
+            num_unique_keys,
+            distribution,
+        } = gen
+        {
+            *num_unique_keys = SHARED_WINDOW_KEYS;
+            *distribution = KeyDistribution::Shared;
+        }
+    }
+    launch
 }

--- a/src/test_utils/checkpoint/mid_flight.rs
+++ b/src/test_utils/checkpoint/mid_flight.rs
@@ -114,6 +114,7 @@ pub async fn run_checkpoint_mid_flight_kill_after_safe(
     mode: WorkerKillMode,
 ) -> Result<RecoveryReport> {
     let timeouts = RecoveryTimeouts::for_env(env);
+    let pipeline = launch.pipeline.clone();
     let cluster = VolgaCluster::launch(env, launch).await?;
     let result = async {
         let target = cluster
@@ -188,6 +189,7 @@ pub async fn run_checkpoint_mid_flight_kill_after_safe(
             &snapshot,
             env,
             CheckpointWorkload::PassThrough,
+            &pipeline,
         )
         .await?;
 

--- a/src/test_utils/checkpoint/mod.rs
+++ b/src/test_utils/checkpoint/mod.rs
@@ -13,9 +13,10 @@ pub use kill_recovery::{
     run_checkpoint_worker_kill_recovery, wait_for_kill_restore,
 };
 pub use launch::{
-    checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec, kube_checkpoint_spec,
-    CheckpointWorkload,
-    MULTI_FAILURE_COUNT, MULTI_WORKER_PARALLELISM, SINGLE_WORKER_PARALLELISM, WINDOW_RANGE_MS,
+    checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec,
+    checkpoint_shared_key_window_launch_spec, kube_checkpoint_spec, CheckpointWorkload,
+    MULTI_FAILURE_COUNT, MULTI_WORKER_PARALLELISM, SHARED_WINDOW_KEYS, SINGLE_WORKER_PARALLELISM,
+    WINDOW_RANGE_MS,
 };
 pub use mid_flight::{
     run_checkpoint_mid_flight_kill_after_safe, run_checkpoint_mid_flight_kill_no_prior,

--- a/src/test_utils/checkpoint/mod.rs
+++ b/src/test_utils/checkpoint/mod.rs
@@ -13,9 +13,9 @@ pub use kill_recovery::{
     run_checkpoint_worker_kill_recovery, wait_for_kill_restore,
 };
 pub use launch::{
-    checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec, kube_checkpoint_spec,
-    CheckpointWorkload, MULTI_FAILURE_COUNT, MULTI_WORKER_PARALLELISM, SINGLE_WORKER_PARALLELISM,
-    WINDOW_RANGE_MS,
+    checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec,
+    checkpoint_shared_key_window_launch_spec, kube_checkpoint_spec, CheckpointWorkload,
+    MULTI_FAILURE_COUNT, MULTI_WORKER_PARALLELISM, SINGLE_WORKER_PARALLELISM, WINDOW_RANGE_MS,
 };
 pub use mid_flight::{
     run_checkpoint_mid_flight_kill_after_safe, run_checkpoint_mid_flight_kill_no_prior,

--- a/src/test_utils/checkpoint/mod.rs
+++ b/src/test_utils/checkpoint/mod.rs
@@ -13,9 +13,8 @@ pub use kill_recovery::{
     run_checkpoint_worker_kill_recovery, wait_for_kill_restore,
 };
 pub use launch::{
-    checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec,
-    checkpoint_shared_key_window_launch_spec, kube_checkpoint_spec, CheckpointWorkload,
-    MULTI_FAILURE_COUNT, MULTI_WORKER_PARALLELISM, SHARED_WINDOW_KEYS, SINGLE_WORKER_PARALLELISM,
+    checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec, kube_checkpoint_spec,
+    CheckpointWorkload, MULTI_FAILURE_COUNT, MULTI_WORKER_PARALLELISM, SINGLE_WORKER_PARALLELISM,
     WINDOW_RANGE_MS,
 };
 pub use mid_flight::{

--- a/src/test_utils/checkpoint/sink_oracle.rs
+++ b/src/test_utils/checkpoint/sink_oracle.rs
@@ -124,6 +124,16 @@ fn materialize_input_rows(
             }
         }
     }
+    let mut seen = HashSet::new();
+    for row in &rows {
+        if !seen.insert((row.key.clone(), row.timestamp)) {
+            return Err(anyhow!(
+                "duplicate upsert identity ({}, {}); shared-key datagen must use unique event-time lanes",
+                row.key,
+                row.timestamp
+            ));
+        }
+    }
     Ok(rows)
 }
 
@@ -161,6 +171,9 @@ fn pass_through_sink_rows(
 }
 
 fn expected_window_rows(rows: Vec<InputRow>) -> HashMap<String, WindowAggregateRow> {
+    // Shared-key workloads emit the same logical key from every source task; merge
+    // all of those rows before RANGE aggregation so the oracle matches hash-repartitioned
+    // window input rather than per-task partitioned keys.
     let mut by_key: HashMap<String, Vec<InputRow>> = HashMap::new();
     for row in rows {
         by_key.entry(row.key.clone()).or_default().push(row);
@@ -368,8 +381,11 @@ fn window_key_context(
             .find(|(task_index, _)| *task_index == task)
             .map(|(_, records)| *records)
     });
+    let shared_key = key
+        .strip_prefix("key-")
+        .is_some_and(|suffix| !suffix.contains('-'));
     format!(
-        "key={key} expected_key_rows={} actual_key_rows={} source_task={source_task:?} source_records={source_records:?}",
+        "key={key} expected_key_rows={} actual_key_rows={} source_task={source_task:?} source_records={source_records:?} shared_key={shared_key} task_counts={task_counts:?}",
         expected_rows.len(),
         actual_rows.len(),
     )
@@ -424,7 +440,7 @@ pub(super) async fn assert_sink_matches_offline_datagen(
     let total: u64 = task_counts.iter().map(|(_, n)| n).sum();
     let input_rows = materialize_input_rows(&task_counts, workload)?;
 
-    if workload == CheckpointWorkload::Window {
+    if workload.is_window() {
         assert_no_window_late_drops(&snapshot)?;
         let expected = expected_window_rows(input_rows);
         let actual = window_sink_rows(storage)?;
@@ -455,4 +471,37 @@ pub(super) async fn assert_sink_matches_offline_datagen(
         actual.len()
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expected_window_rows_merges_shared_keys_across_source_tasks() {
+        let rows = vec![
+            InputRow {
+                key: "key-0".into(),
+                timestamp: 1000,
+                value: 1.0,
+            },
+            InputRow {
+                key: "key-0".into(),
+                timestamp: 1001,
+                value: 2.0,
+            },
+            InputRow {
+                key: "key-0".into(),
+                timestamp: 2000,
+                value: 3.0,
+            },
+        ];
+        let expected = expected_window_rows(rows);
+        let at_1001 = expected.get("key-0|1001").expect("merged row at 1001");
+        assert_eq!(at_1001.count, 2);
+        assert!((at_1001.sum - 3.0).abs() < 1e-9);
+        let at_2000 = expected.get("key-0|2000").expect("merged row at 2000");
+        assert_eq!(at_2000.count, 3);
+        assert!((at_2000.sum - 6.0).abs() < 1e-9);
+    }
 }

--- a/src/test_utils/checkpoint/sink_oracle.rs
+++ b/src/test_utils/checkpoint/sink_oracle.rs
@@ -171,9 +171,6 @@ fn pass_through_sink_rows(
 }
 
 fn expected_window_rows(rows: Vec<InputRow>) -> HashMap<String, WindowAggregateRow> {
-    // Shared-key workloads emit the same logical key from every source task; merge
-    // all of those rows before RANGE aggregation so the oracle matches hash-repartitioned
-    // window input rather than per-task partitioned keys.
     let mut by_key: HashMap<String, Vec<InputRow>> = HashMap::new();
     for row in rows {
         by_key.entry(row.key.clone()).or_default().push(row);
@@ -381,11 +378,8 @@ fn window_key_context(
             .find(|(task_index, _)| *task_index == task)
             .map(|(_, records)| *records)
     });
-    let shared_key = key
-        .strip_prefix("key-")
-        .is_some_and(|suffix| !suffix.contains('-'));
     format!(
-        "key={key} expected_key_rows={} actual_key_rows={} source_task={source_task:?} source_records={source_records:?} shared_key={shared_key} task_counts={task_counts:?}",
+        "key={key} expected_key_rows={} actual_key_rows={} source_task={source_task:?} source_records={source_records:?}",
         expected_rows.len(),
         actual_rows.len(),
     )
@@ -471,37 +465,4 @@ pub(super) async fn assert_sink_matches_offline_datagen(
         actual.len()
     );
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn expected_window_rows_merges_shared_keys_across_source_tasks() {
-        let rows = vec![
-            InputRow {
-                key: "key-0".into(),
-                timestamp: 1000,
-                value: 1.0,
-            },
-            InputRow {
-                key: "key-0".into(),
-                timestamp: 1001,
-                value: 2.0,
-            },
-            InputRow {
-                key: "key-0".into(),
-                timestamp: 2000,
-                value: 3.0,
-            },
-        ];
-        let expected = expected_window_rows(rows);
-        let at_1001 = expected.get("key-0|1001").expect("merged row at 1001");
-        assert_eq!(at_1001.count, 2);
-        assert!((at_1001.sum - 3.0).abs() < 1e-9);
-        let at_2000 = expected.get("key-0|2000").expect("merged row at 2000");
-        assert_eq!(at_2000.count, 3);
-        assert!((at_2000.sum - 6.0).abs() < 1e-9);
-    }
 }

--- a/src/test_utils/checkpoint/sink_oracle.rs
+++ b/src/test_utils/checkpoint/sink_oracle.rs
@@ -128,7 +128,7 @@ fn materialize_input_rows(
     for row in &rows {
         if !seen.insert((row.key.clone(), row.timestamp)) {
             return Err(anyhow!(
-                "duplicate upsert identity ({}, {}); shared-key datagen must use unique event-time lanes",
+                "duplicate upsert identity ({}, {}); shared-key timestamps must be unique across tasks",
                 row.key,
                 row.timestamp
             ));

--- a/src/test_utils/checkpoint/sink_oracle.rs
+++ b/src/test_utils/checkpoint/sink_oracle.rs
@@ -3,8 +3,12 @@
 use anyhow::{anyhow, Result};
 use arrow::array::{Array, Float64Array, Int64Array, StringArray, TimestampMillisecondArray};
 use arrow::record_batch::RecordBatch;
+use arrow_integration_test::schema_from_json;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
 
+use crate::api::spec::connectors::SourceSpecKind;
+use crate::api::PipelineSpec;
 use crate::runtime::functions::source::datagen_source::{
     DatagenSourceConfig, DatagenSourceFunction,
 };
@@ -13,10 +17,10 @@ use crate::runtime::operators::source::TASK_METADATA_RECORDS_GENERATED;
 use crate::runtime::operators::window::{
     TASK_METADATA_ROWS_ACCEPTED, TASK_METADATA_ROWS_DROPPED_LATE,
 };
-use crate::test_utils::harness::{MasterHandle, RuntimeEnv};
 use crate::storage::InMemoryStorageSnapshot;
+use crate::test_utils::harness::{MasterHandle, RuntimeEnv};
 
-use super::launch::{checkpoint_datagen_parts, CheckpointWorkload, WINDOW_RANGE_MS};
+use super::launch::{CheckpointWorkload, WINDOW_RANGE_MS};
 
 /// Logical sink row identity for upsert-key `(key, timestamp)` plus value for content checks.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -97,9 +101,24 @@ fn materialize_datagen_for_task(
     Ok(out)
 }
 
+fn datagen_config_from_pipeline(pipeline: &PipelineSpec) -> Result<DatagenSourceConfig> {
+    let src = pipeline
+        .sources
+        .first()
+        .ok_or_else(|| anyhow!("pipeline has no sources"))?;
+    let schema = Arc::new(
+        schema_from_json(&src.schema_json)
+            .map_err(|e| anyhow!("failed to parse source.schema_json: {e}"))?,
+    );
+    match &src.source {
+        SourceSpecKind::Datagen(spec) => Ok(DatagenSourceConfig::new(schema, spec.clone())),
+        _ => Err(anyhow!("checkpoint oracle expects a datagen source")),
+    }
+}
+
 fn materialize_input_rows(
     task_counts: &[(i32, u64)],
-    workload: CheckpointWorkload,
+    config: &DatagenSourceConfig,
 ) -> Result<Vec<InputRow>> {
     let parallelism = task_counts
         .iter()
@@ -107,9 +126,6 @@ fn materialize_input_rows(
         .max()
         .ok_or_else(|| anyhow!("empty task_counts"))?
         + 1;
-    // run_for unused for offline materialization (counts come from task metadata).
-    let (schema, spec) = checkpoint_datagen_parts(parallelism as usize, workload);
-    let config = DatagenSourceConfig::new(schema, spec);
     let mut rows = Vec::new();
     for &(task_index, num_records) in task_counts {
         let batches = materialize_datagen_for_task(
@@ -425,6 +441,7 @@ pub(super) async fn assert_sink_matches_offline_datagen(
     storage: &InMemoryStorageSnapshot,
     env: RuntimeEnv,
     workload: CheckpointWorkload,
+    pipeline: &PipelineSpec,
 ) -> Result<()> {
     let snapshot = master
         .latest_pipeline_snapshot()
@@ -432,9 +449,10 @@ pub(super) async fn assert_sink_matches_offline_datagen(
         .ok_or_else(|| anyhow!("missing pipeline snapshot after PipelineFinished"))?;
     let task_counts = task_record_counts(&snapshot)?;
     let total: u64 = task_counts.iter().map(|(_, n)| n).sum();
-    let input_rows = materialize_input_rows(&task_counts, workload)?;
+    let config = datagen_config_from_pipeline(pipeline)?;
+    let input_rows = materialize_input_rows(&task_counts, &config)?;
 
-    if workload.is_window() {
+    if workload == CheckpointWorkload::Window {
         assert_no_window_late_drops(&snapshot)?;
         let expected = expected_window_rows(input_rows);
         let actual = window_sink_rows(storage)?;

--- a/src/test_utils/smoke.rs
+++ b/src/test_utils/smoke.rs
@@ -68,7 +68,7 @@ pub fn docker_smoke_launch_spec() -> PipelineLaunchSpec {
 }
 
 pub fn kube_smoke_launch_spec() -> PipelineLaunchSpec {
-    deployment_smoke_launch_spec(FieldGenerator::Key { num_unique_keys: 6 })
+    deployment_smoke_launch_spec(FieldGenerator::key(6))
         .with_kube_worker_health_poll(true)
         .with_state_maintenance(true, 100)
 }

--- a/src/test_utils/smoke.rs
+++ b/src/test_utils/smoke.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 
 use crate::api::TaskWorkerAssignmentStrategyType;
-use crate::runtime::functions::source::datagen_source::FieldGenerator;
+use crate::runtime::functions::source::datagen_source::{FieldGenerator, KeyDistribution};
 use crate::test_utils::harness::{
     OutputOracle, PipelineLaunchSpec, RuntimeEnv, VolgaCluster,
 };
@@ -68,7 +68,10 @@ pub fn docker_smoke_launch_spec() -> PipelineLaunchSpec {
 }
 
 pub fn kube_smoke_launch_spec() -> PipelineLaunchSpec {
-    deployment_smoke_launch_spec(FieldGenerator::key(6))
+    deployment_smoke_launch_spec(FieldGenerator::Key {
+        num_unique_keys: 6,
+        distribution: KeyDistribution::Partitioned,
+    })
         .with_kube_worker_health_poll(true)
         .with_state_maintenance(true, 100)
 }

--- a/src/tests/benchmark/window_operator_benchmark.rs
+++ b/src/tests/benchmark/window_operator_benchmark.rs
@@ -10,7 +10,7 @@ use crate::{
     test_utils::pipeline_exec,
     runtime::{
         functions::source::{
-            datagen_source::{DatagenSourceConfig, FieldGenerator},
+            datagen_source::{DatagenSourceConfig, FieldGenerator, KeyDistribution},
             DatagenSpec,
         },
                 observability::PipelineSnapshot,
@@ -238,7 +238,10 @@ pub async fn run_window_benchmark(config: WindowBenchmarkConfig) -> Result<Bench
         ),
         (
             "key".to_string(),
-            FieldGenerator::key(config.num_keys),
+            FieldGenerator::Key {
+                num_unique_keys: config.num_keys,
+                distribution: KeyDistribution::Partitioned,
+            },
         ),
         (
             "value".to_string(),

--- a/src/tests/benchmark/window_operator_benchmark.rs
+++ b/src/tests/benchmark/window_operator_benchmark.rs
@@ -238,9 +238,7 @@ pub async fn run_window_benchmark(config: WindowBenchmarkConfig) -> Result<Bench
         ),
         (
             "key".to_string(),
-            FieldGenerator::Key {
-                num_unique_keys: config.num_keys,
-            },
+            FieldGenerator::key(config.num_keys),
         ),
         (
             "value".to_string(),

--- a/src/tests/benchmark/window_request_operator_benchmark.rs
+++ b/src/tests/benchmark/window_request_operator_benchmark.rs
@@ -10,7 +10,7 @@ use crate::{
     test_utils::pipeline_exec,
     runtime::{
         functions::source::{
-            datagen_source::{DatagenSourceConfig, FieldGenerator},
+            datagen_source::{DatagenSourceConfig, FieldGenerator, KeyDistribution},
             DatagenSpec,
         },
                 observability::PipelineSnapshot,
@@ -58,7 +58,10 @@ fn create_datagen_config(
         ),
         (
             "key".to_string(),
-            FieldGenerator::key(num_unique_keys),
+            FieldGenerator::Key {
+                num_unique_keys,
+                distribution: KeyDistribution::Partitioned,
+            },
         ),
         (
             "value".to_string(),

--- a/src/tests/benchmark/window_request_operator_benchmark.rs
+++ b/src/tests/benchmark/window_request_operator_benchmark.rs
@@ -58,9 +58,7 @@ fn create_datagen_config(
         ),
         (
             "key".to_string(),
-            FieldGenerator::Key {
-                num_unique_keys: num_unique_keys,
-            },
+            FieldGenerator::key(num_unique_keys),
         ),
         (
             "value".to_string(),

--- a/src/tests/inprocess/checkpoint.rs
+++ b/src/tests/inprocess/checkpoint.rs
@@ -3,10 +3,10 @@ use anyhow::Result;
 use crate::test_utils::checkpoint::{
     assert_checkpoint_multi_restore, assert_checkpoint_restore,
     checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec,
-    run_checkpoint_barrier_path, run_checkpoint_mid_flight_kill_after_safe,
-    run_checkpoint_mid_flight_kill_no_prior, run_checkpoint_sequential_failures,
-    run_checkpoint_worker_kill_recovery, CheckpointWorkload, MULTI_FAILURE_COUNT,
-    MULTI_WORKER_PARALLELISM, SINGLE_WORKER_PARALLELISM,
+    checkpoint_shared_key_window_launch_spec, run_checkpoint_barrier_path,
+    run_checkpoint_mid_flight_kill_after_safe, run_checkpoint_mid_flight_kill_no_prior,
+    run_checkpoint_sequential_failures, run_checkpoint_worker_kill_recovery, CheckpointWorkload,
+    MULTI_FAILURE_COUNT, MULTI_WORKER_PARALLELISM, SINGLE_WORKER_PARALLELISM,
 };
 use crate::test_utils::harness::{RuntimeEnv, WorkerKillMode};
 
@@ -109,9 +109,9 @@ async fn test_local_multi_worker_window_checkpoint_restore() -> Result<()> {
 async fn test_local_multi_worker_window_shared_key_checkpoint_restore() -> Result<()> {
     let report = run_checkpoint_worker_kill_recovery(
         RuntimeEnv::Local,
-        checkpoint_recovery_launch_spec(MULTI_WORKER_PARALLELISM, CheckpointWorkload::WindowSharedKeys),
+        checkpoint_shared_key_window_launch_spec(MULTI_WORKER_PARALLELISM),
         WorkerKillMode::Abrupt,
-        CheckpointWorkload::WindowSharedKeys,
+        CheckpointWorkload::Window,
     )
     .await?;
     assert_checkpoint_multi_restore(&report, 1, 2)

--- a/src/tests/inprocess/checkpoint.rs
+++ b/src/tests/inprocess/checkpoint.rs
@@ -3,10 +3,10 @@ use anyhow::Result;
 use crate::test_utils::checkpoint::{
     assert_checkpoint_multi_restore, assert_checkpoint_restore,
     checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec,
-    run_checkpoint_barrier_path, run_checkpoint_mid_flight_kill_after_safe,
-    run_checkpoint_mid_flight_kill_no_prior, run_checkpoint_sequential_failures,
-    run_checkpoint_worker_kill_recovery, CheckpointWorkload, MULTI_FAILURE_COUNT,
-    MULTI_WORKER_PARALLELISM, SINGLE_WORKER_PARALLELISM,
+    checkpoint_shared_key_window_launch_spec, run_checkpoint_barrier_path,
+    run_checkpoint_mid_flight_kill_after_safe, run_checkpoint_mid_flight_kill_no_prior,
+    run_checkpoint_sequential_failures, run_checkpoint_worker_kill_recovery, CheckpointWorkload,
+    MULTI_FAILURE_COUNT, MULTI_WORKER_PARALLELISM, SINGLE_WORKER_PARALLELISM,
 };
 use crate::test_utils::harness::{RuntimeEnv, WorkerKillMode};
 
@@ -100,6 +100,30 @@ async fn test_local_multi_worker_window_checkpoint_restore() -> Result<()> {
         checkpoint_recovery_launch_spec(MULTI_WORKER_PARALLELISM, CheckpointWorkload::Window),
         WorkerKillMode::Abrupt,
         CheckpointWorkload::Window,
+    )
+    .await?;
+    assert_checkpoint_multi_restore(&report, 1, 2)
+}
+
+#[tokio::test]
+async fn test_local_single_worker_window_shared_key_checkpoint_restore() -> Result<()> {
+    let report = run_checkpoint_worker_kill_recovery(
+        RuntimeEnv::Local,
+        checkpoint_shared_key_window_launch_spec(SINGLE_WORKER_PARALLELISM),
+        WorkerKillMode::Abrupt,
+        CheckpointWorkload::WindowSharedKeys,
+    )
+    .await?;
+    assert_checkpoint_multi_restore(&report, 1, 1)
+}
+
+#[tokio::test]
+async fn test_local_multi_worker_window_shared_key_checkpoint_restore() -> Result<()> {
+    let report = run_checkpoint_worker_kill_recovery(
+        RuntimeEnv::Local,
+        checkpoint_shared_key_window_launch_spec(MULTI_WORKER_PARALLELISM),
+        WorkerKillMode::Abrupt,
+        CheckpointWorkload::WindowSharedKeys,
     )
     .await?;
     assert_checkpoint_multi_restore(&report, 1, 2)

--- a/src/tests/inprocess/checkpoint.rs
+++ b/src/tests/inprocess/checkpoint.rs
@@ -3,10 +3,10 @@ use anyhow::Result;
 use crate::test_utils::checkpoint::{
     assert_checkpoint_multi_restore, assert_checkpoint_restore,
     checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec,
-    checkpoint_shared_key_window_launch_spec, run_checkpoint_barrier_path,
-    run_checkpoint_mid_flight_kill_after_safe, run_checkpoint_mid_flight_kill_no_prior,
-    run_checkpoint_sequential_failures, run_checkpoint_worker_kill_recovery, CheckpointWorkload,
-    MULTI_FAILURE_COUNT, MULTI_WORKER_PARALLELISM, SINGLE_WORKER_PARALLELISM,
+    run_checkpoint_barrier_path, run_checkpoint_mid_flight_kill_after_safe,
+    run_checkpoint_mid_flight_kill_no_prior, run_checkpoint_sequential_failures,
+    run_checkpoint_worker_kill_recovery, CheckpointWorkload, MULTI_FAILURE_COUNT,
+    MULTI_WORKER_PARALLELISM, SINGLE_WORKER_PARALLELISM,
 };
 use crate::test_utils::harness::{RuntimeEnv, WorkerKillMode};
 
@@ -106,22 +106,10 @@ async fn test_local_multi_worker_window_checkpoint_restore() -> Result<()> {
 }
 
 #[tokio::test]
-async fn test_local_single_worker_window_shared_key_checkpoint_restore() -> Result<()> {
-    let report = run_checkpoint_worker_kill_recovery(
-        RuntimeEnv::Local,
-        checkpoint_shared_key_window_launch_spec(SINGLE_WORKER_PARALLELISM),
-        WorkerKillMode::Abrupt,
-        CheckpointWorkload::WindowSharedKeys,
-    )
-    .await?;
-    assert_checkpoint_multi_restore(&report, 1, 1)
-}
-
-#[tokio::test]
 async fn test_local_multi_worker_window_shared_key_checkpoint_restore() -> Result<()> {
     let report = run_checkpoint_worker_kill_recovery(
         RuntimeEnv::Local,
-        checkpoint_shared_key_window_launch_spec(MULTI_WORKER_PARALLELISM),
+        checkpoint_recovery_launch_spec(MULTI_WORKER_PARALLELISM, CheckpointWorkload::WindowSharedKeys),
         WorkerKillMode::Abrupt,
         CheckpointWorkload::WindowSharedKeys,
     )

--- a/src/tests/inprocess/watermark_streaming.rs
+++ b/src/tests/inprocess/watermark_streaming.rs
@@ -66,9 +66,7 @@ pub(crate) async fn run_watermark_window_pipeline(
     );
     fields.insert(
         "partition_key".to_string(),
-        FieldGenerator::Key {
-            num_unique_keys: num_unique_keys,
-        },
+        FieldGenerator::key(num_unique_keys),
     );
     fields.insert(
         "value".to_string(),

--- a/src/tests/inprocess/watermark_streaming.rs
+++ b/src/tests/inprocess/watermark_streaming.rs
@@ -11,7 +11,7 @@ use crate::api::spec::pipeline::ExecutionProfile;
 use crate::api::{compile_logical_graph, ExecutionMode, PipelineSpecBuilder};
 use crate::common::ports::gen_unique_grpc_port;
 use crate::common::types::PipelineId;
-use crate::runtime::functions::source::datagen_source::{DatagenSpec, FieldGenerator};
+use crate::runtime::functions::source::datagen_source::{DatagenSpec, FieldGenerator, KeyDistribution};
 use crate::runtime::observability::snapshot_types::StreamTaskStatus;
 use crate::runtime::operators::operator::OperatorConfig;
 use crate::test_utils::support::{
@@ -66,7 +66,10 @@ pub(crate) async fn run_watermark_window_pipeline(
     );
     fields.insert(
         "partition_key".to_string(),
-        FieldGenerator::key(num_unique_keys),
+        FieldGenerator::Key {
+            num_unique_keys,
+            distribution: KeyDistribution::Partitioned,
+        },
     );
     fields.insert(
         "value".to_string(),

--- a/src/tests/kube/checkpoint.rs
+++ b/src/tests/kube/checkpoint.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 
 use crate::test_utils::checkpoint::{
     assert_checkpoint_multi_restore, assert_checkpoint_restore,
-    checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec, kube_checkpoint_spec,
+    checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec,
+    checkpoint_shared_key_window_launch_spec, kube_checkpoint_spec,
     run_checkpoint_barrier_path, run_checkpoint_mid_flight_kill_after_safe,
     run_checkpoint_mid_flight_kill_no_prior, run_checkpoint_sequential_failures,
     run_checkpoint_worker_kill_recovery, CheckpointWorkload, MULTI_FAILURE_COUNT,
@@ -130,6 +131,36 @@ async fn test_kube_multi_worker_window_checkpoint_restore() -> Result<()> {
         ),
         WorkerKillMode::Abrupt,
         CheckpointWorkload::Window,
+    )
+    .await?;
+    assert_checkpoint_multi_restore(&report, 1, 2)
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_kube_single_worker_window_shared_key_checkpoint_restore() -> Result<()> {
+    let report = run_checkpoint_worker_kill_recovery(
+        RuntimeEnv::Kube,
+        kube_checkpoint_launch(checkpoint_shared_key_window_launch_spec(
+            SINGLE_WORKER_PARALLELISM,
+        )),
+        WorkerKillMode::Abrupt,
+        CheckpointWorkload::WindowSharedKeys,
+    )
+    .await?;
+    assert_checkpoint_multi_restore(&report, 1, 1)
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_kube_multi_worker_window_shared_key_checkpoint_restore() -> Result<()> {
+    let report = run_checkpoint_worker_kill_recovery(
+        RuntimeEnv::Kube,
+        kube_checkpoint_launch(checkpoint_shared_key_window_launch_spec(
+            MULTI_WORKER_PARALLELISM,
+        )),
+        WorkerKillMode::Abrupt,
+        CheckpointWorkload::WindowSharedKeys,
     )
     .await?;
     assert_checkpoint_multi_restore(&report, 1, 2)

--- a/src/tests/kube/checkpoint.rs
+++ b/src/tests/kube/checkpoint.rs
@@ -4,8 +4,7 @@ use anyhow::Result;
 
 use crate::test_utils::checkpoint::{
     assert_checkpoint_multi_restore, assert_checkpoint_restore,
-    checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec,
-    checkpoint_shared_key_window_launch_spec, kube_checkpoint_spec,
+    checkpoint_multi_failure_launch_spec, checkpoint_recovery_launch_spec, kube_checkpoint_spec,
     run_checkpoint_barrier_path, run_checkpoint_mid_flight_kill_after_safe,
     run_checkpoint_mid_flight_kill_no_prior, run_checkpoint_sequential_failures,
     run_checkpoint_worker_kill_recovery, CheckpointWorkload, MULTI_FAILURE_COUNT,
@@ -131,36 +130,6 @@ async fn test_kube_multi_worker_window_checkpoint_restore() -> Result<()> {
         ),
         WorkerKillMode::Abrupt,
         CheckpointWorkload::Window,
-    )
-    .await?;
-    assert_checkpoint_multi_restore(&report, 1, 2)
-}
-
-#[tokio::test]
-#[ignore]
-async fn test_kube_single_worker_window_shared_key_checkpoint_restore() -> Result<()> {
-    let report = run_checkpoint_worker_kill_recovery(
-        RuntimeEnv::Kube,
-        kube_checkpoint_launch(checkpoint_shared_key_window_launch_spec(
-            SINGLE_WORKER_PARALLELISM,
-        )),
-        WorkerKillMode::Abrupt,
-        CheckpointWorkload::WindowSharedKeys,
-    )
-    .await?;
-    assert_checkpoint_multi_restore(&report, 1, 1)
-}
-
-#[tokio::test]
-#[ignore]
-async fn test_kube_multi_worker_window_shared_key_checkpoint_restore() -> Result<()> {
-    let report = run_checkpoint_worker_kill_recovery(
-        RuntimeEnv::Kube,
-        kube_checkpoint_launch(checkpoint_shared_key_window_launch_spec(
-            MULTI_WORKER_PARALLELISM,
-        )),
-        WorkerKillMode::Abrupt,
-        CheckpointWorkload::WindowSharedKeys,
     )
     .await?;
     assert_checkpoint_multi_restore(&report, 1, 2)


### PR DESCRIPTION
## Summary
- Datagen `KeyDistribution::{Partitioned, Shared}`: shared mode has every source task emit `key-0`..`key-3`. Incremental timestamps start at `start_ms + task_index` so `(key, timestamp)` stays a unique upsert identity.
- `CheckpointWorkload` is only pipeline shape (`PassThrough` | `Window`). Shared keys are a patch on the launched `DatagenSpec`; the sink oracle replays that spec instead of reconstructing datagen from the enum.
- One in-process multi-worker window kill/restore test. Sources hash the same keys onto one window task (min-merge watermarks). Offline oracle groups by key, checks RANGE aggregates, and requires `window_rows_dropped_late == 0`.
- Sink check is `expected ⊆ actual` (overshoot allowed until #150 / #198). Missing keys, wrong aggregates, and late drops still fail.
- Implements #173. Broadens the recovery surface for #169.

## Test plan
- [ ] `scripts/test inprocess --filter 'test(test_local_multi_worker_window_shared_key_checkpoint_restore)'`
- [ ] Existing partitioned window checkpoint test still passes