### PR TITLE
InMemoryGrpc window store + request-mode correctness runner

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("proto/worker_service.proto")?;
     tonic_build::compile_protos("proto/in_memory_storage_service.proto")?;
+    tonic_build::compile_protos("proto/window_store_service.proto")?;
     tonic_build::compile_protos("proto/master_service.proto")?;
     Ok(())
 } 

--- a/proto/window_store_service.proto
+++ b/proto/window_store_service.proto
@@ -1,0 +1,104 @@
+syntax = "proto3";
+
+package window_store_service;
+
+service WindowStoreService {
+  rpc LoadKeyState(PartitionMsg) returns (BytesReply);
+  rpc LoadRaw(LoadRawReq) returns (BatchesReply);
+  rpc LoadTiles(LoadTilesReq) returns (BytesReply);
+  rpc CommitEvents(CommitEventsReq) returns (EmptyReply);
+  rpc StreamDuePage(StreamDuePageReq) returns (StreamDuePageReply);
+  rpc StoreKeyState(StoreKeyStateReq) returns (EmptyReply);
+  rpc Checkpoint(BindingMsg) returns (BytesReply);
+  rpc Restore(RestoreReq) returns (EmptyReply);
+  rpc LoadWindowData(LoadWindowDataReq) returns (WindowDataReply);
+  rpc Maintain(MaintainReq) returns (EmptyReply);
+}
+
+message BindingMsg {
+  bytes namespace = 1;
+  uint64 max_parallelism = 2;
+  uint64 range_start = 3;
+  uint64 range_end = 4;
+  bytes writer_id = 5;
+  bytes attempt = 6;
+}
+
+message PartitionMsg {
+  bytes namespace = 1;
+  bytes business_key = 2;
+}
+
+message LoadRawReq {
+  PartitionMsg partition = 1;
+  bytes raw_runs = 2;
+}
+
+message LoadTilesReq {
+  PartitionMsg partition = 1;
+  bytes tile_runs = 2;
+}
+
+message CommitEventsReq {
+  PartitionMsg partition = 1;
+  uint64 ts_column_index = 2;
+  bytes events = 3;
+  bytes tiles = 4;
+  bytes key_state = 5;
+  bytes triggers = 6;
+}
+
+message StreamDuePageReq {
+  BindingMsg binding = 1;
+  bytes after = 2;
+  int64 through_ts = 3;
+  uint64 through_seq = 4;
+  bytes resume_after = 5;
+}
+
+message StreamDuePageReply {
+  bytes work = 1;
+  bytes resume_after = 2;
+  bool done = 3;
+}
+
+message StoreKeyStateReq {
+  PartitionMsg partition = 1;
+  bytes key_state = 2;
+}
+
+message RestoreReq {
+  BindingMsg binding = 1;
+  bytes snapshot = 2;
+}
+
+message LoadWindowDataReq {
+  PartitionMsg partition = 1;
+  bytes raw_runs = 2;
+  bytes tile_runs = 3;
+}
+
+message WindowDataReply {
+  repeated bytes raw_batches = 1;
+  bytes tiles = 2;
+}
+
+message MaintainReq {
+  bytes namespace = 1;
+  uint64 range_start = 2;
+  uint64 range_end = 3;
+  uint64 max_parallelism = 4;
+  int64 watermark = 5;
+  int64 floor = 6;
+  string task_id = 7;
+}
+
+message BatchesReply {
+  repeated bytes batches = 1;
+}
+
+message BytesReply {
+  bytes payload = 1;
+}
+
+message EmptyReply {}

--- a/src/api/spec/pipeline.rs
+++ b/src/api/spec/pipeline.rs
@@ -287,8 +287,19 @@ impl PipelineSpec {
                 ));
             }
         }
-        if self.execution_mode == ExecutionMode::Request && self.state.request_store.is_none() {
-            return Err("request mode requires a request store".to_string());
+        if self.execution_mode == ExecutionMode::Request {
+            if self.state.request_store.is_none() {
+                return Err("request mode requires a request store".to_string());
+            }
+            if matches!(
+                self.state.operator_backend,
+                OperatorStateBackendConfig::InMemory
+            ) {
+                return Err(
+                    "request mode cannot use process-local InMemory operator state; use InMemoryGrpc or another shared backend"
+                        .to_string(),
+                );
+            }
         }
         if self.state.checkpoint.interval_ms.is_none() {
             return Err(

--- a/src/api/spec/state.rs
+++ b/src/api/spec/state.rs
@@ -15,11 +15,14 @@ pub enum CheckpointStoreConfig {
 pub enum OperatorStateBackendConfig {
     #[default]
     InMemory,
+    InMemoryGrpc { endpoint: String },
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum RequestStoreConfig {}
+pub enum RequestStoreConfig {
+    InMemoryGrpc { endpoint: String },
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(default)]

--- a/src/bin/volga-test-storage.rs
+++ b/src/bin/volga-test-storage.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use anyhow::Result;
-use volga::storage::InMemoryStorageServer;
+use volga::runtime::operators::window::store::InMemoryGrpcStateServer;
 
 async fn shutdown_signal() {
     #[cfg(unix)]
@@ -24,7 +24,7 @@ async fn shutdown_signal() {
 async fn main() -> Result<()> {
     let bind_addr =
         env::var("VOLGA_TEST_STORAGE_BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:50071".to_string());
-    let mut storage_server = InMemoryStorageServer::new();
+    let mut storage_server = InMemoryGrpcStateServer::new();
     storage_server.start(&bind_addr).await?;
     println!("[VOLGA_TEST_STORAGE] listening on {}", bind_addr);
     shutdown_signal().await;

--- a/src/common/grpc/mod.rs
+++ b/src/common/grpc/mod.rs
@@ -1,6 +1,7 @@
 pub mod master;
 pub mod storage;
 pub mod stubs;
+pub mod window_store;
 pub mod worker;
 
 use std::net::SocketAddr;
@@ -84,12 +85,14 @@ impl_client_limits! {
     stubs::master_service::master_service_client::MasterServiceClient<Channel>,
     stubs::worker_service::worker_service_client::WorkerServiceClient<Channel>,
     stubs::in_memory_storage_service::in_memory_storage_service_client::InMemoryStorageServiceClient<Channel>,
+    stubs::window_store_service::window_store_service_client::WindowStoreServiceClient<Channel>,
 }
 
 impl_server_limits! {
     stubs::master_service::master_service_server::MasterServiceServer<T>,
     stubs::worker_service::worker_service_server::WorkerServiceServer<T>,
     stubs::in_memory_storage_service::in_memory_storage_service_server::InMemoryStorageServiceServer<T>,
+    stubs::window_store_service::window_store_service_server::WindowStoreServiceServer<T>,
 }
 
 fn normalize_endpoint(addr: &str) -> String {

--- a/src/common/grpc/stubs.rs
+++ b/src/common/grpc/stubs.rs
@@ -11,3 +11,7 @@ pub mod worker_service {
 pub mod in_memory_storage_service {
     tonic::include_proto!("in_memory_storage_service");
 }
+
+pub mod window_store_service {
+    tonic::include_proto!("window_store_service");
+}

--- a/src/common/grpc/window_store.rs
+++ b/src/common/grpc/window_store.rs
@@ -1,0 +1,27 @@
+use std::time::Duration;
+
+use tonic::transport::Channel;
+
+use super::stubs::window_store_service::window_store_service_client::WindowStoreServiceClient;
+use super::stubs::window_store_service::window_store_service_server::{
+    WindowStoreService, WindowStoreServiceServer,
+};
+use super::{connect_with_retry, GrpcConfig, WithMessageLimits};
+
+pub fn window_store() -> GrpcConfig {
+    GrpcConfig::new().with_retries(5, Duration::from_secs(1))
+}
+
+pub fn window_store_server<S>(svc: S) -> WindowStoreServiceServer<S>
+where
+    S: WindowStoreService,
+{
+    WindowStoreServiceServer::new(svc).with_message_limits()
+}
+
+pub async fn window_store_client(
+    addr: &str,
+) -> Result<WindowStoreServiceClient<Channel>, tonic::transport::Error> {
+    let channel = connect_with_retry(addr, &window_store()).await?;
+    Ok(WindowStoreServiceClient::new(channel).with_message_limits())
+}

--- a/src/orchestrator/task_assignment.rs
+++ b/src/orchestrator/task_assignment.rs
@@ -1,9 +1,20 @@
 use crate::api::PipelineSpec;
 use crate::orchestrator::orchestrator::WorkerNode;
 use crate::runtime::execution_graph::ExecutionGraph;
+use crate::runtime::operators::operator::OperatorConfig;
+use crate::runtime::operators::sink::sink_operator::SinkConfig;
+use crate::runtime::operators::source::source_operator::SourceConfig;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+fn is_request_io_operator(config: &OperatorConfig) -> bool {
+    matches!(
+        config,
+        OperatorConfig::SourceConfig(SourceConfig::HttpRequestSourceConfig(_))
+            | OperatorConfig::SinkConfig(SinkConfig::RequestSinkConfig)
+    )
+}
 
 /// Mapping from execution vertex ID (task ID) to worker node
 pub type TaskWorkerMapping = HashMap<String, WorkerNode>;
@@ -128,6 +139,25 @@ impl TaskWorkerAssignStrategy for OperatorPerWorkerStrategy {
                 .entry(operator_id)
                 .or_insert_with(Vec::new)
                 .push(vertex_id.as_ref().to_string());
+        }
+
+        // HTTP request source and request sink share a process-local processor.
+        let mut request_io_vertices = Vec::new();
+        operator_to_vertices.retain(|_, vertex_ids| {
+            let request_io = vertex_ids.iter().any(|vid| {
+                execution_graph
+                    .get_vertex(vid)
+                    .is_some_and(|v| is_request_io_operator(&v.operator_config))
+            });
+            if request_io {
+                request_io_vertices.extend(vertex_ids.iter().cloned());
+                false
+            } else {
+                true
+            }
+        });
+        if !request_io_vertices.is_empty() {
+            operator_to_vertices.insert("__request_io__".to_string(), request_io_vertices);
         }
 
         // Check if we have enough nodes for all operators

--- a/src/runtime/functions/source/request_source.rs
+++ b/src/runtime/functions/source/request_source.rs
@@ -117,9 +117,17 @@ pub struct RequestSourceProcessor {
 }
 
 
-pub fn extract_request_source_config(graph: &ExecutionGraph) -> Option<RequestSourceConfig> {
-    for (_vertex_id, vertex) in graph.get_vertices() {
-        if let OperatorConfig::SourceConfig(SourceConfig::HttpRequestSourceConfig(config)) = &vertex.operator_config {
+pub fn extract_request_source_config(
+    graph: &ExecutionGraph,
+    vertex_ids: &[crate::runtime::VertexId],
+) -> Option<RequestSourceConfig> {
+    for vertex_id in vertex_ids {
+        let Some(vertex) = graph.get_vertex(vertex_id.as_ref()) else {
+            continue;
+        };
+        if let OperatorConfig::SourceConfig(SourceConfig::HttpRequestSourceConfig(config)) =
+            &vertex.operator_config
+        {
             return Some(config.clone());
         }
     }

--- a/src/runtime/operators/window/model.rs
+++ b/src/runtime/operators/window/model.rs
@@ -171,14 +171,14 @@ impl TimeGranularity {
 }
 
 /// Raw segment: half-open `[from, to)`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RawRun {
     pub from: Cursor,
     pub to: Cursor,
 }
 
 /// Coalesced tile range at one granularity: half-open `[start_ts, end_ts_exclusive)`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TileRun {
     pub granularity: TimeGranularity,
     pub start_ts: Timestamp,

--- a/src/runtime/operators/window/request.rs
+++ b/src/runtime/operators/window/request.rs
@@ -235,6 +235,8 @@ impl OperatorTrait for WindowRequestOperator {
 impl StreamOperator for WindowRequestOperator {
     async fn process_data(&mut self, data: Vec<Message>, out: &mut dyn Output) -> Result<()> {
         for message in data {
+            let extras = message.get_extras();
+            let ingest_timestamp = message.ingest_timestamp();
             let Message::Regular(base) = message else {
                 panic!("window request ingest expects data messages, got {message:?}");
             };
@@ -243,14 +245,15 @@ impl StreamOperator for WindowRequestOperator {
                 out.emit(Message::new(
                     None,
                     RecordBatch::new_empty(self.output_schema.clone()),
-                    None,
-                    None,
+                    ingest_timestamp,
+                    extras,
                 ))
                 .await?;
                 continue;
             }
             let batch = self.process_groups(groups).await;
-            out.emit(Message::new(None, batch, None, None)).await?;
+            out.emit(Message::new(None, batch, ingest_timestamp, extras))
+                .await?;
         }
         Ok(())
     }

--- a/src/runtime/operators/window/store/backend/codec.rs
+++ b/src/runtime/operators/window/store/backend/codec.rs
@@ -1,0 +1,38 @@
+use anyhow::{anyhow, Result};
+use arrow::array::RecordBatch;
+use arrow::ipc::reader::FileReader;
+use arrow::ipc::writer::FileWriter;
+use std::io::Cursor;
+
+pub fn encode_batch(batch: &RecordBatch) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    {
+        let mut writer = FileWriter::try_new(&mut bytes, batch.schema().as_ref())?;
+        writer.write(batch)?;
+        writer.finish()?;
+    }
+    Ok(bytes)
+}
+
+pub fn decode_batch(bytes: &[u8]) -> Result<RecordBatch> {
+    FileReader::try_new(Cursor::new(bytes), None)?
+        .next()
+        .transpose()?
+        .ok_or_else(|| anyhow!("empty Arrow IPC payload"))
+}
+
+pub fn encode_batches(batches: &[RecordBatch]) -> Result<Vec<Vec<u8>>> {
+    batches.iter().map(encode_batch).collect()
+}
+
+pub fn decode_batches(bytes: &[Vec<u8>]) -> Result<Vec<RecordBatch>> {
+    bytes.iter().map(|b| decode_batch(b)).collect()
+}
+
+pub fn encode_val<T: serde::Serialize>(value: &T) -> Result<Vec<u8>> {
+    Ok(bincode::serialize(value)?)
+}
+
+pub fn decode_val<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T> {
+    Ok(bincode::deserialize(bytes)?)
+}

--- a/src/runtime/operators/window/store/backend/grpc.rs
+++ b/src/runtime/operators/window/store/backend/grpc.rs
@@ -1,0 +1,579 @@
+//! gRPC remote handle over a process-local [`super::InMemWindowStore`].
+
+use std::any::Any;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use arrow::array::RecordBatch;
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use tonic::{Request, Response, Status};
+
+use crate::common::grpc::stubs::window_store_service::window_store_service_server::WindowStoreService;
+use crate::common::grpc::stubs::window_store_service::{
+    BatchesReply, BindingMsg, BytesReply, CommitEventsReq, EmptyReply, LoadRawReq, LoadTilesReq,
+    LoadWindowDataReq, MaintainReq, PartitionMsg, RestoreReq, StoreKeyStateReq, StreamDuePageReq,
+    StreamDuePageReply, WindowDataReply,
+};
+use crate::common::grpc::window_store::{window_store_client, window_store_server};
+use crate::common::grpc::{server_builder, spawn_with_shutdown, GrpcServeHandle};
+use crate::common::KeyGroupRange;
+use crate::runtime::operators::window::model::{
+    Cursor, KeyState, PartitionKey, RawRun, StateNamespace, TileMap, TileRun, WindowTrigger,
+};
+use crate::runtime::operators::window::state::WindowOperatorState;
+use crate::runtime::state::{OperatorStore, OperatorTaskState};
+use crate::storage::in_memory_storage_grpc_server::InMemoryStorageServiceImpl;
+use crate::common::grpc::storage::storage_server;
+
+use super::codec::{decode_batch, decode_batches, decode_val, encode_batch, encode_batches, encode_val};
+use super::{
+    DueWindowWork, DueWorkStream, InMemWindowStore, WindowBackendSnapshot, WindowOperatorStore,
+    WindowRequestStore, WindowStoreBinding, WriterId,
+};
+
+use crate::runtime::operators::window::store::data::WindowData;
+
+fn status(err: anyhow::Error) -> Status {
+    Status::internal(err.to_string())
+}
+
+fn partition_from_msg(msg: &PartitionMsg) -> PartitionKey {
+    PartitionKey {
+        namespace: msg.namespace.clone(),
+        business_key: msg.business_key.clone(),
+    }
+}
+
+fn partition_to_msg(partition: &PartitionKey) -> PartitionMsg {
+    PartitionMsg {
+        namespace: partition.namespace.clone(),
+        business_key: partition.business_key.clone(),
+    }
+}
+
+fn binding_from_msg(msg: &BindingMsg) -> WindowStoreBinding {
+    WindowStoreBinding {
+        namespace: StateNamespace::new(&msg.namespace),
+        max_parallelism: msg.max_parallelism as usize,
+        owned: KeyGroupRange::new(msg.range_start as usize, msg.range_end as usize),
+        writer_id: WriterId(msg.writer_id.clone()),
+        attempt: msg.attempt.clone(),
+    }
+}
+
+fn binding_to_msg(binding: &WindowStoreBinding) -> BindingMsg {
+    BindingMsg {
+        namespace: binding.namespace.bytes.clone(),
+        max_parallelism: binding.max_parallelism as u64,
+        range_start: binding.owned.start as u64,
+        range_end: binding.owned.end as u64,
+        writer_id: binding.writer_id.0.clone(),
+        attempt: binding.attempt.clone(),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WindowStoreServiceImpl {
+    store: InMemWindowStore,
+}
+
+impl WindowStoreServiceImpl {
+    pub fn new() -> Self {
+        Self {
+            store: InMemWindowStore::new(),
+        }
+    }
+}
+
+impl Default for WindowStoreServiceImpl {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[tonic::async_trait]
+impl WindowStoreService for WindowStoreServiceImpl {
+    async fn load_key_state(
+        &self,
+        request: Request<PartitionMsg>,
+    ) -> Result<Response<BytesReply>, Status> {
+        let partition = partition_from_msg(&request.into_inner());
+        let state = self
+            .store
+            .load_key_state(&partition)
+            .await
+            .map_err(status)?;
+        Ok(Response::new(BytesReply {
+            payload: encode_val(&state).map_err(status)?,
+        }))
+    }
+
+    async fn load_raw(
+        &self,
+        request: Request<LoadRawReq>,
+    ) -> Result<Response<BatchesReply>, Status> {
+        let req = request.into_inner();
+        let partition = partition_from_msg(req.partition.as_ref().ok_or_else(|| {
+            Status::invalid_argument("load_raw missing partition")
+        })?);
+        let runs: Vec<RawRun> = decode_val(&req.raw_runs).map_err(status)?;
+        let batches = self
+            .store
+            .load_raw(&partition, &runs)
+            .await
+            .map_err(status)?;
+        Ok(Response::new(BatchesReply {
+            batches: encode_batches(&batches).map_err(status)?,
+        }))
+    }
+
+    async fn load_tiles(
+        &self,
+        request: Request<LoadTilesReq>,
+    ) -> Result<Response<BytesReply>, Status> {
+        let req = request.into_inner();
+        let partition = partition_from_msg(req.partition.as_ref().ok_or_else(|| {
+            Status::invalid_argument("load_tiles missing partition")
+        })?);
+        let runs: Vec<TileRun> = decode_val(&req.tile_runs).map_err(status)?;
+        let tiles = self
+            .store
+            .load_tiles(&partition, &runs)
+            .await
+            .map_err(status)?;
+        Ok(Response::new(BytesReply {
+            payload: encode_val(&tiles).map_err(status)?,
+        }))
+    }
+
+    async fn commit_events(
+        &self,
+        request: Request<CommitEventsReq>,
+    ) -> Result<Response<EmptyReply>, Status> {
+        let req = request.into_inner();
+        let partition = partition_from_msg(req.partition.as_ref().ok_or_else(|| {
+            Status::invalid_argument("commit_events missing partition")
+        })?);
+        let events = decode_batch(&req.events).map_err(status)?;
+        let tiles: TileMap = decode_val(&req.tiles).map_err(status)?;
+        let key_state: KeyState = decode_val(&req.key_state).map_err(status)?;
+        let triggers: Vec<WindowTrigger> = decode_val(&req.triggers).map_err(status)?;
+        self.store
+            .commit_events(
+                &partition,
+                req.ts_column_index as usize,
+                &events,
+                &tiles,
+                &key_state,
+                &triggers,
+            )
+            .await
+            .map_err(status)?;
+        Ok(Response::new(EmptyReply {}))
+    }
+
+    async fn stream_due_page(
+        &self,
+        request: Request<StreamDuePageReq>,
+    ) -> Result<Response<StreamDuePageReply>, Status> {
+        let req = request.into_inner();
+        let binding = binding_from_msg(req.binding.as_ref().ok_or_else(|| {
+            Status::invalid_argument("stream_due missing binding")
+        })?);
+        let after = if req.after.is_empty() {
+            None
+        } else {
+            Some(decode_val::<Cursor>(&req.after).map_err(status)?)
+        };
+        let through = Cursor::new(req.through_ts, req.through_seq);
+        let resume_after = if req.resume_after.is_empty() {
+            None
+        } else {
+            Some(decode_val::<WindowTrigger>(&req.resume_after).map_err(status)?)
+        };
+        let client = self.store.bind_assignment(binding);
+        let mut stream = client.stream_due(after, through);
+        // Skip pages until we pass resume_after (client owns paging; one page per RPC).
+        use futures::TryStreamExt;
+        let mut skipped = resume_after.is_some();
+        while let Some(work) = stream.try_next().await.map_err(|e| status(e))? {
+            let last = work
+                .iter()
+                .flat_map(|w| w.triggers.iter())
+                .max()
+                .cloned();
+            if skipped {
+                if let (Some(resume), Some(last)) = (resume_after.as_ref(), last.as_ref()) {
+                    if last <= resume {
+                        continue;
+                    }
+                }
+                skipped = false;
+            }
+            return Ok(Response::new(StreamDuePageReply {
+                work: encode_val(&work).map_err(status)?,
+                resume_after: last
+                    .as_ref()
+                    .map(encode_val)
+                    .transpose()
+                    .map_err(status)?
+                    .unwrap_or_default(),
+                done: false,
+            }));
+        }
+        Ok(Response::new(StreamDuePageReply {
+            work: Vec::new(),
+            resume_after: Vec::new(),
+            done: true,
+        }))
+    }
+
+    async fn store_key_state(
+        &self,
+        request: Request<StoreKeyStateReq>,
+    ) -> Result<Response<EmptyReply>, Status> {
+        let req = request.into_inner();
+        let partition = partition_from_msg(req.partition.as_ref().ok_or_else(|| {
+            Status::invalid_argument("store_key_state missing partition")
+        })?);
+        let state: KeyState = decode_val(&req.key_state).map_err(status)?;
+        self.store
+            .store_key_state(&partition, &state)
+            .await
+            .map_err(status)?;
+        Ok(Response::new(EmptyReply {}))
+    }
+
+    async fn checkpoint(
+        &self,
+        request: Request<BindingMsg>,
+    ) -> Result<Response<BytesReply>, Status> {
+        let binding = binding_from_msg(&request.into_inner());
+        let snapshot = self
+            .store
+            .bind_assignment(binding)
+            .checkpoint()
+            .await
+            .map_err(status)?;
+        Ok(Response::new(BytesReply {
+            payload: encode_val(&snapshot).map_err(status)?,
+        }))
+    }
+
+    async fn restore(&self, request: Request<RestoreReq>) -> Result<Response<EmptyReply>, Status> {
+        let req = request.into_inner();
+        let binding = binding_from_msg(req.binding.as_ref().ok_or_else(|| {
+            Status::invalid_argument("restore missing binding")
+        })?);
+        let snapshot: WindowBackendSnapshot = decode_val(&req.snapshot).map_err(status)?;
+        self.store
+            .bind_assignment(binding)
+            .restore(&snapshot)
+            .await
+            .map_err(status)?;
+        Ok(Response::new(EmptyReply {}))
+    }
+
+    async fn load_window_data(
+        &self,
+        request: Request<LoadWindowDataReq>,
+    ) -> Result<Response<WindowDataReply>, Status> {
+        let req = request.into_inner();
+        let partition = partition_from_msg(req.partition.as_ref().ok_or_else(|| {
+            Status::invalid_argument("load_window_data missing partition")
+        })?);
+        let raw_runs: Vec<RawRun> = decode_val(&req.raw_runs).map_err(status)?;
+        let tile_runs: Vec<TileRun> = decode_val(&req.tile_runs).map_err(status)?;
+        let data = WindowRequestStore::load_window_data(&self.store, &partition, &raw_runs, &tile_runs)
+            .await
+            .map_err(status)?;
+        Ok(Response::new(WindowDataReply {
+            raw_batches: encode_batches(data.raw_batches()).map_err(status)?,
+            tiles: encode_val(data.tile_map()).map_err(status)?,
+        }))
+    }
+
+    async fn maintain(&self, request: Request<MaintainReq>) -> Result<Response<EmptyReply>, Status> {
+        let req = request.into_inner();
+        let ns = StateNamespace::new(&req.namespace);
+        self.store
+            .maintain_cutoff(
+                &ns,
+                KeyGroupRange::new(req.range_start as usize, req.range_end as usize),
+                req.max_parallelism as usize,
+                req.watermark,
+                req.floor,
+                &req.task_id,
+            )
+            .map_err(status)?;
+        Ok(Response::new(EmptyReply {}))
+    }
+}
+
+/// Combined sink + window-store gRPC server for cluster tests.
+pub struct InMemoryGrpcStateServer {
+    serve: Option<GrpcServeHandle>,
+}
+
+impl InMemoryGrpcStateServer {
+    pub fn new() -> Self {
+        Self { serve: None }
+    }
+
+    pub async fn start(&mut self, addr: &str) -> Result<()> {
+        let addr = addr.parse()?;
+        let sink = storage_server(InMemoryStorageServiceImpl::new());
+        let window = window_store_server(WindowStoreServiceImpl::new());
+        self.serve = Some(spawn_with_shutdown(
+            addr,
+            server_builder().add_service(sink).add_service(window),
+        ));
+        Ok(())
+    }
+
+    pub async fn stop(&mut self) {
+        if let Some(mut serve) = self.serve.take() {
+            serve.stop().await;
+        }
+    }
+}
+
+impl Drop for InMemoryGrpcStateServer {
+    fn drop(&mut self) {
+        if let Some(mut serve) = self.serve.take() {
+            serve.abort();
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GrpcWindowStore {
+    endpoint: String,
+    client: Arc<Mutex<Option<crate::common::grpc::stubs::window_store_service::window_store_service_client::WindowStoreServiceClient<tonic::transport::Channel>>>>,
+    binding: Option<WindowStoreBinding>,
+}
+
+impl GrpcWindowStore {
+    pub fn connect(endpoint: impl Into<String>) -> Self {
+        Self {
+            endpoint: endpoint.into(),
+            client: Arc::new(Mutex::new(None)),
+            binding: None,
+        }
+    }
+
+    pub fn bind_assignment(&self, binding: WindowStoreBinding) -> Self {
+        Self {
+            endpoint: self.endpoint.clone(),
+            client: self.client.clone(),
+            binding: Some(binding),
+        }
+    }
+
+    fn binding(&self) -> Result<&WindowStoreBinding> {
+        self.binding
+            .as_ref()
+            .ok_or_else(|| anyhow!("gRPC window store client is not bound"))
+    }
+
+    async fn client(
+        &self,
+    ) -> Result<
+        crate::common::grpc::stubs::window_store_service::window_store_service_client::WindowStoreServiceClient<
+            tonic::transport::Channel,
+        >,
+    > {
+        let mut guard = self.client.lock().await;
+        if guard.is_none() {
+            *guard = Some(window_store_client(&self.endpoint).await?);
+        }
+        Ok(guard.as_ref().expect("client").clone())
+    }
+}
+
+#[async_trait]
+impl WindowOperatorStore for GrpcWindowStore {
+    async fn load_key_state(&self, partition: &PartitionKey) -> Result<KeyState> {
+        let mut client = self.client().await?;
+        let reply = client
+            .load_key_state(partition_to_msg(partition))
+            .await?
+            .into_inner();
+        decode_val(&reply.payload)
+    }
+
+    async fn load_raw(
+        &self,
+        partition: &PartitionKey,
+        runs: &[RawRun],
+    ) -> Result<Vec<RecordBatch>> {
+        let mut client = self.client().await?;
+        let reply = client
+            .load_raw(LoadRawReq {
+                partition: Some(partition_to_msg(partition)),
+                raw_runs: encode_val(&runs.to_vec())?,
+            })
+            .await?
+            .into_inner();
+        decode_batches(&reply.batches)
+    }
+
+    async fn load_tiles(&self, partition: &PartitionKey, runs: &[TileRun]) -> Result<TileMap> {
+        let mut client = self.client().await?;
+        let reply = client
+            .load_tiles(LoadTilesReq {
+                partition: Some(partition_to_msg(partition)),
+                tile_runs: encode_val(&runs.to_vec())?,
+            })
+            .await?
+            .into_inner();
+        decode_val(&reply.payload)
+    }
+
+    async fn commit_events(
+        &self,
+        partition: &PartitionKey,
+        ts_column_index: usize,
+        events: &RecordBatch,
+        tiles: &TileMap,
+        meta: &KeyState,
+        triggers: &[WindowTrigger],
+    ) -> Result<()> {
+        let mut client = self.client().await?;
+        client
+            .commit_events(CommitEventsReq {
+                partition: Some(partition_to_msg(partition)),
+                ts_column_index: ts_column_index as u64,
+                events: encode_batch(events)?,
+                tiles: encode_val(tiles)?,
+                key_state: encode_val(meta)?,
+                triggers: encode_val(&triggers.to_vec())?,
+            })
+            .await?;
+        Ok(())
+    }
+
+    fn stream_due<'a>(&'a self, after: Option<Cursor>, through: Cursor) -> DueWorkStream<'a> {
+        let store = self.clone();
+        Box::pin(futures::stream::try_unfold(
+            (store, after, None::<Vec<u8>>),
+            move |(store, after, resume)| {
+                async move {
+                    let binding = store.binding()?.clone();
+                    let mut client = store.client().await?;
+                    let reply = client
+                        .stream_due_page(StreamDuePageReq {
+                            binding: Some(binding_to_msg(&binding)),
+                            after: after
+                                .map(|c| encode_val(&c))
+                                .transpose()?
+                                .unwrap_or_default(),
+                            through_ts: through.ts,
+                            through_seq: through.seq_no,
+                            resume_after: resume.unwrap_or_default(),
+                        })
+                        .await?
+                        .into_inner();
+                    if reply.done {
+                        return Ok(None);
+                    }
+                    let work: Vec<DueWindowWork> = decode_val(&reply.work)?;
+                    Ok(Some((
+                        work,
+                        (store, after, Some(reply.resume_after)),
+                    )))
+                }
+            },
+        ))
+    }
+
+    async fn store_key_state(&self, partition: &PartitionKey, state: &KeyState) -> Result<()> {
+        let mut client = self.client().await?;
+        client
+            .store_key_state(StoreKeyStateReq {
+                partition: Some(partition_to_msg(partition)),
+                key_state: encode_val(state)?,
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn checkpoint(&self) -> Result<WindowBackendSnapshot> {
+        let mut client = self.client().await?;
+        let reply = client
+            .checkpoint(binding_to_msg(self.binding()?))
+            .await?
+            .into_inner();
+        decode_val(&reply.payload)
+    }
+
+    async fn restore(&self, snapshot: &WindowBackendSnapshot) -> Result<()> {
+        let mut client = self.client().await?;
+        client
+            .restore(RestoreReq {
+                binding: Some(binding_to_msg(self.binding()?)),
+                snapshot: encode_val(snapshot)?,
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl WindowRequestStore for GrpcWindowStore {
+    async fn load_window_data(
+        &self,
+        partition: &PartitionKey,
+        raw_runs: &[RawRun],
+        tile_runs: &[TileRun],
+    ) -> Result<WindowData> {
+        let mut client = self.client().await?;
+        let reply = client
+            .load_window_data(LoadWindowDataReq {
+                partition: Some(partition_to_msg(partition)),
+                raw_runs: encode_val(&raw_runs.to_vec())?,
+                tile_runs: encode_val(&tile_runs.to_vec())?,
+            })
+            .await?
+            .into_inner();
+        Ok(WindowData::new(
+            decode_batches(&reply.raw_batches)?,
+            decode_val(&reply.tiles)?,
+        ))
+    }
+}
+
+#[async_trait]
+impl OperatorStore for GrpcWindowStore {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    async fn maintain(&self, ns: &StateNamespace, state: &dyn OperatorTaskState) -> Result<()> {
+        let Some(wo) = state.as_any().downcast_ref::<WindowOperatorState>() else {
+            return Ok(());
+        };
+        let Some((watermark, floor)) = wo.retention_cutoff() else {
+            return Ok(());
+        };
+        let owned = state.key_group_range();
+        let mut client = self.client().await?;
+        client
+            .maintain(MaintainReq {
+                namespace: ns.bytes.clone(),
+                range_start: owned.start as u64,
+                range_end: owned.end as u64,
+                max_parallelism: state.max_parallelism() as u64,
+                watermark,
+                floor,
+                task_id: state.task_id().to_string(),
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+/// Stream due on the server by consuming the full client stream is inefficient.
+/// The page RPC above re-walks from the start each time; acceptable for InMemoryGrpc tests.
+const _: () = ();

--- a/src/runtime/operators/window/store/backend/mod.rs
+++ b/src/runtime/operators/window/store/backend/mod.rs
@@ -16,8 +16,11 @@ use crate::runtime::state::{OperatorStore, StateRegistry};
 
 use super::WindowData;
 
+mod codec;
+mod grpc;
 mod inmem;
 
+pub use grpc::{GrpcWindowStore, InMemoryGrpcStateServer, WindowStoreServiceImpl};
 pub use inmem::{InMemWindowStore, InMemWindowStoreClient};
 
 /// Job-level execution attempt stamped on published versions.
@@ -69,13 +72,29 @@ pub fn open_window_operator_store(
                 .clone();
             Ok(Arc::new(inmem.bind_assignment(binding.clone())) as Arc<dyn WindowOperatorStore>)
         }
+        OperatorStateBackendConfig::InMemoryGrpc { endpoint } => {
+            let endpoint = endpoint.clone();
+            let store = registry.get_or_insert_store(OperatorKind::Window, move |_session| {
+                Arc::new(GrpcWindowStore::connect(endpoint.clone())) as Arc<dyn OperatorStore>
+            });
+            let grpc = store
+                .as_any()
+                .downcast_ref::<GrpcWindowStore>()
+                .expect("window InMemoryGrpc store type")
+                .clone();
+            Ok(Arc::new(grpc.bind_assignment(binding.clone())) as Arc<dyn WindowOperatorStore>)
+        }
     }
 }
 
 pub async fn open_window_request_store(
     config: &RequestStoreConfig,
 ) -> Result<Arc<dyn WindowRequestStore>> {
-    match *config {}
+    match config {
+        RequestStoreConfig::InMemoryGrpc { endpoint } => {
+            Ok(Arc::new(GrpcWindowStore::connect(endpoint)) as Arc<dyn WindowRequestStore>)
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -91,7 +110,7 @@ pub enum WindowBackendSnapshot {
     Versioned { version: StateVersion },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DueWindowWork {
     pub partition: PartitionKey,
     pub key_state: KeyState,

--- a/src/runtime/operators/window/store/data.rs
+++ b/src/runtime/operators/window/store/data.rs
@@ -158,6 +158,10 @@ impl WindowData {
         &self.raw_batches
     }
 
+    pub fn tile_map(&self) -> &TileMap {
+        &self.tile_map
+    }
+
     pub fn for_window(
         &self,
         window_id: WindowId,

--- a/src/runtime/operators/window/store/mod.rs
+++ b/src/runtime/operators/window/store/mod.rs
@@ -7,7 +7,8 @@ pub use crate::runtime::operators::window::model::{
 };
 pub use backend::{
     open_window_operator_store, open_window_request_store, AttemptToken, DueWindowWork,
-    DueWorkStream, InMemWindowStore, InMemWindowStoreClient, StateVersion, WindowBackendSnapshot,
-    WindowOperatorStore, WindowRequestStore, WindowStoreBinding, WriterId,
+    DueWorkStream, GrpcWindowStore, InMemWindowStore, InMemWindowStoreClient,
+    InMemoryGrpcStateServer, StateVersion, WindowBackendSnapshot, WindowOperatorStore,
+    WindowRequestStore, WindowStoreBinding, WriterId,
 };
 pub use data::{WindowData, WindowView};

--- a/src/runtime/state/session.rs
+++ b/src/runtime/state/session.rs
@@ -17,7 +17,9 @@ impl StateSessionHandle {
     /// In-memory backends do not need a session (`Ok(None)`).
     pub fn connect(backend: &OperatorStateBackendConfig) -> Result<Option<Self>> {
         match backend {
-            OperatorStateBackendConfig::InMemory => Ok(None),
+            OperatorStateBackendConfig::InMemory | OperatorStateBackendConfig::InMemoryGrpc { .. } => {
+                Ok(None)
+            }
         }
     }
 }

--- a/src/runtime/worker/inner.rs
+++ b/src/runtime/worker/inner.rs
@@ -54,7 +54,8 @@ impl WorkerInner {
             task_runtimes.insert(vertex_id.clone(), task_runtime);
         }
 
-        let request_source_config = extract_request_source_config(&config.graph);
+        let request_source_config =
+            extract_request_source_config(&config.graph, &config.vertex_ids);
         let request_source_processor_runtime = if request_source_config.is_some() {
             Some(
                 Builder::new_multi_thread()

--- a/src/runtime/worker/tasks.rs
+++ b/src/runtime/worker/tasks.rs
@@ -423,8 +423,9 @@ impl WorkerInner {
     pub(crate) async fn start_request_source_processor_if_needed(&mut self) {
         let config = self.config.clone();
         if let Some(request_runtime) = &self.request_source_processor_runtime {
-            let request_source_config = extract_request_source_config(&config.graph)
-                .expect("request_source_config should be set");
+            let request_source_config =
+                extract_request_source_config(&config.graph, &config.vertex_ids)
+                    .expect("request_source_config should be set");
             println!("[WORKER] Starting request source processor");
 
             let mut processor = RequestSourceProcessor::new(request_source_config);

--- a/src/test_utils/harness/mod.rs
+++ b/src/test_utils/harness/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use local::LocalCluster;
 
 use crate::api::spec::connectors::SinkSpec;
 use crate::api::spec::state::{OperatorStateBackendConfig, RequestStoreConfig};
-use crate::api::PipelineSpec;
+use crate::api::{ExecutionMode, PipelineSpec};
 use crate::runtime::consts::RuntimeConstsProfile;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -138,7 +138,11 @@ impl PipelineLaunchSpec {
 
 /// Install/replace the in-memory gRPC sink address, preserving any upsert keys already on the pipeline.
 /// Non-InMemory sinks (Count, Parquet, Request) are left unchanged.
+/// Request mode must not get a streaming sink — the planner attaches the request sink later.
 pub(crate) fn install_in_memory_sink(pipeline: &mut PipelineSpec, server_addr: impl Into<String>) {
+    if pipeline.execution_mode == ExecutionMode::Request {
+        return;
+    }
     let server_addr = server_addr.into();
     pipeline.sink = Some(match pipeline.sink.take() {
         Some(sink @ SinkSpec::InMemoryStorageGrpc { .. }) => sink.with_server_addr(server_addr),

--- a/src/test_utils/harness/mod.rs
+++ b/src/test_utils/harness/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use kube::KubeCluster;
 pub(crate) use local::LocalCluster;
 
 use crate::api::spec::connectors::SinkSpec;
+use crate::api::spec::state::{OperatorStateBackendConfig, RequestStoreConfig};
 use crate::api::PipelineSpec;
 use crate::runtime::consts::RuntimeConstsProfile;
 
@@ -152,4 +153,29 @@ pub(crate) fn pipeline_needs_in_memory_store(pipeline: &PipelineSpec) -> bool {
         .as_ref()
         .map(SinkSpec::needs_in_memory_store)
         .unwrap_or(true)
+        || pipeline_needs_inmem_grpc_state(pipeline)
+}
+
+pub(crate) fn pipeline_needs_inmem_grpc_state(pipeline: &PipelineSpec) -> bool {
+    matches!(
+        pipeline.state.operator_backend,
+        OperatorStateBackendConfig::InMemoryGrpc { .. }
+    ) || matches!(
+        pipeline.state.request_store,
+        Some(RequestStoreConfig::InMemoryGrpc { .. })
+    )
+}
+
+pub(crate) fn install_in_memory_grpc_state(pipeline: &mut PipelineSpec, endpoint: impl Into<String>) {
+    let endpoint = endpoint.into();
+    if let OperatorStateBackendConfig::InMemoryGrpc { endpoint: dest } =
+        &mut pipeline.state.operator_backend
+    {
+        *dest = endpoint.clone();
+    }
+    if let Some(RequestStoreConfig::InMemoryGrpc { endpoint: dest }) =
+        &mut pipeline.state.request_store
+    {
+        *dest = endpoint;
+    }
 }

--- a/src/test_utils/harness/resources/docker.rs
+++ b/src/test_utils/harness/resources/docker.rs
@@ -210,6 +210,7 @@ impl DockerClusterResources {
         let mut spec = launch.pipeline;
         if super::pipeline_needs_in_memory_store(&spec) {
             super::install_in_memory_sink(&mut spec, "http://storage:50071");
+            super::install_in_memory_grpc_state(&mut spec, "http://storage:50071");
         }
         Ok(Self {
             resources: Some(DockerResources::start(

--- a/src/test_utils/harness/resources/kube.rs
+++ b/src/test_utils/harness/resources/kube.rs
@@ -315,6 +315,14 @@ fn write_pipeline_manifest(
                 "upsert_key_columns": upsert_key_columns,
             }
         });
+        if let Some(backend) = pipeline_json.get_mut("state").and_then(|s| s.get_mut("operator_backend")) {
+            if backend.get("in_memory_grpc").is_some() || backend.get("InMemoryGrpc").is_some() {
+                *backend = serde_json::json!({ "in_memory_grpc": { "endpoint": server_addr } });
+            }
+        }
+        if let Some(store) = pipeline_json.get_mut("state").and_then(|s| s.get_mut("request_store")) {
+            *store = serde_json::json!({ "in_memory_grpc": { "endpoint": server_addr } });
+        }
     }
     manifest["spec"]["pipelineSpec"] = pipeline_json;
     manifest["spec"]["workers"]["replicas"] = Value::Number(worker_count.into());

--- a/src/test_utils/harness/resources/local/common.rs
+++ b/src/test_utils/harness/resources/local/common.rs
@@ -13,7 +13,8 @@ use crate::orchestrator::orchestrator::{MasterOrchestrator, WorkerOrchestrator};
 use crate::runtime::master::server::MasterServer;
 use crate::test_utils::harness::WorkerKillMode;
 use crate::runtime::worker_server::WorkerServer;
-use crate::storage::{InMemoryStorageClient, InMemoryStorageServer, InMemoryStorageSnapshot};
+use crate::runtime::operators::window::store::InMemoryGrpcStateServer;
+use crate::storage::{InMemoryStorageClient, InMemoryStorageSnapshot};
 
 const WORKER_TASK_STOP_TIMEOUT: Duration = Duration::from_secs(10);
 const WORKER_CRASH_TIMEOUT: Duration = Duration::from_secs(5);
@@ -22,13 +23,13 @@ const WORKER_RUNTIME_THREADS: usize = 2;
 
 pub(super) struct LocalStorage {
     pub(super) addr: String,
-    server: InMemoryStorageServer,
+    server: InMemoryGrpcStateServer,
 }
 
 impl LocalStorage {
     pub(super) async fn start() -> Result<Self> {
         let addr = format!("127.0.0.1:{}", gen_unique_grpc_port());
-        let mut server = InMemoryStorageServer::new();
+        let mut server = InMemoryGrpcStateServer::new();
         server.start(&addr).await?;
         wait_until_addr_listening(&addr, ADDR_WAIT_TIMEOUT)
             .await

--- a/src/test_utils/harness/resources/local/smoke.rs
+++ b/src/test_utils/harness/resources/local/smoke.rs
@@ -135,6 +135,7 @@ impl LocalClusterResources {
         let storage = if super::super::pipeline_needs_in_memory_store(&spec) {
             let storage = LocalStorage::start().await?;
             super::super::install_in_memory_sink(&mut spec, storage.endpoint());
+            super::super::install_in_memory_grpc_state(&mut spec, storage.endpoint());
             Some(storage)
         } else {
             None

--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -5,6 +5,7 @@ pub mod common;
 pub mod checkpoint;
 pub mod harness;
 pub mod launch_specs;
+pub mod request_correctness;
 #[cfg(test)]
 pub mod many_to_many_harness;
 #[cfg(test)]

--- a/src/test_utils/request_correctness.rs
+++ b/src/test_utils/request_correctness.rs
@@ -13,13 +13,13 @@ use serde_json::Value;
 
 use crate::api::spec::connectors::{RequestSourceSinkSpec, SinkSpec, SourceSpec, SourceSpecKind};
 use crate::api::spec::pipeline::ExecutionProfile;
-use crate::api::spec::state::{OperatorStateBackendConfig, RequestStoreConfig};
+use crate::api::spec::state::{OperatorStateBackendConfig, RequestStoreConfig, ScyllaConfig};
 use crate::api::{ExecutionMode, PipelineSpecBuilder, TaskWorkerAssignmentStrategyType};
 use crate::common::ports::gen_unique_grpc_port;
 use crate::runtime::functions::source::datagen_source::{DatagenSpec, FieldGenerator, KeyDistribution};
 use crate::runtime::observability::StreamTaskStatus;
 use crate::test_utils::harness::{
-    FaultAction, PipelineLaunchSpec, RuntimeEnv, VolgaCluster, WorkerKillMode,
+    PipelineLaunchSpec, RuntimeEnv, VolgaCluster, WorkerKillMode,
 };
 
 const WINDOW_SQL: &str = r#"
@@ -28,13 +28,14 @@ FROM events
 WINDOW w AS (
   PARTITION BY key
   ORDER BY event_time
-  RANGE BETWEEN INTERVAL '5000' MILLISECOND PRECEDING AND CURRENT ROW
+  RANGE BETWEEN INTERVAL '1' MINUTE PRECEDING AND CURRENT ROW
 )
 "#;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RequestStoreBackend {
     InMemoryGrpc,
+    Scylla,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -106,7 +107,9 @@ pub async fn run_request_correctness_with_fault(
     let (assignment, worker_count, parallelism) = match env {
         RuntimeEnv::Local | RuntimeEnv::Kube => (
             TaskWorkerAssignmentStrategyType::OperatorPerWorker,
-            8,
+            // 7 groups: write Source/KeyBy/Window + read KeyBy/WRO/Projection
+            // + colocated request source/sink.
+            7,
             1,
         ),
         RuntimeEnv::Docker => (
@@ -159,6 +162,23 @@ pub async fn run_request_correctness_with_fault(
                 endpoint: placeholder,
             },
         ),
+        RequestStoreBackend::Scylla => {
+            let cfg = ScyllaConfig {
+                contact_points: std::env::var("VOLGA_SCYLLA_CONTACT")
+                    .unwrap_or_else(|_| "127.0.0.1:9042".to_string())
+                    .split(',')
+                    .map(|s| s.trim().to_string())
+                    .collect(),
+                keyspace: std::env::var("VOLGA_SCYLLA_KEYSPACE")
+                    .unwrap_or_else(|_| "volga_window".to_string()),
+                datacenter: std::env::var("VOLGA_SCYLLA_DC").ok(),
+                max_parallelism: Some(parallelism),
+            };
+            (
+                OperatorStateBackendConfig::Scylla(cfg.clone()),
+                RequestStoreConfig::Scylla(cfg),
+            )
+        }
     };
 
     let pipeline = PipelineSpecBuilder::new()
@@ -213,7 +233,10 @@ pub async fn run_request_correctness_with_fault(
 
     let expected = expected_sums(workload.num_keys, workload.events_per_key);
     let client = reqwest::Client::new();
-    let request_ts = 1_000 + ((rows as i64) - 1) * workload.step_ms;
+    // Query just after the last per-key event so every committed row is
+    // historical (request value 0 must not replace the last ingest).
+    let last_event_ts = 1_000 + ((workload.events_per_key as i64) - 1) * workload.step_ms;
+    let request_ts = last_event_ts + 1;
     let mut handles = Vec::new();
     for key_idx in 0..workload.num_keys {
         for _ in 0..workload.request_concurrency / workload.num_keys.max(1) {
@@ -277,18 +300,9 @@ fn pick_worker(cluster: &VolgaCluster, fault: RequestFault) -> Result<String> {
 }
 
 fn expected_sums(num_keys: usize, events_per_key: usize) -> Vec<f64> {
-    // Datagen Key+Increment is global increment, not per-key. Oracle is last
-    // committed SUM for the 5s frame at the last event time: all events for that
-    // key fall in-frame. Values are assigned in generation order.
-    let mut sums = vec![0.0; num_keys];
-    let mut value = 1.0;
-    for _ in 0..events_per_key {
-        for key in 0..num_keys {
-            sums[key] += value;
-            value += 1.0;
-        }
-    }
-    sums
+    // Per-key Increment starts at 1. Last per-key event is in-frame for all keys.
+    let per_key: f64 = (events_per_key * (events_per_key + 1)) as f64 / 2.0;
+    vec![per_key; num_keys]
 }
 
 async fn post_sum(client: &reqwest::Client, url: &str, key: &str, ts: i64) -> Result<(String, f64)> {

--- a/src/test_utils/request_correctness.rs
+++ b/src/test_utils/request_correctness.rs
@@ -1,0 +1,330 @@
+//! Layer C: request-mode cluster correctness (`env × backend × profile`).
+//!
+//! Windows are the first scenario. APIs are write path / read path / shared state.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow_integration_test::schema_to_json;
+use datafusion::common::ScalarValue;
+use serde_json::Value;
+
+use crate::api::spec::connectors::{RequestSourceSinkSpec, SinkSpec, SourceSpec, SourceSpecKind};
+use crate::api::spec::pipeline::ExecutionProfile;
+use crate::api::spec::state::{OperatorStateBackendConfig, RequestStoreConfig};
+use crate::api::{ExecutionMode, PipelineSpecBuilder, TaskWorkerAssignmentStrategyType};
+use crate::common::ports::gen_unique_grpc_port;
+use crate::runtime::functions::source::datagen_source::{DatagenSpec, FieldGenerator, KeyDistribution};
+use crate::runtime::observability::StreamTaskStatus;
+use crate::test_utils::harness::{
+    FaultAction, PipelineLaunchSpec, RuntimeEnv, VolgaCluster, WorkerKillMode,
+};
+
+const WINDOW_SQL: &str = r#"
+SELECT event_time, key, value, SUM(value) OVER w AS sum_value
+FROM events
+WINDOW w AS (
+  PARTITION BY key
+  ORDER BY event_time
+  RANGE BETWEEN INTERVAL '5000' MILLISECOND PRECEDING AND CURRENT ROW
+)
+"#;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestStoreBackend {
+    InMemoryGrpc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestProfile {
+    Smoke,
+    Stress,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestFault {
+    None,
+    KillWriteWorker,
+    KillReadWorker,
+}
+
+#[derive(Debug, Clone)]
+struct Workload {
+    num_keys: usize,
+    events_per_key: usize,
+    request_concurrency: usize,
+    step_ms: i64,
+}
+
+impl RequestProfile {
+    fn workload(self) -> Workload {
+        match self {
+            Self::Smoke => Workload {
+                num_keys: 4,
+                events_per_key: 3,
+                request_concurrency: 4,
+                step_ms: 1_000,
+            },
+            Self::Stress => Workload {
+                num_keys: 16,
+                events_per_key: 8,
+                request_concurrency: 16,
+                step_ms: 1_000,
+            },
+        }
+    }
+}
+
+pub async fn run_request_correctness(
+    env: RuntimeEnv,
+    backend: RequestStoreBackend,
+    profile: RequestProfile,
+) -> Result<()> {
+    run_request_correctness_with_fault(env, backend, profile, RequestFault::None).await
+}
+
+pub async fn run_request_correctness_with_fault(
+    env: RuntimeEnv,
+    backend: RequestStoreBackend,
+    profile: RequestProfile,
+    fault: RequestFault,
+) -> Result<()> {
+    let workload = profile.workload();
+    let request_bind = match env {
+        RuntimeEnv::Local => format!("127.0.0.1:{}", gen_unique_grpc_port()),
+        RuntimeEnv::Docker | RuntimeEnv::Kube => "0.0.0.0:18080".to_string(),
+    };
+    let request_url = match env {
+        RuntimeEnv::Local => format!("http://{}/request", request_bind),
+        RuntimeEnv::Docker | RuntimeEnv::Kube => {
+            format!("http://127.0.0.1:18080/request")
+        }
+    };
+
+    let (assignment, worker_count, parallelism) = match env {
+        RuntimeEnv::Local | RuntimeEnv::Kube => (
+            TaskWorkerAssignmentStrategyType::OperatorPerWorker,
+            8,
+            1,
+        ),
+        RuntimeEnv::Docker => (
+            TaskWorkerAssignmentStrategyType::Pipelined { slots_per_node: 2 },
+            3,
+            1,
+        ),
+    };
+
+    let schema = Schema::new(vec![
+        Field::new(
+            "event_time",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            false,
+        ),
+        Field::new("key", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, false),
+    ]);
+    let rows = workload.num_keys * workload.events_per_key;
+    let mut fields = HashMap::new();
+    fields.insert(
+        "event_time".to_string(),
+        FieldGenerator::IncrementalTimestamp {
+            start_ms: 1_000,
+            step_ms: workload.step_ms,
+        },
+    );
+    fields.insert(
+        "key".to_string(),
+        FieldGenerator::Key {
+            num_unique_keys: workload.num_keys,
+            distribution: KeyDistribution::Shared,
+        },
+    );
+    fields.insert(
+        "value".to_string(),
+        FieldGenerator::Increment {
+            start: ScalarValue::Float64(Some(1.0)),
+            step: ScalarValue::Float64(Some(1.0)),
+        },
+    );
+
+    let placeholder = String::new();
+    let (operator_backend, request_store) = match backend {
+        RequestStoreBackend::InMemoryGrpc => (
+            OperatorStateBackendConfig::InMemoryGrpc {
+                endpoint: placeholder.clone(),
+            },
+            RequestStoreConfig::InMemoryGrpc {
+                endpoint: placeholder,
+            },
+        ),
+    };
+
+    let pipeline = PipelineSpecBuilder::new()
+        .with_parallelism(parallelism)
+        .with_execution_profile(ExecutionProfile::MasterWorker {
+            num_threads_per_task: 2,
+        })
+        .with_execution_mode(ExecutionMode::Request)
+        .with_task_assignment_strategy(assignment)
+        .with_operator_state_backend(operator_backend)
+        .with_request_store(request_store)
+        .with_source(SourceSpec::new(
+            "events",
+            SourceSpecKind::Datagen(DatagenSpec {
+                rate: None,
+                limit: Some(rows),
+                run_for_s: None,
+                batch_size: workload.events_per_key,
+                fields,
+                replayable: true,
+            }),
+            schema_to_json(&schema),
+        ))
+        .with_request_source_sink(RequestSourceSinkSpec {
+            bind_address: request_bind,
+            max_pending_requests: 1_024,
+            request_timeout_ms: 30_000,
+            schema_json: Some(schema_to_json(&schema)),
+            sink: Some(SinkSpec::Request),
+        })
+        .sql(WINDOW_SQL)
+        .with_checkpoint(Some(0), Some(60_000), Some(1))
+        .build();
+
+    let cluster = VolgaCluster::launch(
+        env,
+        PipelineLaunchSpec::new(pipeline, worker_count, None),
+    )
+    .await?;
+    cluster.start_execution().await?;
+    wait_for_write_path(&cluster, Duration::from_secs(30)).await?;
+
+    if fault != RequestFault::None {
+        let worker_id = pick_worker(&cluster, fault)?;
+        cluster
+            .worker(&worker_id)
+            .ok_or_else(|| anyhow!("worker {worker_id} missing"))?
+            .kill_with(WorkerKillMode::Abrupt)
+            .await?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    let expected = expected_sums(workload.num_keys, workload.events_per_key);
+    let client = reqwest::Client::new();
+    let request_ts = 1_000 + ((rows as i64) - 1) * workload.step_ms;
+    let mut handles = Vec::new();
+    for key_idx in 0..workload.num_keys {
+        for _ in 0..workload.request_concurrency / workload.num_keys.max(1) {
+            let client = client.clone();
+            let url = request_url.clone();
+            let key = format!("key-{key_idx}");
+            handles.push(tokio::spawn(async move {
+                post_sum(&client, &url, &key, request_ts).await
+            }));
+        }
+    }
+    for handle in handles {
+        let (key, sum) = handle.await??;
+        let key_idx = key
+            .strip_prefix("key-")
+            .and_then(|s| s.parse::<usize>().ok())
+            .context("key name")?;
+        anyhow::ensure!(
+            (sum - expected[key_idx]).abs() < 1e-6,
+            "oracle mismatch key={key} got={sum} expected={}",
+            expected[key_idx]
+        );
+    }
+
+    cluster.shutdown().await
+}
+
+async fn wait_for_write_path(cluster: &VolgaCluster, timeout: Duration) -> Result<()> {
+    let start = std::time::Instant::now();
+    loop {
+        if let Some(snapshot) = cluster.master().latest_pipeline_snapshot().await? {
+            let source_finished = snapshot.worker_states.values().any(|worker| {
+                worker.task_statuses.iter().any(|(id, status)| {
+                    id.contains("Source")
+                        && matches!(
+                            status,
+                            StreamTaskStatus::Finished | StreamTaskStatus::Closed
+                        )
+                })
+            });
+            if source_finished {
+                tokio::time::sleep(Duration::from_millis(300)).await;
+                return Ok(());
+            }
+        }
+        if start.elapsed() > timeout {
+            return Err(anyhow!("timed out waiting for write-path source to finish"));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+fn pick_worker(cluster: &VolgaCluster, fault: RequestFault) -> Result<String> {
+    let ids = cluster.worker_ids();
+    anyhow::ensure!(!ids.is_empty(), "no workers");
+    match fault {
+        RequestFault::None => Err(anyhow!("no fault")),
+        RequestFault::KillWriteWorker => Ok(ids[0].clone()),
+        RequestFault::KillReadWorker => Ok(ids.last().cloned().unwrap()),
+    }
+}
+
+fn expected_sums(num_keys: usize, events_per_key: usize) -> Vec<f64> {
+    // Datagen Key+Increment is global increment, not per-key. Oracle is last
+    // committed SUM for the 5s frame at the last event time: all events for that
+    // key fall in-frame. Values are assigned in generation order.
+    let mut sums = vec![0.0; num_keys];
+    let mut value = 1.0;
+    for _ in 0..events_per_key {
+        for key in 0..num_keys {
+            sums[key] += value;
+            value += 1.0;
+        }
+    }
+    sums
+}
+
+async fn post_sum(client: &reqwest::Client, url: &str, key: &str, ts: i64) -> Result<(String, f64)> {
+    let body = serde_json::json!({
+        "data": {
+            "payload": [{
+                "event_time": ts,
+                "key": key,
+                "value": 0.0
+            }]
+        }
+    });
+    let response = client
+        .post(url)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    anyhow::ensure!(
+        response.status().is_success(),
+        "request failed: {}",
+        response.status()
+    );
+    let payload: Value = response.json().await?;
+    let rows = payload
+        .pointer("/data/payload")
+        .or_else(|| payload.pointer("/data"))
+        .ok_or_else(|| anyhow!("response missing data: {payload}"))?;
+    let row = rows
+        .as_array()
+        .and_then(|a| a.first())
+        .unwrap_or(rows);
+    let sum = row
+        .get("sum_value")
+        .or_else(|| row.get("SUM(value)"))
+        .and_then(|v| v.as_f64())
+        .ok_or_else(|| anyhow!("response missing sum_value: {payload}"))?;
+    Ok((key.to_string(), sum))
+}

--- a/src/tests/docker/mod.rs
+++ b/src/tests/docker/mod.rs
@@ -1,3 +1,4 @@
 mod kafka;
 mod parquet_s3;
+mod request_correctness;
 mod smoke;

--- a/src/tests/docker/request_correctness.rs
+++ b/src/tests/docker/request_correctness.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+
+use crate::test_utils::harness::RuntimeEnv;
+use crate::test_utils::request_correctness::{
+    run_request_correctness, RequestProfile, RequestStoreBackend,
+};
+
+#[tokio::test]
+#[ignore]
+async fn request_correctness_inmem_grpc_smoke() -> Result<()> {
+    run_request_correctness(
+        RuntimeEnv::Docker,
+        RequestStoreBackend::InMemoryGrpc,
+        RequestProfile::Smoke,
+    )
+    .await
+}

--- a/src/tests/inprocess/mod.rs
+++ b/src/tests/inprocess/mod.rs
@@ -1,6 +1,7 @@
 mod checkpoint;
 mod recovery;
 mod request_source;
+mod request_correctness;
 mod smoke;
 pub(crate) mod watermark_streaming;
 mod worker;

--- a/src/tests/inprocess/request_correctness.rs
+++ b/src/tests/inprocess/request_correctness.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+
+use crate::test_utils::harness::RuntimeEnv;
+use crate::test_utils::request_correctness::{
+    run_request_correctness, run_request_correctness_with_fault, RequestFault, RequestProfile,
+    RequestStoreBackend,
+};
+
+#[tokio::test]
+async fn request_correctness_inmem_grpc_smoke() -> Result<()> {
+    run_request_correctness(
+        RuntimeEnv::Local,
+        RequestStoreBackend::InMemoryGrpc,
+        RequestProfile::Smoke,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn request_correctness_kill_write_worker() -> Result<()> {
+    run_request_correctness_with_fault(
+        RuntimeEnv::Local,
+        RequestStoreBackend::InMemoryGrpc,
+        RequestProfile::Smoke,
+        RequestFault::KillWriteWorker,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn request_correctness_kill_read_worker() -> Result<()> {
+    run_request_correctness_with_fault(
+        RuntimeEnv::Local,
+        RequestStoreBackend::InMemoryGrpc,
+        RequestProfile::Smoke,
+        RequestFault::KillReadWorker,
+    )
+    .await
+}

--- a/src/tests/kube/mod.rs
+++ b/src/tests/kube/mod.rs
@@ -1,3 +1,4 @@
 mod checkpoint;
 mod recovery;
+mod request_correctness;
 mod smoke;

--- a/src/tests/kube/request_correctness.rs
+++ b/src/tests/kube/request_correctness.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+
+use crate::test_utils::harness::RuntimeEnv;
+use crate::test_utils::request_correctness::{
+    run_request_correctness, RequestProfile, RequestStoreBackend,
+};
+
+#[tokio::test]
+#[ignore]
+async fn request_correctness_inmem_grpc_smoke() -> Result<()> {
+    run_request_correctness(
+        RuntimeEnv::Kube,
+        RequestStoreBackend::InMemoryGrpc,
+        RequestProfile::Smoke,
+    )
+    .await
+}


### PR DESCRIPTION
## Summary
- gRPC service over process-local InMem; remote clients implement `WindowOperatorStore` and `WindowRequestStore`.
- Request mode rejects process-local `InMemory`. Cluster storage process serves both sink storage and the window store.
- Layer C runner `run_request_correctness(env, backend, profile)` with local/docker/kube entrypoints and write/read worker kill.

Depends on #285. Next: `feat/scylla-wo-write`.

## Test plan
- [ ] Local smoke + kill-write / kill-read (`tests/inprocess/request_correctness.rs`)
- [ ] Docker/kube ignored wrappers via `scripts/test`


Made with [Cursor](https://cursor.com)