### PR TITLE
Flush sink before checkpoint Aligned

### DIFF
--- a/src/runtime/functions/sink/in_memory_storage_sink.rs
+++ b/src/runtime/functions/sink/in_memory_storage_sink.rs
@@ -22,8 +22,6 @@ pub struct InMemoryStorageSinkFunction {
     buffer: Arc<Mutex<Vec<Message>>>,
     keyed_buffer: Arc<Mutex<HashMap<String, Message>>>,
     flush_handle: Option<tokio::task::JoinHandle<()>>,
-    /// Serializes drain+RPC so barrier flush waits for an in-flight ticker flush.
-    flush_gate: Arc<Mutex<()>>,
     running: Arc<AtomicBool>,
     runtime_context: Option<RuntimeContext>,
     server_addr: String,
@@ -38,7 +36,6 @@ impl InMemoryStorageSinkFunction {
             buffer: Arc::new(Mutex::new(Vec::new())),
             keyed_buffer: Arc::new(Mutex::new(HashMap::new())),
             flush_handle: None,
-            flush_gate: Arc::new(Mutex::new(())),
             running: Arc::new(AtomicBool::new(false)),
             runtime_context: None,
             server_addr,
@@ -117,20 +114,20 @@ impl InMemoryStorageSinkFunction {
         storage_client: &Arc<Mutex<InMemoryStorageClient>>,
         buffer: &Arc<Mutex<Vec<Message>>>,
         keyed_buffer: &Arc<Mutex<HashMap<String, Message>>>,
-        flush_gate: &Arc<Mutex<()>>,
     ) -> Result<()> {
-        let _gate = flush_gate.lock().await;
+        // Client first so barrier flush waits out an in-flight ticker RPC.
+        let mut client = storage_client.lock().await;
         let mut regular_batches = buffer.lock().await;
         if !regular_batches.is_empty() {
             let batches: Vec<Message> = regular_batches.drain(..).collect();
-            let mut client = storage_client.lock().await;
+            drop(regular_batches);
             client.append_many(batches).await?;
         }
 
         let mut keyed_batches = keyed_buffer.lock().await;
         if !keyed_batches.is_empty() {
             let batches: HashMap<String, Message> = keyed_batches.drain().collect();
-            let mut client = storage_client.lock().await;
+            drop(keyed_batches);
             client.insert_keyed_many(batches).await?;
         }
 
@@ -159,7 +156,7 @@ impl SinkFunctionTrait for InMemoryStorageSinkFunction {
         let Some(client) = &self.storage_client else {
             return Ok(());
         };
-        Self::flush_buffers(client, &self.buffer, &self.keyed_buffer, &self.flush_gate).await
+        Self::flush_buffers(client, &self.buffer, &self.keyed_buffer).await
     }
 }
 
@@ -176,19 +173,14 @@ impl FunctionTrait for InMemoryStorageSinkFunction {
 
         let buffer = self.buffer.clone();
         let keyed_buffer = self.keyed_buffer.clone();
-        let flush_gate = self.flush_gate.clone();
         let running = self.running.clone();
         self.flush_handle = Some(tokio::spawn(async move {
             let mut ticker = interval(Duration::from_millis(BUFFER_FLUSH_INTERVAL_MS));
             while running.load(Ordering::SeqCst) {
                 ticker.tick().await;
-                if let Err(e) = InMemoryStorageSinkFunction::flush_buffers(
-                    &shared_client,
-                    &buffer,
-                    &keyed_buffer,
-                    &flush_gate,
-                )
-                .await
+                if let Err(e) =
+                    InMemoryStorageSinkFunction::flush_buffers(&shared_client, &buffer, &keyed_buffer)
+                        .await
                 {
                     eprintln!("[IN_MEMORY_SINK] flush error: {e}");
                 }
@@ -204,8 +196,7 @@ impl FunctionTrait for InMemoryStorageSinkFunction {
             let _ = handle.await;
         }
         if let Some(client) = &self.storage_client {
-            Self::flush_buffers(client, &self.buffer, &self.keyed_buffer, &self.flush_gate)
-                .await?;
+            Self::flush_buffers(client, &self.buffer, &self.keyed_buffer).await?;
         }
         Ok(())
     }

--- a/src/runtime/functions/sink/in_memory_storage_sink.rs
+++ b/src/runtime/functions/sink/in_memory_storage_sink.rs
@@ -22,6 +22,8 @@ pub struct InMemoryStorageSinkFunction {
     buffer: Arc<Mutex<Vec<Message>>>,
     keyed_buffer: Arc<Mutex<HashMap<String, Message>>>,
     flush_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Serializes drain+RPC so barrier flush waits for an in-flight ticker flush.
+    flush_gate: Arc<Mutex<()>>,
     running: Arc<AtomicBool>,
     runtime_context: Option<RuntimeContext>,
     server_addr: String,
@@ -36,6 +38,7 @@ impl InMemoryStorageSinkFunction {
             buffer: Arc::new(Mutex::new(Vec::new())),
             keyed_buffer: Arc::new(Mutex::new(HashMap::new())),
             flush_handle: None,
+            flush_gate: Arc::new(Mutex::new(())),
             running: Arc::new(AtomicBool::new(false)),
             runtime_context: None,
             server_addr,
@@ -114,7 +117,9 @@ impl InMemoryStorageSinkFunction {
         storage_client: &Arc<Mutex<InMemoryStorageClient>>,
         buffer: &Arc<Mutex<Vec<Message>>>,
         keyed_buffer: &Arc<Mutex<HashMap<String, Message>>>,
+        flush_gate: &Arc<Mutex<()>>,
     ) -> Result<()> {
+        let _gate = flush_gate.lock().await;
         let mut regular_batches = buffer.lock().await;
         if !regular_batches.is_empty() {
             let batches: Vec<Message> = regular_batches.drain(..).collect();
@@ -154,7 +159,7 @@ impl SinkFunctionTrait for InMemoryStorageSinkFunction {
         let Some(client) = &self.storage_client else {
             return Ok(());
         };
-        Self::flush_buffers(client, &self.buffer, &self.keyed_buffer).await
+        Self::flush_buffers(client, &self.buffer, &self.keyed_buffer, &self.flush_gate).await
     }
 }
 
@@ -171,14 +176,19 @@ impl FunctionTrait for InMemoryStorageSinkFunction {
 
         let buffer = self.buffer.clone();
         let keyed_buffer = self.keyed_buffer.clone();
+        let flush_gate = self.flush_gate.clone();
         let running = self.running.clone();
         self.flush_handle = Some(tokio::spawn(async move {
             let mut ticker = interval(Duration::from_millis(BUFFER_FLUSH_INTERVAL_MS));
             while running.load(Ordering::SeqCst) {
                 ticker.tick().await;
-                if let Err(e) =
-                    InMemoryStorageSinkFunction::flush_buffers(&shared_client, &buffer, &keyed_buffer)
-                        .await
+                if let Err(e) = InMemoryStorageSinkFunction::flush_buffers(
+                    &shared_client,
+                    &buffer,
+                    &keyed_buffer,
+                    &flush_gate,
+                )
+                .await
                 {
                     eprintln!("[IN_MEMORY_SINK] flush error: {e}");
                 }
@@ -194,7 +204,8 @@ impl FunctionTrait for InMemoryStorageSinkFunction {
             let _ = handle.await;
         }
         if let Some(client) = &self.storage_client {
-            Self::flush_buffers(client, &self.buffer, &self.keyed_buffer).await?;
+            Self::flush_buffers(client, &self.buffer, &self.keyed_buffer, &self.flush_gate)
+                .await?;
         }
         Ok(())
     }

--- a/src/runtime/stream_task/processor.rs
+++ b/src/runtime/stream_task/processor.rs
@@ -5,7 +5,9 @@ use futures::StreamExt;
 
 use crate::common::message::Message;
 use crate::runtime::consts::{runtime_consts, WINDOW_INGEST_MAX_RECORDS};
-use crate::runtime::operators::operator::{drain_ready_after, MessageStream, StreamOperator};
+use crate::runtime::operators::operator::{
+    drain_ready_after, MessageStream, OperatorType, StreamOperator,
+};
 use crate::transport::transport_client::DataReaderControl;
 
 use super::checkpoint::on_checkpoint_barrier;
@@ -65,6 +67,13 @@ pub(super) async fn processor_loop(
                             Ok(Some((checkpoint_id, inject_stamp, wms))) => {
                                 ctx.emit_watermarks(wms, false, Some(operator)).await?;
                                 let aligned = ctx.new_barrier(checkpoint_id, inject_stamp);
+                                // Sink is not checkpointable (no state ack). Aligned is its
+                                // only CP signal, so flush must finish before that report.
+                                // Otherwise kill-after-complete can drop the last buffered batch.
+                                if operator.operator_type() == OperatorType::Sink {
+                                    let mut out = ctx.output();
+                                    operator.handle_barrier(aligned.clone(), &mut out).await?;
+                                }
                                 on_checkpoint_barrier(
                                     operator,
                                     &mut ctx,
@@ -73,8 +82,10 @@ pub(super) async fn processor_loop(
                                     Some(&reader_control),
                                 )
                                 .await?;
-                                let mut out = ctx.output();
-                                operator.handle_barrier(aligned, &mut out).await?;
+                                if operator.operator_type() != OperatorType::Sink {
+                                    let mut out = ctx.output();
+                                    operator.handle_barrier(aligned, &mut out).await?;
+                                }
                             }
                             Err(error) => {
                                 panic!(

--- a/src/runtime/stream_task/processor.rs
+++ b/src/runtime/stream_task/processor.rs
@@ -5,9 +5,7 @@ use futures::StreamExt;
 
 use crate::common::message::Message;
 use crate::runtime::consts::{runtime_consts, WINDOW_INGEST_MAX_RECORDS};
-use crate::runtime::operators::operator::{
-    drain_ready_after, MessageStream, OperatorType, StreamOperator,
-};
+use crate::runtime::operators::operator::{drain_ready_after, MessageStream, StreamOperator};
 use crate::transport::transport_client::DataReaderControl;
 
 use super::checkpoint::on_checkpoint_barrier;
@@ -67,10 +65,9 @@ pub(super) async fn processor_loop(
                             Ok(Some((checkpoint_id, inject_stamp, wms))) => {
                                 ctx.emit_watermarks(wms, false, Some(operator)).await?;
                                 let aligned = ctx.new_barrier(checkpoint_id, inject_stamp);
-                                // Sink is not checkpointable (no state ack). Aligned is its
-                                // only CP signal, so flush must finish before that report.
-                                // Otherwise kill-after-complete can drop the last buffered batch.
-                                if operator.operator_type() == OperatorType::Sink {
+                                // handle_barrier first: sink flush must finish before Aligned
+                                // (sink has no state ack; kill-after-complete can drop a buffered batch).
+                                {
                                     let mut out = ctx.output();
                                     operator.handle_barrier(aligned.clone(), &mut out).await?;
                                 }
@@ -82,10 +79,6 @@ pub(super) async fn processor_loop(
                                     Some(&reader_control),
                                 )
                                 .await?;
-                                if operator.operator_type() != OperatorType::Sink {
-                                    let mut out = ctx.output();
-                                    operator.handle_barrier(aligned, &mut out).await?;
-                                }
                             }
                             Err(error) => {
                                 panic!(

--- a/src/runtime/stream_task/processor.rs
+++ b/src/runtime/stream_task/processor.rs
@@ -66,7 +66,6 @@ pub(super) async fn processor_loop(
                                 ctx.emit_watermarks(wms, false, Some(operator)).await?;
                                 let aligned = ctx.new_barrier(checkpoint_id, inject_stamp);
                                 // handle_barrier first: sink flush must finish before Aligned
-                                // (sink has no state ack; kill-after-complete can drop a buffered batch).
                                 {
                                     let mut out = ctx.output();
                                     operator.handle_barrier(aligned.clone(), &mut out).await?;

--- a/src/test_utils/checkpoint/kill_recovery.rs
+++ b/src/test_utils/checkpoint/kill_recovery.rs
@@ -240,6 +240,11 @@ pub async fn run_checkpoint_sequential_failures(
         )
         .await?;
 
+        // Running does not mean replay reached the sink. Finish immediately and the
+        // oracle sees CP-cut records_generated with a short upsert map (one batch).
+        let sink_rows = cluster.storage().snapshot().await?.row_count();
+        wait_for_sink_progress(&cluster, sink_rows, timeouts.attempt_running).await?;
+
         harness_finish_pipeline(&cluster, &mut cursor, env, failure_count).await?;
 
         let snapshot = cluster.storage().snapshot().await?;

--- a/src/test_utils/checkpoint/kill_recovery.rs
+++ b/src/test_utils/checkpoint/kill_recovery.rs
@@ -240,11 +240,6 @@ pub async fn run_checkpoint_sequential_failures(
         )
         .await?;
 
-        // Running does not mean replay reached the sink. Finish immediately and the
-        // oracle sees CP-cut records_generated with a short upsert map (one batch).
-        let sink_rows = cluster.storage().snapshot().await?.row_count();
-        wait_for_sink_progress(&cluster, sink_rows, timeouts.attempt_running).await?;
-
         harness_finish_pipeline(&cluster, &mut cursor, env, failure_count).await?;
 
         let snapshot = cluster.storage().snapshot().await?;


### PR DESCRIPTION
## Summary
- Master `default-tests` failed on `test_local_single_worker_checkpoint_complete_then_worker_kill_restores`: `missing=20 expected=200 actual=180`.
- Sink is not checkpointable, so **Aligned** is its only completion signal. That report ran **before** `handle_barrier` flush. Kill-after-complete dropped the last buffered batch; datagen `records_generated` was already past those rows, so restore did not replay them.
- Call `handle_barrier` (sink flush) before reporting Aligned. Take the storage client lock before draining buffers so a barrier flush waits out an in-flight ticker RPC.

## Test plan
- [x] `scripts/test inprocess --filter 'test(test_local_single_worker_checkpoint_complete_then_worker_kill_restores)'`
- [ ] CI `default-tests` / inproc-stress