### PR TITLE
fix: include the months component in RANGE window length

### DIFF
--- a/src/runtime/operators/window/frame_utils.rs
+++ b/src/runtime/operators/window/frame_utils.rs
@@ -1,6 +1,10 @@
 use datafusion::logical_expr::{WindowFrame, WindowFrameBound, WindowFrameUnits};
 
+use crate::runtime::operators::window::model::TimeGranularity;
+
 /// RANGE window length in milliseconds.
+/// Month components use the same fixed 30-day month as [`TimeGranularity::Months`],
+/// so a month-based frame stays an exact multiple of month tiles.
 pub fn get_window_length_ms(window_frame: &WindowFrame) -> i64 {
     assert_eq!(
         window_frame.units,
@@ -10,7 +14,9 @@ pub fn get_window_length_ms(window_frame: &WindowFrame) -> i64 {
     match &window_frame.start_bound {
         WindowFrameBound::Preceding(value) => match value {
             datafusion::scalar::ScalarValue::IntervalMonthDayNano(Some(v)) => {
-                (v.nanoseconds / 1_000_000) + (v.days as i64 * 24 * 60 * 60 * 1000)
+                (v.nanoseconds / 1_000_000)
+                    + (v.days as i64 * TimeGranularity::Days(1).to_millis())
+                    + (v.months as i64 * TimeGranularity::Months(1).to_millis())
             }
             datafusion::scalar::ScalarValue::UInt64(Some(v)) => *v as i64,
             datafusion::scalar::ScalarValue::Int64(Some(v)) => *v,
@@ -29,5 +35,82 @@ pub fn require_range_frame(window_frame: &WindowFrame) {
             "ROWS windows are not supported; use RANGE (got {:?})",
             window_frame.units
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::IntervalMonthDayNano;
+    use datafusion::scalar::ScalarValue;
+
+    const DAY_MS: i64 = 24 * 60 * 60 * 1000;
+
+    /// `INTERVAL '<n>' <unit>` planned as a PRECEDING RANGE bound.
+    fn interval_frame(months: i32, days: i32, nanoseconds: i64) -> WindowFrame {
+        WindowFrame::new_bounds(
+            WindowFrameUnits::Range,
+            WindowFrameBound::Preceding(ScalarValue::IntervalMonthDayNano(Some(
+                IntervalMonthDayNano::new(months, days, nanoseconds),
+            ))),
+            WindowFrameBound::CurrentRow,
+        )
+    }
+
+    #[test]
+    fn sub_day_intervals_use_nanoseconds() {
+        // INTERVAL '1000' MILLISECOND
+        assert_eq!(
+            get_window_length_ms(&interval_frame(0, 0, 1_000_000_000)),
+            1_000
+        );
+        // INTERVAL '5' MINUTE
+        assert_eq!(
+            get_window_length_ms(&interval_frame(0, 0, 300_000_000_000)),
+            300_000
+        );
+    }
+
+    #[test]
+    fn day_intervals_use_days() {
+        // INTERVAL '7' DAY
+        assert_eq!(get_window_length_ms(&interval_frame(0, 7, 0)), 7 * DAY_MS);
+    }
+
+    #[test]
+    fn month_intervals_use_months() {
+        // INTERVAL '1' MONTH
+        assert_eq!(get_window_length_ms(&interval_frame(1, 0, 0)), 30 * DAY_MS);
+        // INTERVAL '1' YEAR is planned as 12 months
+        assert_eq!(
+            get_window_length_ms(&interval_frame(12, 0, 0)),
+            12 * 30 * DAY_MS
+        );
+    }
+
+    #[test]
+    fn month_length_matches_month_tile_granularity() {
+        assert_eq!(
+            get_window_length_ms(&interval_frame(1, 0, 0)),
+            TimeGranularity::Months(1).to_millis()
+        );
+    }
+
+    #[test]
+    fn all_interval_components_are_summed() {
+        assert_eq!(
+            get_window_length_ms(&interval_frame(1, 2, 3_000_000)),
+            30 * DAY_MS + 2 * DAY_MS + 3
+        );
+    }
+
+    #[test]
+    fn integer_bounds_are_millis() {
+        let frame = WindowFrame::new_bounds(
+            WindowFrameUnits::Range,
+            WindowFrameBound::Preceding(ScalarValue::Int64(Some(5_000))),
+            WindowFrameBound::CurrentRow,
+        );
+        assert_eq!(get_window_length_ms(&frame), 5_000);
     }
 }

--- a/src/runtime/operators/window/frame_utils.rs
+++ b/src/runtime/operators/window/frame_utils.rs
@@ -3,8 +3,6 @@ use datafusion::logical_expr::{WindowFrame, WindowFrameBound, WindowFrameUnits};
 use crate::runtime::operators::window::model::TimeGranularity;
 
 /// RANGE window length in milliseconds.
-/// Month components use the same fixed 30-day month as [`TimeGranularity::Months`],
-/// so a month-based frame stays an exact multiple of month tiles.
 pub fn get_window_length_ms(window_frame: &WindowFrame) -> i64 {
     assert_eq!(
         window_frame.units,


### PR DESCRIPTION
## Problem

`get_window_length_ms` decodes an `IntervalMonthDayNano` RANGE bound by summing only `nanoseconds` and `days`, and never reads `months`:

```rust
ScalarValue::IntervalMonthDayNano(Some(v)) => {
    (v.nanoseconds / 1_000_000) + (v.days as i64 * 24 * 60 * 60 * 1000)
}
```

DataFusion normalizes `MONTH` and `YEAR` intervals into the `months` field with `days == 0` and `nanoseconds == 0`, so any month-based frame silently collapses to a **0 ms window**.

I confirmed this against the real planner path (`window_exec_from_sql` → `get_window_length_ms`):

| Frame bound | Planned interval | `window_length_ms` |
|---|---|---|
| `INTERVAL '1000' MILLISECOND` | `{months: 0, days: 0, nanos: 1e9}` | `1000` |
| `INTERVAL '5' MINUTE` | `{months: 0, days: 0, nanos: 3e11}` | `300000` |
| `INTERVAL '7' DAY` | `{months: 0, days: 7, nanos: 0}` | `604800000` |
| `INTERVAL '1' MONTH` | `{months: 1, days: 0, nanos: 0}` | **`0`** |
| `INTERVAL '3' MONTH` | `{months: 3, days: 0, nanos: 0}` | **`0`** |
| `INTERVAL '1' YEAR` | `{months: 12, days: 0, nanos: 0}` | **`0`** |

The window length feeds retention (`retention_cutoff`), tiling eligibility (`TileConfig::usable_for_window_length_ms`, which requires `window_length_ms > 0`) and coverage geometry in `eval/advance.rs` / `eval/wro.rs`, so a month window silently produces wrong aggregates rather than failing loudly. This matters for the long-window use case in the README (`30d`, `1y`).

Note that the existing `_ => panic!("Unsupported window frame bound type")` arm shows unsupported bounds are meant to fail loudly, so returning `0` here is wrong either way.

## Fix

Add the `months` component, reusing `TimeGranularity` rather than repeating magic numbers:

```rust
(v.nanoseconds / 1_000_000)
    + (v.days as i64 * TimeGranularity::Days(1).to_millis())
    + (v.months as i64 * TimeGranularity::Months(1).to_millis())
```

The 30-day month matches the existing convention already used for tiles in `TimeGranularity::Months` (`model.rs`):

```rust
TimeGranularity::Months(m) => *m as i64 * 30 * 24 * 60 * 60 * 1000,
```

That choice is deliberate rather than cosmetic: tile boundaries are a fixed-size grid (`(timestamp / duration_millis) * duration_millis`), so using the same 30-day month keeps a month-based frame an exact multiple of `Months(1)` tiles. A calendar-accurate month (~30.44 days) would leave the frame misaligned with the tile grid.

Happy to switch to rejecting month intervals outright instead if you'd rather not imply calendar support — just say which you prefer.
